### PR TITLE
fix(e3-0): entry guard for two CI steps + the scanner gaps ADR-19 measured

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -53,6 +53,14 @@ always-loaded context surface is a guarded resource.
   inferring "this is binary" from a file's own contents — can be defeated by
   editing those contents, which is how a poisoned file bought its way out of
   this gate twice during development.
+  The scan covers a file's **name** and a symlink's **target** as well as its
+  contents — both reach the reader through tool output and through the
+  projections an agent reads, and an exemption granted to a file's bytes never
+  covers its name. TAB and LF are legal inside a file and forbidden in a path.
+  Two gaps are deliberate and documented in the scanner rather than hidden:
+  `U+FE00`-`U+FE0F` stay legal because `U+FE0F` is emoji presentation and this
+  repo's README uses it 24 times, and the list is a denylist, so it is
+  structurally incomplete by construction (ADR-19 correction 1).
 - **A test for a guarantee is finished only once you have watched it fail**
   (ADR-20) — see below.
 

--- a/scripts/desc-budget.mjs
+++ b/scripts/desc-budget.mjs
@@ -10,7 +10,7 @@
  * Usage:  node scripts/desc-budget.mjs [--budget <chars>] [pluginRoot]
  * Exit:   0 within budget · 1 over budget · 2 usage/IO error
  */
-import { readFileSync, readdirSync, statSync, existsSync } from 'node:fs';
+import { readFileSync, readdirSync, statSync, existsSync, realpathSync } from 'node:fs';
 import { join, dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
@@ -84,4 +84,36 @@ function main() {
   }
 }
 
-if (process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url)) main();
+/**
+ * Absolute, symlink-resolved path; falls back to the merely absolute form when
+ * realpath cannot follow argv[1] (the script directory was renamed after
+ * launch, a parent component is unreadable, or a launcher rewrote argv[1] to a
+ * logical name). Without the fallback the guard would throw out of module
+ * scope and kill the tool at startup — a different bug, not a fix.
+ */
+function canonicalPath(path) {
+  const abs = resolve(path);
+  try {
+    return realpathSync(abs);
+  } catch {
+    return abs;
+  }
+}
+
+/**
+ * True when this module is the program's entry point.
+ *
+ * BOTH sides must be canonicalized. `import.meta.url` already names the real
+ * file — Node resolves module specifiers through symlinks — while
+ * `process.argv[1]` is whatever the caller typed. Comparing them raw turned
+ * every invocation through a symlinked path into a SILENT no-op under exit 0:
+ * `main()` never ran, nothing was summed, and CI read that as "within budget".
+ * `/tmp` and `/var` are symlinks on macOS and plugin installs reach `scripts/`
+ * through one, so this is the ordinary case rather than an exotic one.
+ */
+function isMainModule(moduleUrl) {
+  if (!process.argv[1]) return false;
+  return canonicalPath(process.argv[1]) === canonicalPath(fileURLToPath(moduleUrl));
+}
+
+if (isMainModule(import.meta.url)) main();

--- a/scripts/scan-control-chars.mjs
+++ b/scripts/scan-control-chars.mjs
@@ -29,7 +29,7 @@
  *       that covered zero files
  */
 import { execFileSync } from 'node:child_process';
-import { readFileSync, realpathSync } from 'node:fs';
+import { readFileSync, readlinkSync, realpathSync } from 'node:fs';
 import { resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
@@ -46,11 +46,53 @@ export const FORBIDDEN = Object.freeze([
   Object.freeze({ lo: 0x00, hi: 0x08, what: 'C0 control character' }),
   Object.freeze({ lo: 0x0b, hi: 0x1f, what: 'C0 control character' }),
   Object.freeze({ lo: 0x7f, hi: 0x9f, what: 'DEL / C1 control character' }),
+  Object.freeze({ lo: 0x00ad, hi: 0x00ad, what: 'invisible formatting character (SOFT HYPHEN)' }),
   Object.freeze({ lo: 0x061c, hi: 0x061c, what: 'bidi mark (ARABIC LETTER MARK)' }),
+  Object.freeze({ lo: 0x115f, hi: 0x1160, what: 'invisible filler that renders as nothing' }),
+  Object.freeze({ lo: 0x180e, hi: 0x180e, what: 'invisible separator (MONGOLIAN VOWEL SEPARATOR)' }),
   Object.freeze({ lo: 0x200b, hi: 0x200f, what: 'zero-width or directional mark' }),
   Object.freeze({ lo: 0x202a, hi: 0x202e, what: 'bidi embedding or override' }),
+  Object.freeze({ lo: 0x2060, hi: 0x2064, what: 'word joiner or invisible operator' }),
   Object.freeze({ lo: 0x2066, hi: 0x2069, what: 'bidi isolate' }),
+  Object.freeze({ lo: 0x206a, hi: 0x206f, what: 'deprecated formatting character' }),
+  Object.freeze({ lo: 0x3164, hi: 0x3164, what: 'invisible filler that renders as nothing' }),
+  Object.freeze({ lo: 0xffa0, hi: 0xffa0, what: 'invisible filler that renders as nothing' }),
   Object.freeze({ lo: 0xfeff, hi: 0xfeff, what: 'byte order mark / zero-width no-break space' }),
+  Object.freeze({ lo: 0xfff9, hi: 0xfffb, what: 'interlinear annotation character' }),
+  Object.freeze({ lo: 0x1d173, hi: 0x1d17a, what: 'invisible musical formatting character' }),
+  // The one that matters most, and the one the old test could not even see:
+  // U+E0001..U+E007E map ONE-TO-ONE onto ASCII and render as nothing at all.
+  // Projections (STATE.md, PROGRESS.md) are read by AGENTS, and their content
+  // travels from subagent reports about foreign repositories — so invisible
+  // text in a projection is prompt injection aimed at our own team, not an
+  // aesthetic complaint. The block is astral, which is why the pinning test
+  // stopping at U+FFFF hid it (ADR-19 correction 1).
+  Object.freeze({ lo: 0xe0000, hi: 0xe007f, what: 'TAG character (invisible ASCII)' }),
+  // Variation Selectors Supplement. Same smuggling channel as the TAG block —
+  // a sequence of them encodes arbitrary bytes onto a visible carrier — and
+  // zero occurrences in this repo, so banning them costs nothing here. Their
+  // BMP counterparts are deliberately NOT banned; see below.
+  Object.freeze({ lo: 0xe0100, hi: 0xe01ef, what: 'variation selector (supplement)' }),
+]);
+
+/**
+ * DELIBERATE GAP: U+FE00..U+FE0F (variation selectors 1-16) are NOT banned.
+ *
+ * U+FE0F is the emoji presentation selector and occurs 24 times in this repo's
+ * README today; U+FE0E is its text-presentation twin. Banning the range would
+ * turn CI red on a file nobody touched, and ADR-19 is explicit that a gate
+ * which cries wolf gets switched off and never restored — which costs more
+ * than the gap.
+ *
+ * The gap is real and stated rather than hidden: 16 codepoints still carry
+ * four bits each, so a determined smuggler can encode data with them. That is
+ * an argument for the direction ADR-19 correction 1 already names — an
+ * ALLOWLIST for machine-generated text, where the legal repertoire is narrow —
+ * not for a nineteenth range in a denylist that will always be one Unicode
+ * revision behind.
+ */
+export const DELIBERATELY_ALLOWED = Object.freeze([
+  Object.freeze({ lo: 0xfe00, hi: 0xfe0f, why: 'variation selectors: U+FE0F is legal emoji presentation' }),
 ]);
 
 /** Names worth spelling out; everything else falls back to its range label. */
@@ -61,7 +103,9 @@ const NAMES = Object.freeze({
   0x0b: 'VERTICAL TAB',
   0x0c: 'FORM FEED',
   0x0d: 'CARRIAGE RETURN',
+  0x09: 'TAB',
   0x1b: 'ESC',
+  0x0a: 'LF',
   0x7f: 'DELETE',
   0x061c: 'ARABIC LETTER MARK',
   0x200b: 'ZERO WIDTH SPACE',
@@ -78,14 +122,57 @@ const NAMES = Object.freeze({
   0x2067: 'RIGHT-TO-LEFT ISOLATE',
   0x2068: 'FIRST STRONG ISOLATE',
   0x2069: 'POP DIRECTIONAL ISOLATE',
+  0x00ad: 'SOFT HYPHEN',
+  0x115f: 'HANGUL CHOSEONG FILLER',
+  0x1160: 'HANGUL JUNGSEONG FILLER',
+  0x180e: 'MONGOLIAN VOWEL SEPARATOR',
+  0x2060: 'WORD JOINER',
+  0x2061: 'FUNCTION APPLICATION',
+  0x2062: 'INVISIBLE TIMES',
+  0x2063: 'INVISIBLE SEPARATOR',
+  0x2064: 'INVISIBLE PLUS',
+  0x3164: 'HANGUL FILLER',
+  0xffa0: 'HALFWIDTH HANGUL FILLER',
   0xfeff: 'BYTE ORDER MARK',
+  0xfff9: 'INTERLINEAR ANNOTATION ANCHOR',
+  0xfffa: 'INTERLINEAR ANNOTATION SEPARATOR',
+  0xfffb: 'INTERLINEAR ANNOTATION TERMINATOR',
+  0xe0001: 'LANGUAGE TAG',
 });
+
+/**
+ * The name to print for a codepoint, or null when the range label says enough.
+ *
+ * TAG characters get their ASCII equivalent spelled out, because U+E0041 is
+ * not a fact anyone can act on while `TAG for ASCII "A"` tells the reader what
+ * the invisible text actually SAID. A gate that reports an unfixable finding
+ * is an obstacle (ADR-19).
+ */
+function nameOf(cp) {
+  if (NAMES[cp] !== undefined) return NAMES[cp];
+  if (cp >= 0xe0020 && cp <= 0xe007e) {
+    return `TAG for ASCII ${JSON.stringify(String.fromCharCode(cp - 0xe0000))}`;
+  }
+  return null;
+}
 
 function classify(cp) {
   for (const range of FORBIDDEN) {
     if (cp >= range.lo && cp <= range.hi) return range.what;
   }
   return null;
+}
+
+/**
+ * The same rule, plus TAB and LF, for text that is a PATH rather than file
+ * contents. The asymmetry is deliberate: a tab is ordinary text inside a file
+ * and a catastrophe in a filename, where it makes one path print as two
+ * columns in every tool that lists it — and a newline in a path breaks the
+ * line-oriented output of all of them.
+ */
+function classifyInPath(cp) {
+  if (cp === 0x09 || cp === 0x0a) return 'control character in a path';
+  return classify(cp);
 }
 
 /** UTF-8 width of a codepoint — lets us report byte offsets without re-encoding. */
@@ -106,21 +193,21 @@ export function formatCodePoint(cp) {
  * byte offset and identity. Pure and file-free, which is what makes the rule
  * itself testable rather than only its command-line wrapper.
  */
-export function scanText(text) {
+export function scanText(text, classifier = classify) {
   const findings = [];
   let line = 1;
   let column = 1;
   let byteOffset = 0;
   for (const ch of text) {
     const cp = ch.codePointAt(0);
-    const what = classify(cp);
+    const what = classifier(cp);
     if (what !== null) {
       findings.push({
         line,
         column,
         byteOffset,
         codePoint: cp,
-        name: NAMES[cp] ?? null,
+        name: nameOf(cp),
         what,
       });
     }
@@ -135,10 +222,27 @@ export function scanText(text) {
   return findings;
 }
 
-/** One finding as an operator-readable line: file, position, identity. */
-export function formatFinding(file, f) {
+/**
+ * Every forbidden codepoint in a PATH — a file's name or a symlink's target.
+ * Both reach the reader through tool output and through the projections an
+ * agent reads, so both are part of the repository's text even though neither
+ * is inside a file.
+ */
+export function scanPath(path) {
+  return scanText(path, classifyInPath);
+}
+
+/**
+ * One finding as an operator-readable line: file, position, identity.
+ *
+ * `where` says which text the position refers to. Without it a hit at 1:5 in a
+ * NAME reads as a hit at 1:5 in the contents, and the reader edits the wrong
+ * thing — the same "unfixable finding" failure the byte offsets exist to avoid.
+ */
+export function formatFinding(file, f, where = 'content') {
   const name = f.name ? ` ${f.name}` : '';
-  return `${file}:${f.line}:${f.column} (byte ${f.byteOffset}): ${formatCodePoint(f.codePoint)}${name} — ${f.what}`;
+  const site = where === 'content' ? '' : ` [in the ${where === 'name' ? 'file NAME' : 'symlink TARGET'}]`;
+  return `${file}:${f.line}:${f.column} (byte ${f.byteOffset}): ${formatCodePoint(f.codePoint)}${name} — ${f.what}${site}`;
 }
 
 function git(args, cwd) {
@@ -194,9 +298,21 @@ function isValidUtf8(buffer) {
  * landed. Excusing them would aim the gate away from its own motivating case.
  */
 export function partitionTrackedFiles(cwd = process.cwd()) {
-  const empty = { scan: [], exempt: [], refused: [] };
-  const listing = git(['ls-files', '-z'], cwd);
-  const candidates = listing.split('\0').filter((p) => p !== '');
+  const empty = { paths: [], scan: [], links: [], exempt: [], refused: [] };
+  // `-s` for the mode, because a symlink must never be read with readFileSync:
+  // that FOLLOWS the link, so a link pointing outside the repo would have some
+  // other project's contents scanned in its place, and a dangling one would be
+  // filed as "missing" and skipped — target unread either way. Git's own
+  // record (mode 120000) is the authority here, not a filesystem stat.
+  const listing = git(['ls-files', '-s', '-z'], cwd);
+  const modes = new Map();
+  for (const entry of listing.split('\0')) {
+    if (entry === '') continue;
+    const tab = entry.indexOf('\t');
+    if (tab === -1) continue;
+    modes.set(entry.slice(tab + 1), entry.slice(0, entry.indexOf(' ')));
+  }
+  const candidates = [...modes.keys()];
   if (candidates.length === 0) return empty;
 
   const attr = execFileSync('git', ['check-attr', '-z', '--stdin', 'binary'], {
@@ -212,8 +328,23 @@ export function partitionTrackedFiles(cwd = process.cwd()) {
     if (fields[i + 2] === 'set') declaredBinary.add(fields[i]);
   }
 
-  const out = { scan: [], exempt: [], refused: [] };
+  const out = { paths: candidates, scan: [], links: [], exempt: [], refused: [] };
   for (const path of candidates) {
+    if (modes.get(path) === '120000') {
+      // The payload of a symlink is its target string. Read it with readlink,
+      // which does NOT follow the link, so a dangling target is still text we
+      // can scan rather than an ENOENT that excuses the entry.
+      try {
+        out.links.push({ file: path, target: readlinkSync(resolve(cwd, path)) });
+      } catch (err) {
+        if (err.code === 'ENOENT') {
+          out.exempt.push({ file: path, reason: 'tracked but missing from the working tree' });
+          continue;
+        }
+        throw err;
+      }
+      continue;
+    }
     if (declaredBinary.has(path)) {
       out.exempt.push({ file: path, reason: 'declared `binary` in .gitattributes' });
       continue;
@@ -248,13 +379,26 @@ export function partitionTrackedFiles(cwd = process.cwd()) {
  * Returns findings plus the full accounting of what was NOT scanned.
  */
 export function scanRepo(cwd = process.cwd()) {
-  const { scan, exempt, refused } = partitionTrackedFiles(cwd);
+  const { paths, scan, links, exempt, refused } = partitionTrackedFiles(cwd);
   const results = [];
+  // NAMES first, and for EVERY tracked path — including exempt and refused
+  // ones. `binary` exempts a file's bytes; nothing exempts its name, which
+  // still reaches `git log --stat`, a PR diff header and the projections an
+  // agent reads. An override in a name mirrors the rest of the line exactly
+  // as one inside a table row does.
+  for (const file of paths) {
+    const findings = scanPath(file);
+    if (findings.length > 0) results.push({ file, findings, where: 'name' });
+  }
+  for (const { file, target } of links) {
+    const findings = scanPath(target);
+    if (findings.length > 0) results.push({ file, findings, where: 'target' });
+  }
   for (const file of scan) {
     const findings = scanText(readFileSync(resolve(cwd, file), 'utf8'));
-    if (findings.length > 0) results.push({ file, findings });
+    if (findings.length > 0) results.push({ file, findings, where: 'content' });
   }
-  return { scanned: scan.length, exempt, refused, results };
+  return { scanned: scan.length + links.length, exempt, refused, results };
 }
 
 // ------------------------------------------------------------------- CLI
@@ -324,10 +468,10 @@ function main() {
     return;
   }
   let total = 0;
-  for (const { file, findings } of report.results) {
+  for (const { file, findings, where } of report.results) {
     total += findings.length;
     for (const f of findings.slice(0, MAX_PER_FILE)) {
-      console.error(formatFinding(file, f));
+      console.error(formatFinding(file, f, where));
     }
     if (findings.length > MAX_PER_FILE) {
       console.error(`${file}: ... and ${findings.length - MAX_PER_FILE} more in this file`);

--- a/scripts/scan-control-chars.mjs
+++ b/scripts/scan-control-chars.mjs
@@ -297,6 +297,63 @@ function isValidUtf8(buffer) {
  * are generated STATE.md files — precisely where the bidi bug behind ADR-19
  * landed. Excusing them would aim the gate away from its own motivating case.
  */
+const LINK_REMEDY =
+  'Git records the mode of every entry. Inspect it with:\n' +
+  '    git ls-files -s -- <path>\n' +
+  'A 120000 entry whose target cannot be read is either a damaged working tree\n' +
+  '(re-checkout the path) or a target this scanner must not guess at.';
+
+/**
+ * The target of an entry git records as a symlink (mode 120000), as
+ * `{target}` | `{exempt}` | `{refused}` — never a throw.
+ *
+ * Three outcomes, and the reason each exists:
+ *
+ *  - **ENOENT** — the working tree is dirty and the entry is simply absent.
+ *    An exemption, reported like every other one.
+ *  - **EINVAL** — readlink was handed something that is not a link. This is
+ *    NOT exotic: `core.symlinks=false` is git's DEFAULT on Windows, and under
+ *    it a clone materializes mode 120000 as an ordinary file whose CONTENTS
+ *    are the target path, while `ls-files -s` still says 120000. Git has
+ *    already told us this is a link, so the target is read from those bytes.
+ *    Failing here would be a regression: the previous scanner read that file
+ *    with readFileSync and caught the payload inside it.
+ *  - **anything else** — a refusal with an actionable message, not a bare
+ *    errno escaping as an exception. A gate that dies with a stack trace has
+ *    not made a finding; it has broken, and exit 2 tells the reader nothing
+ *    about what to do next.
+ *
+ * The target is read as BYTES in both branches. `readlinkSync` with no
+ * encoding replaces undecodable bytes with U+FFFD, which would quietly sand
+ * the poison off a target — while the same bytes inside a file's CONTENTS are
+ * refused outright. One criterion cannot hold on one side and not the other,
+ * or the weaker side is the real rule.
+ */
+function readLinkTarget(abs) {
+  let bytes;
+  try {
+    bytes = readlinkSync(abs, 'buffer');
+  } catch (err) {
+    if (err.code === 'ENOENT') return { exempt: 'tracked but missing from the working tree' };
+    if (err.code !== 'EINVAL') {
+      return { refused: `git records this as a symlink (mode 120000) but its target could not be read (${err.code})` };
+    }
+    try {
+      bytes = readFileSync(abs);
+    } catch (readErr) {
+      return {
+        refused:
+          'git records this as a symlink (mode 120000), it is not one on disk, ' +
+          `and its contents could not be read either (${readErr.code})`,
+      };
+    }
+  }
+  if (!isValidUtf8(bytes)) {
+    return { refused: 'the symlink target is not valid UTF-8, so it cannot be scanned without mangling it' };
+  }
+  return { target: bytes.toString('utf8') };
+}
+
 export function partitionTrackedFiles(cwd = process.cwd()) {
   const empty = { paths: [], scan: [], links: [], exempt: [], refused: [] };
   // `-s` for the mode, because a symlink must never be read with readFileSync:
@@ -331,18 +388,10 @@ export function partitionTrackedFiles(cwd = process.cwd()) {
   const out = { paths: candidates, scan: [], links: [], exempt: [], refused: [] };
   for (const path of candidates) {
     if (modes.get(path) === '120000') {
-      // The payload of a symlink is its target string. Read it with readlink,
-      // which does NOT follow the link, so a dangling target is still text we
-      // can scan rather than an ENOENT that excuses the entry.
-      try {
-        out.links.push({ file: path, target: readlinkSync(resolve(cwd, path)) });
-      } catch (err) {
-        if (err.code === 'ENOENT') {
-          out.exempt.push({ file: path, reason: 'tracked but missing from the working tree' });
-          continue;
-        }
-        throw err;
-      }
+      const outcome = readLinkTarget(resolve(cwd, path));
+      if (outcome.target !== undefined) out.links.push({ file: path, target: outcome.target });
+      else if (outcome.exempt !== undefined) out.exempt.push({ file: path, reason: outcome.exempt });
+      else out.refused.push({ file: path, reason: outcome.refused, remedy: LINK_REMEDY });
       continue;
     }
     if (declaredBinary.has(path)) {
@@ -420,6 +469,19 @@ function main() {
     console.error(`scan-control-chars: ${err.message}`);
     process.exit(2);
   }
+  // Announced BEFORE any verdict, on every run, clean or not — the same rule
+  // the file exemptions below follow, for the same reason. A gap that lives
+  // only in a source comment is invisible exactly where it is load-bearing:
+  // fifty variation selectors carry twenty-five bytes of ASCII past all three
+  // layers of this repo's defences, and without this line the gate would print
+  // "clean" over them without a word. Derived from the export, never typed
+  // twice, so emptying the export cannot leave the promise standing.
+  for (const gap of DELIBERATELY_ALLOWED) {
+    console.log(
+      `scan-control-chars: deliberate gap: ${formatCodePoint(gap.lo)}..${formatCodePoint(gap.hi)} — ${gap.why}`,
+    );
+  }
+
   // Announced BEFORE any verdict, on every run, clean or not. An exemption
   // that only shows up when something else already failed is not visible —
   // and the whole point is that leaving the scan can never be quiet.
@@ -439,14 +501,23 @@ function main() {
     for (const { file, reason } of report.refused) {
       console.error(`scan-control-chars: ${file}: ${reason}`);
     }
-    console.error(
-      `\nscan-control-chars: ${report.refused.length} tracked file(s) could not be read as\n` +
-        'text and are not declared binary. This is refused rather than skipped: one\n' +
-        'stray byte is enough to make a poisoned text file undecodable, which would\n' +
-        'otherwise carry it out of the scan under a green tick.\n' +
-        'If the file really is binary, declare it in .gitattributes:\n' +
-        `    ${report.refused[0].file} binary`,
-    );
+    // Two classes of refusal, two remedies. Printing the `binary` advice for a
+    // broken symlink would send the reader to declare a file that is not the
+    // problem — an unactionable message is how a gate becomes an obstacle.
+    const undecodable = report.refused.filter((r) => r.remedy === undefined);
+    if (undecodable.length > 0) {
+      console.error(
+        `\nscan-control-chars: ${undecodable.length} tracked file(s) could not be read as\n` +
+          'text and are not declared binary. This is refused rather than skipped: one\n' +
+          'stray byte is enough to make a poisoned text file undecodable, which would\n' +
+          'otherwise carry it out of the scan under a green tick.\n' +
+          'If the file really is binary, declare it in .gitattributes:\n' +
+          `    ${undecodable[0].file} binary`,
+      );
+    }
+    for (const remedy of new Set(report.refused.map((r) => r.remedy).filter((r) => r !== undefined))) {
+      console.error(`\n${remedy}`);
+    }
     process.exit(1);
   }
 

--- a/scripts/schema.mjs
+++ b/scripts/schema.mjs
@@ -13,7 +13,7 @@
  * CLI:  node schema.mjs validate <kind> <file...>     kind: config|knowledge|policy
  * Exit: 0 valid · 1 findings · 2 usage/IO error
  */
-import { readFileSync, existsSync } from 'node:fs';
+import { readFileSync, existsSync, realpathSync } from 'node:fs';
 import { resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { parse, YamlLiteError } from './yaml-lite.mjs';
@@ -410,4 +410,36 @@ function main() {
   process.exit(failed ? 1 : 0);
 }
 
-if (process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url)) main();
+/**
+ * Absolute, symlink-resolved path; falls back to the merely absolute form when
+ * realpath cannot follow argv[1] (the script directory was renamed after
+ * launch, a parent component is unreadable, or a launcher rewrote argv[1] to a
+ * logical name). Without the fallback the guard would throw out of module
+ * scope and kill the tool at startup — a different bug, not a fix.
+ */
+function canonicalPath(path) {
+  const abs = resolve(path);
+  try {
+    return realpathSync(abs);
+  } catch {
+    return abs;
+  }
+}
+
+/**
+ * True when this module is the program's entry point.
+ *
+ * BOTH sides must be canonicalized. `import.meta.url` already names the real
+ * file — Node resolves module specifiers through symlinks — while
+ * `process.argv[1]` is whatever the caller typed. Comparing them raw turned
+ * every invocation through a symlinked path into a SILENT no-op under exit 0:
+ * `main()` never ran, no file was validated, and CI read that as "valid".
+ * `/tmp` and `/var` are symlinks on macOS and plugin installs reach `scripts/`
+ * through one, so this is the ordinary case rather than an exotic one.
+ */
+function isMainModule(moduleUrl) {
+  if (!process.argv[1]) return false;
+  return canonicalPath(process.argv[1]) === canonicalPath(fileURLToPath(moduleUrl));
+}
+
+if (isMainModule(import.meta.url)) main();

--- a/tests/unit/desc-budget.test.mjs
+++ b/tests/unit/desc-budget.test.mjs
@@ -1,9 +1,13 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { mkdtempSync, mkdirSync, writeFileSync } from 'node:fs';
+import { mkdtempSync, mkdirSync, readFileSync, symlinkSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
+import { spawnSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
 import { parseFrontmatterDescription, collectSkillDescriptions } from '../../scripts/desc-budget.mjs';
+
+const SCRIPT = fileURLToPath(new URL('../../scripts/desc-budget.mjs', import.meta.url));
 
 function fixture(skills) {
   const root = mkdtempSync(join(tmpdir(), 'tyran-descbudget-'));
@@ -50,4 +54,48 @@ test('collects and sorts descriptions across skills, flags missing', () => {
 test('returns empty list when skills/ does not exist', () => {
   const root = mkdtempSync(join(tmpdir(), 'tyran-noskills-'));
   assert.deepEqual(collectSkillDescriptions(root), []);
+});
+
+test('CLI: invoked through a symlinked path, the budget is still enforced (ADR-19 debt)', () => {
+  // Same silent no-op that bit journal.mjs, project.mjs and the scanner: the
+  // self-run guard compared resolve(argv[1]) — which keeps symlinks — with
+  // import.meta.url, which Node has already canonicalized. Through a link,
+  // main() never ran: no table, no total, and EXIT 0 over a repo that is over
+  // budget. This is a CI step, so exit 0 reads as "within budget" when nothing
+  // was summed. /tmp and /var are symlinks on macOS, so this is the ordinary
+  // case, not the exotic one.
+  const base = mkdtempSync(join(tmpdir(), 'tyran-descbudget-symlink-'));
+  const real = join(base, 'real-root');
+  mkdirSync(join(real, 'scripts'), { recursive: true });
+  writeFileSync(join(real, 'scripts', 'desc-budget.mjs'), readFileSync(SCRIPT));
+  mkdirSync(join(real, 'skills', 'huge'), { recursive: true });
+  writeFileSync(join(real, 'skills', 'huge', 'SKILL.md'), '---\ndescription: ' + 'a'.repeat(80) + '\n---\n');
+  const linked = join(base, 'linked-root');
+  symlinkSync(real, linked);
+
+  const r = spawnSync(process.execPath, [join(linked, 'scripts', 'desc-budget.mjs'), '--budget', '10'], {
+    encoding: 'utf8',
+  });
+  assert.notEqual(r.stdout, '', 'the CLI produced no output at all through the symlink');
+  assert.match(r.stdout, /TOTAL \(budget: 10\)/, 'nothing was summed through the symlink');
+  assert.equal(r.status, 1, 'an over-budget tree exited 0 through the symlink');
+  assert.match(r.stderr, /exceeds budget/);
+});
+
+test('the self-run guard survives an argv[1] that cannot be canonicalized', () => {
+  // realpathSync THROWS on a path it cannot follow. Without the fallback the
+  // throw escapes module scope and importing desc-budget.mjs fails outright,
+  // which is a worse failure than the one being fixed.
+  const base = mkdtempSync(join(tmpdir(), 'tyran-descbudget-argv-'));
+  const harness = join(base, 'harness.mjs');
+  writeFileSync(
+    harness,
+    "process.argv[1] = '/nonexistent-dir-" +
+      "e30/entry.mjs';\n" +
+      `await import(${JSON.stringify(SCRIPT)});\n` +
+      "console.log('SURVIVED');\n",
+  );
+  const r = spawnSync(process.execPath, [harness], { encoding: 'utf8' });
+  assert.equal(r.status, 0, r.stderr);
+  assert.equal(r.stdout.trim(), 'SURVIVED');
 });

--- a/tests/unit/scan-control-chars.test.mjs
+++ b/tests/unit/scan-control-chars.test.mjs
@@ -1,6 +1,6 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { mkdtempSync, writeFileSync, mkdirSync, symlinkSync } from 'node:fs';
+import { mkdtempSync, writeFileSync, mkdirSync, symlinkSync, lstatSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { spawnSync } from 'node:child_process';
@@ -305,6 +305,148 @@ test('a symlink whose TARGET carries a control character fails the gate', () => 
   assert.match(r.stderr, /link\.md/);
   assert.match(r.stderr, /U\+202E RIGHT-TO-LEFT OVERRIDE/);
   assert.match(r.stderr, /in the symlink TARGET/);
+});
+
+/**
+ * A repo where an index entry is a symlink but the working tree is not — the
+ * shape `git clone` produces under `core.symlinks=false`, which is the DEFAULT
+ * on Windows. Git materializes mode 120000 as an ordinary file whose CONTENTS
+ * are the target path, and still reports 120000 from `ls-files -s`.
+ */
+function gitRepoWithFakeSymlink(files, linkName, linkTarget) {
+  const dir = gitRepo(files);
+  const run = (args, opts) => {
+    const r = spawnSync('git', args, { cwd: dir, encoding: 'utf8', ...opts });
+    assert.equal(r.status, 0, `git ${args.join(' ')} failed: ${r.stderr}`);
+    return r.stdout;
+  };
+  run(['config', 'core.symlinks', 'false']);
+  const sha = run(['hash-object', '-w', '--stdin'], { input: linkTarget }).trim();
+  run(['update-index', '--add', '--cacheinfo', `120000,${sha},${linkName}`]);
+  writeFileSync(join(dir, linkName), linkTarget);
+  return dir;
+}
+
+/** Add a mode-120000 index entry directly, without creating a link on disk. */
+function addIndexSymlink(dir, path, target) {
+  const hash = spawnSync('git', ['hash-object', '-w', '--stdin'], { cwd: dir, encoding: 'utf8', input: target });
+  assert.equal(hash.status, 0, hash.stderr);
+  const upd = spawnSync('git', ['update-index', '--add', '--cacheinfo', `120000,${hash.stdout.trim()},${path}`], {
+    cwd: dir,
+    encoding: 'utf8',
+  });
+  assert.equal(upd.status, 0, upd.stderr);
+}
+
+test('a checkout without symlink support still gets its link TARGET scanned', () => {
+  // Blocker 1 (review round 2). readlink() answers EINVAL here, because the
+  // entry git calls a symlink is an ordinary file on disk. Handling only
+  // ENOENT turned that into `throw` -> exit 2 with a bare errno: a REGRESSION,
+  // since the previous scanner read the same file with readFileSync and caught
+  // the payload. Git has already told us the entry is a link; the target is in
+  // the file's bytes, and the gate must go on reading it.
+  const dir = gitRepoWithFakeSymlink(
+    { 'README.md': '# Title\n' },
+    'link.md',
+    'docs/target' + cp(0x202e) + 'gpj.md',
+  );
+  assert.equal(lstatSync(join(dir, 'link.md')).isSymbolicLink(), false, 'premise: not a real symlink');
+
+  const part = partitionTrackedFiles(dir);
+  assert.deepEqual(part.links.map((l) => l.file), ['link.md'], 'the entry must still be read as a link');
+  assert.deepEqual(part.exempt.map((e) => e.file), [], 'an unreadable link must never be skipped silently');
+  assert.deepEqual(part.refused.map((r) => r.file), [], 'the target is recoverable, so this is not a refusal');
+
+  const r = scan(dir);
+  assert.equal(r.status, 1, 'the payload must still fail the gate');
+  assert.match(r.stderr, /link\.md/);
+  assert.match(r.stderr, /U\+202E RIGHT-TO-LEFT OVERRIDE/);
+  assert.match(r.stderr, /in the symlink TARGET/);
+});
+
+test('a link whose target cannot be read at all is REFUSED, with a remedy', () => {
+  // The third branch: neither ENOENT nor EINVAL. A path too long for the
+  // system answers ENAMETOOLONG to readlink and to every other syscall, so
+  // nothing is recoverable. It must not crash with a bare errno — exit 2 says
+  // "the gate broke" and offers no next step — and it must not be skipped. It
+  // is a refusal, the same answer this scanner already gives an undecodable
+  // file, and it carries the remedy for THIS problem rather than the advice to
+  // declare a binary that is not the problem.
+  const dir = gitRepo({ 'README.md': '# Title\n' });
+  const tooLong = Array.from({ length: 12 }, (_, i) => `d${i}`.padEnd(200, 'x')).join('/') + '/link.md';
+  addIndexSymlink(dir, tooLong, 'target.md');
+
+  const part = partitionTrackedFiles(dir);
+  assert.deepEqual(part.refused.map((r) => r.file), [tooLong]);
+  assert.deepEqual(part.exempt.map((e) => e.file), [], 'an unreadable link is not an exemption');
+  assert.deepEqual(part.links.map((l) => l.file), []);
+
+  const r = scan(dir);
+  assert.equal(r.status, 1, 'refusal is exit 1, not a crash');
+  assert.match(r.stderr, /ENAMETOOLONG/, 'the errno is a fact in the message, not the whole message');
+  assert.match(r.stderr, /git ls-files -s/, 'the message must tell the reader how to look into it');
+  assert.doesNotMatch(r.stderr, /^\s+at /m, 'a stack trace is not a finding');
+  assert.doesNotMatch(r.stderr, /binary$/m, 'declaring a binary is the wrong remedy for a broken link');
+});
+
+test('a 120000 entry that is a DIRECTORY on disk is refused, not crashed on', () => {
+  // The EINVAL branch again, with the bytes unreadable too: readlink says
+  // EINVAL for a directory and readFileSync says EISDIR. Both failures have to
+  // land in one refusal rather than escaping as an exception from inside the
+  // recovery path — the recovery must not be able to break the gate worse than
+  // the problem it recovers from.
+  const dir = gitRepo({ 'README.md': '# Title\n' });
+  mkdirSync(join(dir, 'weird'));
+  addIndexSymlink(dir, 'weird', 'target.md');
+
+  const part = partitionTrackedFiles(dir);
+  assert.deepEqual(part.refused.map((r) => r.file), ['weird']);
+  const r = scan(dir);
+  assert.equal(r.status, 1);
+  assert.match(r.stderr, /EISDIR/);
+  assert.match(r.stderr, /git ls-files -s/);
+});
+
+test('a link target that is not valid UTF-8 is refused, not silently mangled', () => {
+  // Review point 4. readlinkSync without 'buffer' replaces undecodable bytes
+  // with U+FFFD, so a target could lose its poison on the way in — while the
+  // CONTENTS of a file in the same situation are refused outright. The two
+  // sides of one criterion have to agree, or the weaker one is the whole rule.
+  const dir = gitRepo({ 'README.md': '# Title\n' });
+  symlinkSync(Buffer.from([0x64, 0x6f, 0x63, 0xff, 0x2e, 0x6d, 0x64]), join(dir, 'link.md'));
+  spawnSync('git', ['add', '-A'], { cwd: dir });
+
+  const part = partitionTrackedFiles(dir);
+  assert.deepEqual(part.refused.map((r) => r.file), ['link.md']);
+  assert.deepEqual(part.links.map((l) => l.file), [], 'a mangled target must not be scanned as if it were fine');
+  const r = scan(dir);
+  assert.equal(r.status, 1);
+  assert.match(r.stderr, /link\.md/);
+  assert.match(r.stderr, /not valid UTF-8/);
+});
+
+test('every deliberate gap is announced on EVERY run, including a clean one', () => {
+  // Blocker 2 (review round 2). The gap in U+FE00..U+FE0F is a real decision,
+  // but a decision recorded only in a source comment is invisible where it
+  // matters: 50 variation selectors carry 25 bytes of ASCII past all three
+  // layers, and the gate's output said "clean" without a word about it.
+  //
+  // This file already applies the opposite rule to file exemptions —
+  // "leaving the scan can never be quiet" — and prints them before any
+  // verdict, clean or not. A gap in the RULE deserves at least as much.
+  //
+  // Asserted on the CLI output rather than on the exported array, because an
+  // assertion that loops over the array proves nothing when the array is
+  // empty: emptying DELIBERATELY_ALLOWED left the whole suite green (mutant
+  // R16 in review round 2).
+  const dir = gitRepo({ 'README.md': '# Title\n' });
+  const r = scan(dir);
+  assert.equal(r.status, 0, r.stderr);
+  assert.match(r.stdout, /clean \(1 tracked text files\)/);
+  assert.match(r.stdout, /deliberate gap: U\+FE00\.\.U\+FE0F/, 'the gap must be announced');
+  assert.match(r.stdout, /variation selectors/);
+  // And the announcement has to be derived from the export, not typed twice.
+  assert.equal(DELIBERATELY_ALLOWED.length, 1);
 });
 
 test('a clean symlink is counted as scanned, not as an exemption', () => {

--- a/tests/unit/scan-control-chars.test.mjs
+++ b/tests/unit/scan-control-chars.test.mjs
@@ -1,6 +1,6 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { mkdtempSync, writeFileSync, mkdirSync, symlinkSync, lstatSync } from 'node:fs';
+import { mkdtempSync, writeFileSync, mkdirSync, readFileSync, symlinkSync, lstatSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { spawnSync } from 'node:child_process';
@@ -364,6 +364,27 @@ test('a checkout without symlink support still gets its link TARGET scanned', ()
   assert.match(r.stderr, /in the symlink TARGET/);
 });
 
+test('a symlink that is tracked but absent is EXEMPT, and says so', () => {
+  // Review round 3. ENOENT is the only branch of readLinkTarget that lets an
+  // entry through, and it was the only one with no guard: turning it into a
+  // refusal passed the whole suite. The mutation makes the gate stricter
+  // rather than weaker, which is why it is not a security hole — but an
+  // unguarded pass-through is exactly the shape this story exists to remove,
+  // and a dirty working tree must not turn CI red on a file nobody edited.
+  const dir = gitRepo({ 'README.md': '# Title\n' });
+  addIndexSymlink(dir, 'gone.md', 'docs/target.md');
+
+  const part = partitionTrackedFiles(dir);
+  assert.deepEqual(part.exempt.map((e) => e.file), ['gone.md'], 'an absent link is an exemption');
+  assert.deepEqual(part.refused.map((r) => r.file), [], 'absence is a dirty tree, not an attack');
+  assert.deepEqual(part.links.map((l) => l.file), []);
+
+  const r = scan(dir);
+  assert.equal(r.status, 0, r.stderr);
+  // And, like every other exemption, it is announced rather than assumed.
+  assert.match(r.stdout, /not scanned: gone\.md — tracked but missing from the working tree/);
+});
+
 test('a link whose target cannot be read at all is REFUSED, with a remedy', () => {
   // The third branch: neither ENOENT nor EINVAL. A path too long for the
   // system answers ENAMETOOLONG to readlink and to every other syscall, so
@@ -445,8 +466,45 @@ test('every deliberate gap is announced on EVERY run, including a clean one', ()
   assert.match(r.stdout, /clean \(1 tracked text files\)/);
   assert.match(r.stdout, /deliberate gap: U\+FE00\.\.U\+FE0F/, 'the gap must be announced');
   assert.match(r.stdout, /variation selectors/);
-  // And the announcement has to be derived from the export, not typed twice.
-  assert.equal(DELIBERATELY_ALLOWED.length, 1);
+});
+
+test('the announcement is DERIVED from the export, not typed alongside it', () => {
+  // Review round 3. The test above passes just as happily over a single
+  // hard-coded console.log — it asserts that the sentence appears, not that
+  // the sentence comes from the list. `DELIBERATELY_ALLOWED.length === 1` did
+  // not help: a hard-coded printer satisfies it too.
+  //
+  // That is blocker 2 one level up. There the assertion could not go negative
+  // over an EMPTY array; here it cannot go negative over an IGNORED one. So
+  // the probe has to change the data and watch the OUTPUT follow: a second
+  // entry is added to the export in a copy of the script, and nothing else is
+  // touched. A printer that types its own sentence announces one gap and
+  // fails; a printer that walks the list announces two.
+  const base = mkdtempSync(join(tmpdir(), 'tyran-gap-derived-'));
+  const patched = join(base, 'scan-control-chars.mjs');
+  const source = readFileSync(SCRIPT, 'utf8');
+  const anchor = 'export const DELIBERATELY_ALLOWED = Object.freeze([\n';
+  assert.ok(source.includes(anchor), 'the export moved — this probe patches source text');
+  writeFileSync(
+    patched,
+    source.replace(
+      anchor,
+      anchor + "  Object.freeze({ lo: 0x2e80, hi: 0x2e81, why: 'probe entry, review round 3' }),\n",
+    ),
+  );
+
+  const dir = gitRepo({ 'README.md': '# Title\n' });
+  const r = spawnSync(process.execPath, [patched, dir], { encoding: 'utf8' });
+  assert.equal(r.status, 0, r.stderr);
+  assert.match(r.stdout, /deliberate gap: U\+FE00\.\.U\+FE0F/, 'the original gap must still be announced');
+  assert.match(
+    r.stdout,
+    /deliberate gap: U\+2E80\.\.U\+2E81 — probe entry, review round 3/,
+    'a gap added to the export alone was not announced: the printer is not reading the list',
+  );
+  // Both the bounds and the reason come from the entry's fields, so a printer
+  // that formats one of them by hand cannot pass either.
+  assert.equal(r.stdout.match(/deliberate gap:/g).length, 2);
 });
 
 test('a clean symlink is counted as scanned, not as an exemption', () => {

--- a/tests/unit/scan-control-chars.test.mjs
+++ b/tests/unit/scan-control-chars.test.mjs
@@ -1,14 +1,16 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { mkdtempSync, writeFileSync, mkdirSync } from 'node:fs';
+import { mkdtempSync, writeFileSync, mkdirSync, symlinkSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { spawnSync } from 'node:child_process';
 import {
+  DELIBERATELY_ALLOWED,
   FORBIDDEN,
   formatCodePoint,
   formatFinding,
   partitionTrackedFiles,
+  scanPath,
   scanRepo,
   scanText,
 } from '../../scripts/scan-control-chars.mjs';
@@ -57,27 +59,61 @@ test('the banned set is exactly the one ADR-19 specifies', () => {
   // Pinned independently of FORBIDDEN, because the range-walk test below
   // iterates that same list: deleting a range there would delete its own
   // coverage and stay green. This is the list, written out, from the ADR.
+  //
+  // The walk covers EVERY codepoint, astral planes included. It used to skip
+  // them (`if (point === 0xffff) point = 0x10fffe;`) on the assumption that
+  // nothing above the BMP was interesting — and that assumption is exactly
+  // what hid the TAG block, the single most dangerous gap in the list
+  // (ADR-19 correction 1). A test whose scope is an assumption cannot falsify
+  // that assumption.
   const banned = [];
   for (let point = 0x00; point <= 0x10ffff; point++) {
+    if (point >= 0xd800 && point <= 0xdfff) continue; // lone surrogates are not codepoints
     if (scanText(cp(point)).length > 0) banned.push(point);
-    if (point === 0xffff) point = 0x10fffe; // above the BMP nothing is banned
   }
   const expected = [
     ...range(0x00, 0x08),
     ...range(0x0b, 0x1f),
     ...range(0x7f, 0x9f),
+    0x00ad,
     0x061c,
+    ...range(0x115f, 0x1160),
+    0x180e,
     ...range(0x200b, 0x200f),
     ...range(0x202a, 0x202e),
+    ...range(0x2060, 0x2064),
     ...range(0x2066, 0x2069),
+    ...range(0x206a, 0x206f),
+    0x3164,
+    0xffa0,
+    ...range(0xfff9, 0xfffb),
     0xfeff,
-  ];
+    ...range(0x1d173, 0x1d17a),
+    ...range(0xe0000, 0xe007f),
+    ...range(0xe0100, 0xe01ef),
+  ].sort((a, b) => a - b);
   assert.deepEqual(banned, expected);
   // TAB and LF are legal text and must never join the set.
   assert.ok(!banned.includes(0x09) && !banned.includes(0x0a));
+  // U+FE0F is a legal emoji presentation selector and appears 24 times in this
+  // repo's README. Banning it would turn the gate red on a file nobody
+  // touched, which is how gates get switched off (ADR-19). Deliberate gap,
+  // documented in scan-control-chars.mjs.
+  assert.ok(!banned.includes(0xfe0f) && !banned.includes(0xfe0e));
 });
 
 const range = (lo, hi) => Array.from({ length: hi - lo + 1 }, (_, i) => lo + i);
+
+test('a deliberately allowed range is never also forbidden', () => {
+  // DELIBERATELY_ALLOWED documents a gap. If a later range quietly covers it,
+  // the comment keeps promising a gap that no longer exists — and the next
+  // reader trusts the comment over the code.
+  for (const gap of DELIBERATELY_ALLOWED) {
+    for (const point of [gap.lo, gap.hi]) {
+      assert.equal(scanText(cp(point)).length, 0, `${formatCodePoint(point)} is documented as allowed`);
+    }
+  }
+});
 
 test('every forbidden range is actually caught, at both of its edges', () => {
   for (const range of FORBIDDEN) {
@@ -103,6 +139,35 @@ test('the characters that actually bit us are named, not just flagged', () => {
   assert.equal(named(0xfeff).name, 'BYTE ORDER MARK');
   // A BOM anywhere, including position 0, is a finding — not a blessed prefix.
   assert.equal(scanText(cp(0xfeff) + '# Title\n').length, 1);
+});
+
+test('the TAG block is caught, and it is measured as ONE codepoint', () => {
+  // The vector, spelled out: U+E0001..U+E007E map one-to-one onto ASCII and
+  // render as nothing at all. STATE.md and PROGRESS.md are read by AGENTS, and
+  // the text in them arrives from subagent reports about foreign repositories,
+  // so an invisible instruction in a projection is prompt injection aimed at
+  // our own team — not an ugly character.
+  //
+  // The proof has to show WHICH unit is being measured. A TAG codepoint is a
+  // surrogate PAIR in UTF-16: charCodeAt sees 0xDB40 and 0xDC01, neither of
+  // which is in any forbidden range, while codePointAt sees 0xE0001. A scanner
+  // walking UTF-16 units would report zero findings here and stay green.
+  const tag = cp(0xe0001);
+  assert.equal(tag.length, 2, 'premise: this is a surrogate pair in UTF-16');
+  assert.equal(tag.charCodeAt(0), 0xdb40);
+  assert.equal(tag.charCodeAt(1), 0xdc01);
+  assert.equal(tag.codePointAt(0), 0xe0001);
+
+  const findings = scanText('visible' + tag + 'text');
+  assert.equal(findings.length, 1, 'the TAG codepoint was not caught');
+  assert.equal(findings[0].codePoint, 0xe0001, 'a surrogate unit was reported instead of the codepoint');
+  assert.equal(findings[0].byteOffset, 7, 'UTF-8 width of a TAG character is 4 bytes, and it starts after "visible"');
+
+  // Both edges of the block, and the ASCII a TAG character stands for, because
+  // "there is an invisible character here" is not a fixable finding.
+  assert.equal(scanText(cp(0xe0000)).length, 1);
+  assert.equal(scanText(cp(0xe007f)).length, 1);
+  assert.match(formatFinding('STATE.md', scanText(cp(0xe0041))[0]), /TAG for ASCII "A"/);
 });
 
 test('CR is a finding: this repo normalizes to LF', () => {
@@ -163,6 +228,97 @@ test('an untracked poisoned file is not the gate\'s business', () => {
   writeFileSync(join(dir, 'scratch.md'), 'x' + cp(0x0000) + 'y\n');
   const r = scan(dir);
   assert.equal(r.status, 0, r.stderr);
+});
+
+// --- the path is part of the repository too --------------------------------
+
+test('a poisoned file NAME fails the gate, even when its contents are clean', () => {
+  // The scanner read contents only. A file whose NAME carries an override was
+  // waved through with a green tick — and the name is what every tool prints:
+  // `git log --stat`, `ls`, a PR diff header, and the projections an agent
+  // reads. A bidi override in a name mirrors the rest of the line just as well
+  // as one in a table row.
+  const dir = gitRepo({ ['notes' + cp(0x202e) + 'fdp.md']: '# clean contents\n' });
+  const r = scan(dir);
+  assert.equal(r.status, 1, 'a poisoned name must not pass');
+  assert.match(r.stderr, /U\+202E RIGHT-TO-LEFT OVERRIDE/);
+  assert.match(r.stderr, /in the file NAME/, 'the message must say WHERE the character is');
+});
+
+test('a poisoned name is caught even on a file that is exempt from the content scan', () => {
+  // The exemption is for a file's BYTES. Its name still reaches every tool and
+  // every projection, so `binary` must not buy an exemption for the path.
+  const blob = Buffer.from([0xff, 0xd8, 0xff, 0xe0]);
+  const dir = gitRepo({
+    '.gitattributes': '*.jpg binary\n',
+    ['assets/logo' + cp(0x200b) + '.jpg']: blob,
+  });
+  const r = scan(dir);
+  assert.equal(r.status, 1, 'an exempt file still has a name');
+  assert.match(r.stderr, /U\+200B ZERO WIDTH SPACE/);
+  assert.match(r.stderr, /in the file NAME/);
+});
+
+test('TAB and LF are legal in contents and forbidden in a path', () => {
+  // The asymmetry is the point: a tab is ordinary text and a catastrophe in a
+  // filename, where it makes one path print as two columns.
+  assert.deepEqual(scanText('a\tb\nc'), []);
+  assert.equal(scanPath('a\tb').length, 1);
+  assert.equal(scanPath('a\nb').length, 1);
+  assert.equal(scanPath('docs/ordinary-name.md').length, 0);
+
+  // End to end, because a TAB in a name also stresses the parser that reads
+  // `git ls-files -s -z`: the mode is separated from the path by a TAB, so a
+  // parser splitting on the LAST tab would lose half the name of exactly the
+  // file it is meant to report.
+  const dir = gitRepo({ ['na' + cp(0x09) + 'me.md']: '# clean\n' });
+  const r = scan(dir);
+  assert.equal(r.status, 1);
+  assert.match(r.stderr, /U\+0009 TAB — control character in a path \[in the file NAME\]/);
+});
+
+test('a symlink whose TARGET carries a control character fails the gate', () => {
+  // A symlink's payload IS its target string, and git tracks it as such. The
+  // old scanner called readFileSync on the link, which follows it: a target
+  // outside the repo got its CONTENTS scanned instead (a file we do not own),
+  // and a dangling link was filed as "tracked but missing" and quietly skipped
+  // — with its poisoned target never looked at.
+  const dir = mkdtempSync(join(tmpdir(), 'tyran-scan-link-'));
+  const run = (...args) => {
+    const r = spawnSync('git', args, { cwd: dir, encoding: 'utf8' });
+    assert.equal(r.status, 0, `git ${args.join(' ')} failed: ${r.stderr}`);
+  };
+  run('init', '-q');
+  run('config', 'user.email', 'test@example.invalid');
+  run('config', 'user.name', 'Test');
+  writeFileSync(join(dir, 'README.md'), '# Title\n');
+  symlinkSync('docs/target' + cp(0x202e) + 'gpj.md', join(dir, 'link.md'));
+  run('add', '-A');
+
+  const part = partitionTrackedFiles(dir);
+  assert.deepEqual(part.links.map((l) => l.file), ['link.md'], 'the symlink must be scanned as a link');
+  assert.ok(!part.scan.includes('link.md'), 'a symlink must not be read as a file');
+  assert.deepEqual(part.exempt.map((e) => e.file), [], 'a dangling link is not an excuse to skip it');
+
+  const r = scan(dir);
+  assert.equal(r.status, 1, 'a poisoned link target must not pass');
+  assert.match(r.stderr, /link\.md/);
+  assert.match(r.stderr, /U\+202E RIGHT-TO-LEFT OVERRIDE/);
+  assert.match(r.stderr, /in the symlink TARGET/);
+});
+
+test('a clean symlink is counted as scanned, not as an exemption', () => {
+  const dir = mkdtempSync(join(tmpdir(), 'tyran-scan-link-ok-'));
+  const run = (...args) => spawnSync('git', args, { cwd: dir, encoding: 'utf8' });
+  run('init', '-q');
+  run('config', 'user.email', 'test@example.invalid');
+  run('config', 'user.name', 'Test');
+  writeFileSync(join(dir, 'README.md'), '# Title\n');
+  symlinkSync('README.md', join(dir, 'alias.md'));
+  run('add', '-A');
+  const r = scan(dir);
+  assert.equal(r.status, 0, r.stderr);
+  assert.match(r.stdout, /clean \(2 tracked text files\)/, 'the link must be counted');
 });
 
 // --- binary exclusion, the way that actually works ------------------------

--- a/tests/unit/schema.test.mjs
+++ b/tests/unit/schema.test.mjs
@@ -1,9 +1,9 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { mkdtempSync, writeFileSync } from 'node:fs';
+import { mkdtempSync, mkdirSync, symlinkSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
-import { execFileSync } from 'node:child_process';
+import { execFileSync, spawnSync } from 'node:child_process';
 import { readFileSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import {
@@ -281,4 +281,52 @@ test('protected paths cannot be outranked by any glob spelling (E2S2-R10)', () =
   assert.ok(validatePolicy(evil).some((e) => e.includes('**/policy-gate.mjs')));
   // Even a policy that never mentions hooks cannot make them autonomous.
   assert.equal(classifyPath({ default: 'AUTO', rules: [{ path: '**', class: 'AUTO', reason: 'all' }] }, 'hooks/x.mjs'), 'KERNEL');
+});
+
+test('CLI: invoked through a symlinked path, validation still runs (ADR-19 debt)', () => {
+  // The self-run guard compared resolve(argv[1]) — which keeps symlinks — with
+  // import.meta.url, which Node has already canonicalized. Reaching the script
+  // through a link therefore made main() never run: no output, no findings,
+  // and EXIT 0 over a file that does not validate. This script is a CI step,
+  // so a silent no-op reads as "the templates are valid" when nothing looked
+  // at them. Not exotic either: /tmp and /var are symlinks on macOS and plugin
+  // installs reach scripts/ through a link routinely.
+  const base = mkdtempSync(join(tmpdir(), 'tyran-schema-symlink-'));
+  const realScripts = join(base, 'real-scripts');
+  mkdirSync(realScripts);
+  writeFileSync(join(realScripts, 'schema.mjs'), readFileSync(SCRIPT));
+  writeFileSync(
+    join(realScripts, 'yaml-lite.mjs'),
+    readFileSync(fileURLToPath(new URL('../../scripts/yaml-lite.mjs', import.meta.url))),
+  );
+  const linked = join(base, 'linked-scripts');
+  symlinkSync(realScripts, linked);
+
+  const bad = join(base, 'bad.yaml');
+  writeFileSync(bad, 'profile: turbo\n');
+  const r = spawnSync(process.execPath, [join(linked, 'schema.mjs'), 'validate', 'config', bad], {
+    encoding: 'utf8',
+  });
+  assert.notEqual(r.stdout, '', 'the CLI produced no output at all through the symlink');
+  assert.match(r.stdout, /^FAIL /m, 'the invalid file was not reported through the symlink');
+  assert.equal(r.status, 1, 'an invalid file exited 0 through the symlink');
+});
+
+test('the self-run guard survives an argv[1] that cannot be canonicalized', () => {
+  // The guard canonicalizes argv[1] with realpathSync, which THROWS when the
+  // path cannot be followed. Without the fallback that throw escapes module
+  // scope and importing schema.mjs fails outright — taking down every consumer,
+  // including the hook that classifies paths.
+  const base = mkdtempSync(join(tmpdir(), 'tyran-schema-argv-'));
+  const harness = join(base, 'harness.mjs');
+  writeFileSync(
+    harness,
+    "process.argv[1] = '/nonexistent-dir-" +
+      "e30/entry.mjs';\n" +
+      `await import(${JSON.stringify(SCRIPT)});\n` +
+      "console.log('SURVIVED');\n",
+  );
+  const r = spawnSync(process.execPath, [harness], { encoding: 'utf8' });
+  assert.equal(r.status, 0, r.stderr);
+  assert.equal(r.stdout.trim(), 'SURVIVED');
 });


### PR DESCRIPTION
Three E2 debts, all in code that already passed review, all counterexamples to
the sentence epic E3 sells: *a gate you cannot silently bypass*.

## 1. Silent no-op through a symlink — `schema.mjs`, `desc-budget.mjs`

Both compared `resolve(argv[1])` (keeps symlinks) with `import.meta.url`
(already canonicalized by Node). Through a link `main()` never ran: no output,
**exit 0**. Both are CI steps, so that reads as "templates valid" / "within
budget" over work nobody did. `/tmp` and `/var` are symlinks on macOS, so this
is the ordinary case. Fixed with the pattern `journal.mjs`, `project.mjs` and
`doctor.mjs` already carry.

## 2. The forbidden list was structurally incomplete (ADR-19 correction 1)

Added the **TAG block** `U+E0000`-`U+E007F` (invisible codepoints mapping
one-to-one onto ASCII, in files that agents read, fed by subagent reports about
foreign repositories — an injection channel, not an ugly character), the
Variation Selectors Supplement, `U+00AD`, `U+180E`, `U+2060`-`U+2064`,
`U+206A`-`U+206F`, `U+FFF9`-`U+FFFB`, `U+1D173`-`U+1D17A` and the invisible
Hangul fillers. TAG findings now name the ASCII they encode.

`U+FE00`-`U+FE0F` stays **legal, deliberately**: `U+FE0F` is emoji presentation
and this README uses it 24 times; banning it would turn CI red on a file nobody
touched, which is how gates get switched off. Exported as
`DELIBERATELY_ALLOWED` and guarded by a test, rather than left as a silence.

## 3. The pinning test excluded astral planes — which is what hid item 2

With the exclusion restored, deleting the entire TAG range leaves that test
green. Measured, not assumed. The walk now covers every codepoint, and a
separate test proves the scanner measures **codepoints, not UTF-16 units** — a
TAG character is a surrogate pair and neither half is in any range.

## 4. Names and link targets are scanned, not just contents

A file whose NAME carried an override passed the gate; so did a symlink whose
TARGET did. Both reach the reader through tool output and through projections,
and a file's bytes can be exempted while its name cannot. Symlinks are read
with `readlink` instead of `readFileSync`, which followed them — a link out of
the repo had someone else's contents scanned in its place, and a dangling one
was filed as "missing" and skipped. TAB and LF are legal in contents and
forbidden in a path.

## Evidence

- `node --test "tests/**/*.test.mjs"` — **243 passed / 0 failed**, exit 0
  (baseline before the work: 232 / 0).
- `node scripts/scan-control-chars.mjs .` — clean, 48 scanned, 1 exempt,
  exit 0. The 48-file canary is unchanged: no tracked file was added.
- **17 mutants, 17 red tests** (ADR-20), quoted in the work report, including
  the equivalence proof that the astral exclusion made item 2 unfalsifiable.

## Out of scope, on purpose

Unifying the three spellings of this one rule (`journal.mjs`'s
`\p{Cc}\p{Cf}`, `project.mjs`'s `inline()` list, the scanner's `FORBIDDEN`).
The differential table over all 1.1M codepoints is measured and reported (456
disagreeing codepoints in 36 ranges); the unification is its own story, per
ADR-21.
