### PR TITLE
S-E3-1: hook runtime that refuses in every failure mode of its own

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -9,6 +9,7 @@
   "homepage": "https://github.com/jjanczur/tyran#readme",
   "repository": "https://github.com/jjanczur/tyran",
   "license": "Apache-2.0",
+  "hooks": "./hooks/hooks.json",
   "keywords": [
     "orchestration",
     "multi-agent",

--- a/README.md
+++ b/README.md
@@ -151,6 +151,7 @@ links to a LICENSE file that does not exist in the repo.</sub>
 - 📜 [Journal reference](docs/journal.md) — the append-only event schema (shipped)
 - 🧾 [Projections](docs/projections.md) — generated `STATE.md` / `PROGRESS.md` and `--check` (shipped)
 - 🩺 [Doctor](docs/doctor.md) — `--state` consistency check: drift, orphan leases, dead policy rules (shipped)
+- 🪝 [Hook runtime](docs/hooks.md) — gates vs probes, why hooks fail open, and what the deadline really promises (shipped)
 - 🧠 [Self-improvement](docs/self-improvement.md) — how Tyran learns your repo, and its guardrails
 - ❓ [FAQ](docs/faq.md)
 - 🤝 [Contributing](CONTRIBUTING.md)

--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -1,6 +1,6 @@
 # Hook runtime reference
 
-> **Status:** shipped — `hooks/scripts/hook-io.mjs` with 45 unit tests.
+> **Status:** shipped — `hooks/scripts/hook-io.mjs`.
 > Read this before writing a gate. The platform's default failure mode is to
 > **let the action through**, so most of the ways a gate can be wrong end in
 > it silently not existing.
@@ -93,18 +93,30 @@ narrowly — four gates inherit whatever this claims:
 |---|---|
 | the handler yields the event loop and has not decided in time | **yes** — the timer emits the refusal |
 | the handler overruns and *then* returns a verdict | **yes** — the verdict is discarded and replaced by a refusal |
-| the handler blocks the thread and never returns | **no** — nothing on this thread can run; the platform `SIGKILL`s the process and a killed hook produces no output |
+| the handler blocks the thread and never returns | **no** — nothing on this thread can run, and the platform kills the process |
 
-The third row has no in-process fix (Node is single-threaded), so it is a rule
-for gate authors instead:
+**The third row is worse than "the hook had no time to write", and the
+difference decides what a fix would have to look like.** Measured live: a hook
+that wrote a complete, valid refusal to stdout and *then* blocked past its
+timeout was **ignored, and the tool ran**. The kill and the abort are the same
+event, and the platform returns on `aborted` before it ever parses stdout —
+the bytes are collected, even recorded in telemetry, and never read.
+
+> **Writing earlier does not help.** A watchdog that emits the refusal sooner
+> while the process keeps running buys **nothing**. Only making the process
+> **exit** before the platform's timeout closes this case.
+
+That is why every ending in `hook-io.mjs` writes and then exits — and why
+there is no cheap fix for a handler that never returns. The mitigation is a
+rule for gate authors:
 
 > **A gate does no unbounded synchronous work.** Size-check before
 > `readFileSync`, prefer async I/O, and give any child process its own
 > `timeout`.
 
-If that ever proves insufficient the fix is a hard-killed child process or a
-worker-thread watchdog claiming the write through `Atomics`. Both cost real
-latency on **every** tool call, and nothing measured so far justifies it.
+The only remaining escape hatch is running the gate's work in a hard-killed
+child process. That costs real latency on **every** tool call, and nothing
+measured so far justifies it.
 
 ## Writing a probe
 

--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -1,0 +1,139 @@
+# Hook runtime reference
+
+> **Status:** shipped — `hooks/scripts/hook-io.mjs` with 45 unit tests.
+> Read this before writing a gate. The platform's default failure mode is to
+> **let the action through**, so most of the ways a gate can be wrong end in
+> it silently not existing.
+
+Two files, two jobs:
+
+| file | job |
+|---|---|
+| [`hooks/scripts/hook-io.mjs`](../hooks/scripts/hook-io.mjs) | the runtime every hook runs inside |
+| [`hooks/HOOK-CONTRACT-MEASURED.md`](../hooks/HOOK-CONTRACT-MEASURED.md) | what the platform actually does, read out of the shipped binary |
+
+## The rule that decides everything: gates and probes
+
+Claude Code gives some events a way to refuse and others none at all. That is
+not a style choice, it is a property of the platform, so Tyran puts it in the
+type rather than in a comment.
+
+| role | events | can refuse |
+|---|---|---|
+| **gate** — refusal is the product | `PreToolUse`, `SubagentStop`, `Stop`, `PreCompact`, `UserPromptSubmit`, `TaskCompleted`\* | yes |
+| **probe** — injects or records | `SessionStart`, `SubagentStart`, `PostToolUse`, `SessionEnd`, `Notification` | no |
+
+\* `TaskCompleted` fires **only in team mode**. A check placed only there does
+not exist under subagent orchestration. `EVENTS.TaskCompleted.teamModeOnly`
+says so and a test pins it.
+
+`runGate` **throws** if you register it on a probe event. Never work around
+that by putting a security check on `SessionStart` "because it fits there
+logically" — it cannot say no. When a control needs teeth its place is
+`PreToolUse` or `SubagentStop`, and the check must sit on the path the payload
+really travels, not on a path that merely resembles it.
+
+## Writing a gate
+
+```js
+#!/usr/bin/env node
+import { PASS, main, runGate } from './hook-io.mjs';
+
+export const DEADLINE_MS = 4000;          // read by a test against hooks.json
+
+await main(() =>
+  runGate({
+    event: 'PreToolUse',
+    deadlineMs: DEADLINE_MS,
+    handler: ({ input }) => {
+      const command = input.tool_input?.command ?? '';
+      return looksLikeASecret(command)
+        ? { decision: 'deny', reason: `refusing: ${command}` }
+        : PASS;
+    },
+  }),
+);
+```
+
+Rules the runtime enforces for you:
+
+- **you cannot approve.** `PASS` means "no objection" and emits `{}`. There is
+  deliberately no way to emit `permissionDecision: "allow"`, which does not
+  mean "satisfied" — it **auto-approves the call and skips the permission
+  prompt**;
+- **you cannot crash into an approval.** Any throw, malformed input, missing
+  dependency or unrecognised return value becomes a refusal naming the error
+  class;
+- **you cannot pick the wrong output shape.** `PreToolUse` refuses through
+  `hookSpecificOutput`, the rest through top-level `decision`; one `deny()`
+  generates both;
+- **you cannot leak control characters** into the transcript through a quoted
+  tool input.
+
+Rules **you** have to keep:
+
+- **register with an explicit, short `timeout`** in `hooks/hooks.json`. With
+  no `timeout` the platform waits 600 s and then discards the output;
+- **export `DEADLINE_MS`** and keep it at or below half the registered
+  timeout. A test walks every entry in `hooks.json` and fails otherwise;
+- **quote `${CLAUDE_PLUGIN_ROOT}`** in the command; it is run through a shell;
+- **`chmod +x` the script** and give it a shebang, or the shell exits 127 and
+  the gate quietly does not exist;
+- **write the matcher as a list, never with commas or spaces.** `Edit|Write`
+  is a list; `Edit, Write` is an *unanchored regex* that matches nothing at
+  all, and nothing anywhere reports it.
+
+## The deadline: what it promises, exactly
+
+The platform kills a slow hook and throws its output away, so slow equals
+approved. The runtime holds a tighter budget of its own. State its scope
+narrowly — four gates inherit whatever this claims:
+
+| case | enforced? |
+|---|---|
+| the handler yields the event loop and has not decided in time | **yes** — the timer emits the refusal |
+| the handler overruns and *then* returns a verdict | **yes** — the verdict is discarded and replaced by a refusal |
+| the handler blocks the thread and never returns | **no** — nothing on this thread can run; the platform `SIGKILL`s the process and a killed hook produces no output |
+
+The third row has no in-process fix (Node is single-threaded), so it is a rule
+for gate authors instead:
+
+> **A gate does no unbounded synchronous work.** Size-check before
+> `readFileSync`, prefer async I/O, and give any child process its own
+> `timeout`.
+
+If that ever proves insufficient the fix is a hard-killed child process or a
+worker-thread watchdog claiming the write through `Atomics`. Both cost real
+latency on **every** tool call, and nothing measured so far justifies it.
+
+## Writing a probe
+
+`runProbe` is the mirror image: it never refuses and never lets a failure
+reach the user. No state, an unreadable journal, no permissions — all of them
+produce a shorter context or none, and the session starts. This is the one
+place in the system where failing open is correct, because a probe cannot
+refuse anyway and its failure must not cost a session.
+
+Injected context has a hard ceiling of **10 000 characters** (UTF-16 code
+units) which covers the whole serialized payload. Past it the platform writes
+the content to a file and replaces it with a reference, so oversize context
+silently stops being context. `session-start.mjs` aims at ~2 KB and trims on a
+section boundary, always saying how much it dropped.
+
+## Known limits
+
+- `readInitiatives` folds journals synchronously. Measured: 400 000 events /
+  77 MB in 1.91 s, inside the probe's budget. On a probe this is fail-open and
+  therefore safe; the same shape inside a **gate** would be the third row of
+  the deadline table. A gate that reads journals must bound its input first.
+- The forbidden-codepoint membership test is spelled once more here than it
+  should be: the data comes from `scan-control-chars.mjs`, but the loop over
+  it is local because the scanner's `classify` is not exported yet.
+
+## Testing a hook
+
+`tests/unit/hook-io.test.mjs` is the model. The half that matters is the set
+of tests that break the runtime on purpose — thrown handler, exceeded
+deadline, corrupt JSON, missing dependency, failed stdout write — and assert
+that the result is a **refusal, not silence**. Per ADR-20, a guard is finished
+only once you have shown it red by removing the mechanism it defends.

--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -126,9 +126,11 @@ section boundary, always saying how much it dropped.
   77 MB in 1.91 s, inside the probe's budget. On a probe this is fail-open and
   therefore safe; the same shape inside a **gate** would be the third row of
   the deadline table. A gate that reads journals must bound its input first.
-- The forbidden-codepoint membership test is spelled once more here than it
-  should be: the data comes from `scan-control-chars.mjs`, but the loop over
-  it is local because the scanner's `classify` is not exported yet.
+- Sanitization asks `scanText` from `scan-control-chars.mjs` which codepoints
+  are forbidden rather than keeping its own copy of the rule, so the set the
+  CI scanner enforces and the set a gate escapes cannot drift apart. When the
+  scanner's list grows — as it did with the TAG block in ADR-19's first
+  correction — the runtime inherits it with no edit.
 
 ## Testing a hook
 

--- a/hooks/HOOK-CONTRACT-MEASURED.md
+++ b/hooks/HOOK-CONTRACT-MEASURED.md
@@ -17,16 +17,24 @@ when any of these happen:
 
 | what happens | result |
 |---|---|
-| the hook file is missing or not executable | spawn throws, caught, **action proceeds** |
+| the hook file is missing or not executable | the command runs under `shell: true`, so **the shell** exits 127 / 126 with empty stdout; that lands in the "non-blocking status code" branch and the **action proceeds** |
 | stdout is not JSON at all (does not start with `{`) | treated as plain text, **proceeds** |
 | stdout is JSON but fails the output schema | validation error, **proceeds** |
-| `hookSpecificOutput.hookEventName` differs from the fired event | the platform **throws while reading our output**, caught, **proceeds** |
-| the hook is killed at its `timeout` | output discarded, **proceeds** |
-| an exception is thrown while *selecting* which hooks to run | selection returns `[]`, so **every hook silently disappears** |
+| `hookSpecificOutput.hookEventName` differs from the fired event | the platform **throws while reading our output**, caught, **proceeds** (only when `hookSpecificOutput` is present at all — see §3) |
+| the hook is killed at its `timeout` | killed with `SIGKILL`; measured `rc=137`, **stdout empty**, **proceeds** |
+| an exception escapes hook *selection* | the selector is wrapped in `try { … } catch { return [] }`, so **every hook for that event disappears** with no transcript entry |
 
-The last row answers one of ADR-22's open questions: yes, a missing hook file
-disables that gate silently. It is a real attack surface on the plugin
-itself, and the answer is not inside a hook.
+Two corrections to how this was first written, both worth stating because the
+wrong mechanism leads to the wrong fix:
+
+- a missing hook file does **not** make `spawn` throw. There is no
+  pre-existence check; `shell: true` means the shell reports it. The
+  conclusion for ADR-22's open question is unchanged — a deleted hook file
+  disables that gate silently, and the answer cannot live inside a hook.
+- an **invalid regex in a matcher is not** one of the exceptions that empties
+  the selector. It is caught locally inside the matcher predicate, which
+  returns `false` and logs at debug level. The gate still disappears, but
+  only that one, and for a different reason (§5).
 
 ## 2. Exit codes: the documented rule is incomplete
 
@@ -53,6 +61,16 @@ There is **no variant for `Stop`, `SubagentStop`, `PreCompact` or
 discarded. Those events refuse through top-level `decision: "block"` +
 `reason`. This is why `deny()` has to know the event.
 
+Two refinements measured after the first draft:
+
+- the "wrong `hookEventName` throws" check runs **only if `hookSpecificOutput`
+  is present at all**. Top-level `decision` + `reason` is not subject to it,
+  so the decision-shaped events are safe from that failure *by construction*,
+  not by our carefulness.
+- `decision: "block"` on **`SubagentStop` is confirmed live**, not inferred:
+  the subagent was stopped and the parent turn resumed with the reason in
+  context. This is the event the evidence gate will stand on.
+
 ## 4. `permissionDecision: "allow"` is not "no objection"
 
 It sets the permission behaviour to *allow*, i.e. it **auto-approves the tool
@@ -65,23 +83,62 @@ This runtime has no way to emit it. "No objection" is `{}`.
 
 ## 5. Matcher syntax — one predicate for every event
 
+Transcribed in full, including the alias normalisation an earlier draft of
+this file dropped. `normalise` is a lookup in the tool-alias table (identity
+for anything that is not an aliased tool name), and `aliasesOf` is its
+reverse, so a regex matcher is tried against the query *and* against every
+name that aliases to it:
+
 ```
 if (!matcher || matcher === "*") return true;
 if (/^[a-zA-Z0-9_|]+$/.test(matcher))
-    return matcher.includes("|") ? matcher.split("|").includes(query)
-                                 : query === matcher;
-try { return new RegExp(matcher).test(query) } catch { return false }
+    return matcher.includes("|")
+        ? matcher.split("|").map(k => normalise(k.trim())).includes(query)
+        : query === normalise(matcher);
+try {
+    const re = new RegExp(matcher);                 // NOT anchored
+    if (re.test(query)) return true;
+    for (const alias of aliasesOf(query)) if (re.test(alias)) return true;
+    return false;
+} catch { return false }
 ```
 
-Three consequences the documented table does not state:
+Consequences the documented table does not state:
 
 1. **`SessionStart` accepts alternation.** `startup|resume|compact` is a
    single valid entry; three separate entries are unnecessary.
 2. The exact-list character class is `[a-zA-Z0-9_|]` — **no spaces, hyphens
-   or commas.** `Edit, Write` or `my-tool` fall through to the *regex*
-   branch, which is unanchored and matches far more than it looks like.
-3. An invalid regex matches **nothing** and only writes a debug line. A typo
-   in a matcher removes the gate without any visible failure.
+   or commas.** Anything containing them silently becomes a *regex*, and that
+   produces **two opposite failure modes**, not one. Measured:
+
+   | matcher | query | result | |
+   |---|---|---|---|
+   | `tyran-implementer` | `evil-tyran-implementer-nope` | `true` | matches **too much** — regexes are unanchored |
+   | `Edit, Write` | `Write` | `false` | matches **nothing at all** |
+   | `Edit, Write` | `Edit` | `false` | matches **nothing at all** |
+   | `Edit\|Write` | `Write` | `true` | the list syntax, which is what was meant |
+   | `[unclosed` | anything | `false` | invalid regex, caught locally |
+
+   The second mode is the dangerous one and it is the one that looks
+   harmless: a comma-and-space list is valid JSON, reads like a list, appears
+   in the manifest, validates — and **never fires**. A gate that silently
+   matches nothing is indistinguishable from a gate that is installed.
+3. An invalid regex matches **nothing** and only writes a debug line. It does
+   not disable other hooks; the failure is local to that matcher. A typo
+   removes exactly one gate, invisibly.
+
+## 5a. Which events actually fire, and when
+
+- **`TaskCompleted` fires only in TEAM mode.** The platform raises it for the
+  in-progress tasks of the current teammate. Under plain subagent
+  orchestration it never fires, so a check placed only there is an **absent**
+  control, not a weak one. `hook-io.mjs` marks it `teamModeOnly: true` in
+  `EVENTS` and a test pins the flag; it stays available because it does
+  refuse when it does fire.
+- **`SubagentStop` with an empty `agent_type` bypasses matcher filtering
+  entirely** and runs every hook registered for the event. A matcher there is
+  a narrowing that cannot be relied on — treat it as a hint, and re-check the
+  agent identity inside the gate.
 
 ## 6. Sizes, timeouts, execution
 

--- a/hooks/HOOK-CONTRACT-MEASURED.md
+++ b/hooks/HOOK-CONTRACT-MEASURED.md
@@ -21,11 +21,43 @@ when any of these happen:
 | stdout is not JSON at all (does not start with `{`) | treated as plain text, **proceeds** |
 | stdout is JSON but fails the output schema | validation error, **proceeds** |
 | `hookSpecificOutput.hookEventName` differs from the fired event | the platform **throws while reading our output**, caught, **proceeds** (only when `hookSpecificOutput` is present at all — see §3) |
-| the hook is killed at its `timeout` | killed with `SIGKILL`; measured `rc=137`, **stdout empty**, **proceeds** |
+| the hook is killed at its `timeout` | killed with `SIGKILL` — and the output is **not read at all**; see below, this row is the one that misleads |
 | an exception escapes hook *selection* | the selector is wrapped in `try { … } catch { return [] }`, so **every hook for that event disappears** with no transcript entry |
 
-Two corrections to how this was first written, both worth stating because the
-wrong mechanism leads to the wrong fix:
+### The timeout row, in full — because the obvious reading of it is wrong
+
+An earlier version of this file said "measured `rc=137`, stdout empty,
+proceeds". Every word of that is true and the sentence is still misleading,
+because it points at the wrong cause. The problem is **not** that a killed
+hook has no time to write. Measured on a live run: a `PreToolUse` hook with
+`timeout: 3` wrote a complete, valid refusal through `writeSync(1, …)`,
+logged that it had done so, and only then blocked for 60 s. The refusal was
+**ignored and the tool ran**.
+
+The reason is visible in the runner. The same moment that kills the process
+aborts the `AbortSignal`, the `close` handler reports `aborted: true`, and
+the consumer does this:
+
+```
+if (o.aborted) { …record telemetry, including o.stdout…; return }   // ← returns here
+const { json, plainText, validationError } = parse(o.stdout);       // ← never reached
+```
+
+The bytes were collected. They are even stored in the telemetry record. They
+are simply **never parsed**. So:
+
+> **Writing earlier does not help.** A watchdog that emits the refusal sooner
+> and lets the process keep running buys nothing at all. The only thing that
+> closes this case is a mechanism that makes the process **EXIT** before the
+> platform's timeout — a hard-killed child process, or a watchdog that forces
+> the whole process to terminate. Anything that merely produces output while
+> the process stays alive is defeated by this branch.
+
+This is why `hook-io.mjs` enforces its budget by emitting **and exiting**,
+rather than by writing early and hoping.
+
+Two further corrections to how this file was first written, both worth
+stating because the wrong mechanism leads to the wrong fix:
 
 - a missing hook file does **not** make `spawn` throw. There is no
   pre-existence check; `shell: true` means the shell reports it. The

--- a/hooks/HOOK-CONTRACT-MEASURED.md
+++ b/hooks/HOOK-CONTRACT-MEASURED.md
@@ -1,0 +1,103 @@
+# Hook I/O contract — measured, not assumed
+
+Every statement here was read out of the shipped Claude Code binary
+(**v2.1.116**), not out of documentation. It exists because a gate built on a
+guess about the platform is a gate of unknown strength (ADR-22), and because
+four of the facts below **contradict** the documented contract in ways that
+would each have produced a control that looks installed and cannot refuse.
+
+Re-measure after a platform upgrade. The method: the binary embeds its
+JavaScript, so `strings`/byte search finds the hook runner, the output schema
+and the matcher predicate directly.
+
+## 1. Failing open is the default, in more places than expected
+
+The action proceeds — and the hook is recorded as a `non_blocking_error` —
+when any of these happen:
+
+| what happens | result |
+|---|---|
+| the hook file is missing or not executable | spawn throws, caught, **action proceeds** |
+| stdout is not JSON at all (does not start with `{`) | treated as plain text, **proceeds** |
+| stdout is JSON but fails the output schema | validation error, **proceeds** |
+| `hookSpecificOutput.hookEventName` differs from the fired event | the platform **throws while reading our output**, caught, **proceeds** |
+| the hook is killed at its `timeout` | output discarded, **proceeds** |
+| an exception is thrown while *selecting* which hooks to run | selection returns `[]`, so **every hook silently disappears** |
+
+The last row answers one of ADR-22's open questions: yes, a missing hook file
+disables that gate silently. It is a real attack surface on the plugin
+itself, and the answer is not inside a hook.
+
+## 2. Exit codes: the documented rule is incomplete
+
+Documented: `0` decides, `2` blocks, anything else fails open.
+
+Measured: **stdout is parsed first, and a valid refusal on stdout is honoured
+regardless of the exit code.** The exit code is only consulted when stdout
+carried no usable JSON — `2` then becomes a block with stderr as the reason,
+and `3`–`255` become a non-blocking error.
+
+Consequence for us: exit 0 plus a JSON refusal is the strongest available
+ending, and it is what this runtime always emits.
+
+## 3. The output shape is a discriminated union, and it is narrow
+
+`hookSpecificOutput` is validated as a union keyed on `hookEventName`. There
+are variants for `PreToolUse`, `UserPromptSubmit`, `UserPromptExpansion`,
+`SessionStart`, `Setup`, `SubagentStart`, `PostToolUse`, `PostToolUseFailure`,
+`PermissionDenied`, `Notification`, `PermissionRequest`, `Elicitation`,
+`ElicitationResult`, `CwdChanged`, `FileChanged`, `WorktreeCreate`.
+
+There is **no variant for `Stop`, `SubagentStop`, `PreCompact` or
+`TaskCompleted`.** Sending one there fails the schema and the whole output is
+discarded. Those events refuse through top-level `decision: "block"` +
+`reason`. This is why `deny()` has to know the event.
+
+## 4. `permissionDecision: "allow"` is not "no objection"
+
+It sets the permission behaviour to *allow*, i.e. it **auto-approves the tool
+call and skips the permission prompt**. A gate emitting it for everything it
+did not object to would be quietly approving the whole session. `deny` from
+any hook wins over `allow` from another, but that is no comfort when ours is
+the only hook.
+
+This runtime has no way to emit it. "No objection" is `{}`.
+
+## 5. Matcher syntax — one predicate for every event
+
+```
+if (!matcher || matcher === "*") return true;
+if (/^[a-zA-Z0-9_|]+$/.test(matcher))
+    return matcher.includes("|") ? matcher.split("|").includes(query)
+                                 : query === matcher;
+try { return new RegExp(matcher).test(query) } catch { return false }
+```
+
+Three consequences the documented table does not state:
+
+1. **`SessionStart` accepts alternation.** `startup|resume|compact` is a
+   single valid entry; three separate entries are unnecessary.
+2. The exact-list character class is `[a-zA-Z0-9_|]` — **no spaces, hyphens
+   or commas.** `Edit, Write` or `my-tool` fall through to the *regex*
+   branch, which is unanchored and matches far more than it looks like.
+3. An invalid regex matches **nothing** and only writes a debug line. A typo
+   in a matcher removes the gate without any visible failure.
+
+## 6. Sizes, timeouts, execution
+
+- The 10 000-character cap is applied as `text.length` — **UTF-16 code
+  units**. It covers hook stdout, `additionalContext`, `systemMessage` and
+  `initialUserMessage`. Oversize content is not rejected: it is written to a
+  file and replaced by a reference, so injected context silently stops being
+  context.
+- `timeout` in `hooks.json` is in **seconds**; the default when it is absent
+  is **600 s** (`SessionEnd` is the exception, 1.5 s).
+- The command is spawned with `shell: true`, so the substituted
+  `${CLAUDE_PLUGIN_ROOT}` **must be quoted** or a path with a space breaks
+  the invocation. Input arrives on stdin as one JSON object followed by a
+  newline.
+- Hooks matched to one event run **in parallel**, deduplicated by
+  `(pluginRoot, command)`. No hook may assume another has already written
+  anything.
+- `permissionDecision: "defer"` is print-mode only; in an interactive session
+  it is ignored with a warning.

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -1,0 +1,16 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "matcher": "startup|resume|compact",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"${CLAUDE_PLUGIN_ROOT}/hooks/scripts/session-start.mjs\"",
+            "timeout": 10
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/hooks/scripts/hook-io.mjs
+++ b/hooks/scripts/hook-io.mjs
@@ -1,0 +1,604 @@
+/**
+ * hook-io — the runtime every Tyran hook runs inside.
+ *
+ * This is not a stdin parser. It is a security component, because of one
+ * measured property of the platform (ADR-22): **Claude Code fails OPEN.**
+ * A hook that crashes, times out, prints garbage, or is missing entirely
+ * does not block anything — the action proceeds with a small "hook error"
+ * note. So the worse a gate behaves, the less it gates. An attacker does
+ * not need to defeat a gate's logic; breaking the gate is enough.
+ *
+ * Everything below exists to remove the ways a gate can fail quietly.
+ *
+ * Measured against the local install (v2.1.116, binary disassembled at
+ * `hooks/HOOK-CONTRACT-MEASURED.md`), not assumed:
+ *
+ *  - stdout that does not parse as the hook-output schema is discarded and
+ *    the action proceeds. Our JSON must always be valid AND schema-shaped.
+ *  - `hookSpecificOutput.hookEventName` must EQUAL the event that fired, or
+ *    the platform throws while reading our output — which fails open.
+ *  - `hookSpecificOutput` has no variant for Stop / SubagentStop /
+ *    PreCompact / TaskCompleted. Emitting one there fails the schema, so
+ *    those events refuse through top-level `decision` + `reason` instead.
+ *    Two shapes, one call site: `deny(reason)`.
+ *  - the 10 000 limit is applied as `String.prototype.length`, i.e. UTF-16
+ *    code units, so that is what we count.
+ *  - `permissionDecision: "allow"` is NOT "no objection" — it AUTO-APPROVES
+ *    the tool call and skips the permission prompt. There is deliberately no
+ *    way to emit it from this runtime; see `PASS`.
+ */
+import { writeSync } from 'node:fs';
+
+import { FORBIDDEN, formatCodePoint } from '../../scripts/scan-control-chars.mjs';
+
+/**
+ * The platform's cap on hook stdout and on `additionalContext`, measured as
+ * `text.length <= 10000` — UTF-16 code units, not code points. Oversize
+ * output is not rejected: it is persisted to a temp file and replaced by a
+ * reference, which for injected context means the content silently stops
+ * being context. Staying under the limit is the only way to stay read.
+ */
+export const OUTPUT_LIMIT = 10000;
+
+/** Refuse absurd stdin rather than buffering it. 1 MB is ~100x a real payload. */
+export const MAX_INPUT_BYTES = 1024 * 1024;
+
+/**
+ * What each event can do — a property of the TYPE, not of a comment.
+ *
+ * `canBlock: false` events are probes: the platform gives them no way to
+ * refuse. Registering a gate on one produces a control that looks like it
+ * works and cannot say no, which is the most dangerous defect this system
+ * can contain, so `runGate` refuses the registration outright.
+ *
+ * `refusal` names the OUTPUT SHAPE, which differs per event and is checked
+ * by the platform's schema:
+ *   'permissionDecision' -> hookSpecificOutput.permissionDecision = 'deny'
+ *   'decision'           -> top-level decision:'block' + reason
+ *
+ * `context` says whether the event accepts `hookSpecificOutput.additional-
+ * Context`. Where it is null the platform's schema has no variant for the
+ * event and emitting one makes the whole output invalid (fail open).
+ *
+ * Prototype-free, so an event called `constructor` cannot resolve to an
+ * inherited member (same reason as doctor.mjs SEVERITY_BY_CODE).
+ */
+export const EVENTS = Object.freeze(
+  Object.assign(Object.create(null), {
+    // Gates — refusal is the product.
+    PreToolUse: Object.freeze({ canBlock: true, refusal: 'permissionDecision', context: true }),
+    UserPromptSubmit: Object.freeze({ canBlock: true, refusal: 'decision', context: true }),
+    Stop: Object.freeze({ canBlock: true, refusal: 'decision', context: false }),
+    SubagentStop: Object.freeze({ canBlock: true, refusal: 'decision', context: false }),
+    PreCompact: Object.freeze({ canBlock: true, refusal: 'decision', context: false }),
+    TaskCompleted: Object.freeze({ canBlock: true, refusal: 'decision', context: false }),
+    // Probes — injection or record only; refusal is impossible.
+    SessionStart: Object.freeze({ canBlock: false, refusal: null, context: true }),
+    SubagentStart: Object.freeze({ canBlock: false, refusal: null, context: true }),
+    PostToolUse: Object.freeze({ canBlock: false, refusal: null, context: true }),
+    Notification: Object.freeze({ canBlock: false, refusal: null, context: true }),
+    SessionEnd: Object.freeze({ canBlock: false, refusal: null, context: false }),
+  }),
+);
+
+/** True for an event this runtime knows how to answer. */
+export function isKnownEvent(name) {
+  return typeof name === 'string' && Object.hasOwn(EVENTS, name);
+}
+
+/** True for an event on which a refusal is possible at all. */
+export function canBlock(name) {
+  return isKnownEvent(name) && EVENTS[name].canBlock === true;
+}
+
+/**
+ * Registering a gate on an event that cannot refuse. Its own class because
+ * it must be assertable in a test: this is the failure that produces a
+ * control which passes review and cannot say no.
+ */
+export class GateOnProbeEventError extends Error {
+  constructor(event) {
+    super(
+      `cannot register a gate on "${event}": the platform gives this event no way to refuse. ` +
+        'Move the check to PreToolUse, SubagentStop, Stop, PreCompact, UserPromptSubmit or ' +
+        'TaskCompleted, or declare it a probe with runProbe().',
+    );
+    this.name = 'GateOnProbeEventError';
+    this.event = event;
+  }
+}
+
+/** An input this runtime refused to trust. `errorClass` reaches the operator. */
+export class HookInputError extends Error {
+  constructor(errorClass, message, fix) {
+    super(message);
+    this.name = 'HookInputError';
+    this.errorClass = errorClass;
+    this.fix = fix;
+  }
+}
+
+// ------------------------------------------------------------ sanitization
+
+/**
+ * Codepoints this runtime refuses to echo, taken from the SAME table the CI
+ * scanner enforces. Deliberately imported rather than restated: ADR-19's own
+ * correction found THREE spellings of this rule already in the repo, and the
+ * outermost one was the weakest. When that list grows, this grows with it.
+ */
+function isForbidden(cp) {
+  for (const range of FORBIDDEN) {
+    if (cp >= range.lo && cp <= range.hi) return true;
+  }
+  return false;
+}
+
+/**
+ * Everything that reaches our stdout passes through here first.
+ *
+ * `tool_input` is written by the model and by repo content, and a refusal
+ * reason quotes it back. Without this, a gate's own denial message is an
+ * injection channel into the transcript: an unterminated bidi override in a
+ * quoted path reverses everything the operator reads after it, and a NUL
+ * makes the surrounding text invisible to every tool that greps it later.
+ *
+ * Forbidden codepoints become their ESCAPE NOTATION, not nothing. Silent
+ * removal would make a poisoned string and a clean one render identically —
+ * the same class of defect as a silent exemption in the scanner.
+ */
+export function sanitizeForOutput(value) {
+  const text = typeof value === 'string' ? value : String(value);
+  let out = '';
+  for (const ch of text) {
+    const cp = ch.codePointAt(0);
+    out += isForbidden(cp) ? `<${formatCodePoint(cp)}>` : ch;
+  }
+  return out;
+}
+
+// ---------------------------------------------------------------- payloads
+
+/** The refusal payload for `event`, in the shape that event's schema accepts. */
+export function refusalPayload(event, reason) {
+  const meta = EVENTS[event];
+  if (meta === undefined || meta.refusal === null) {
+    throw new GateOnProbeEventError(String(event));
+  }
+  if (meta.refusal === 'permissionDecision') {
+    return {
+      hookSpecificOutput: {
+        hookEventName: event,
+        permissionDecision: 'deny',
+        permissionDecisionReason: reason,
+      },
+    };
+  }
+  return { decision: 'block', reason };
+}
+
+/** The context-injection payload for `event`, or `{}` where it accepts none. */
+export function contextPayload(event, additionalContext) {
+  const meta = EVENTS[event];
+  if (meta === undefined || meta.context !== true) return {};
+  return { hookSpecificOutput: { hookEventName: event, additionalContext } };
+}
+
+/**
+ * `PASS` is "I have no objection", and it is an EMPTY object on purpose.
+ *
+ * The obvious spelling would be `permissionDecision: "allow"`, and it would
+ * be a serious bug: measured in the platform, `allow` does not mean "this
+ * gate is satisfied", it means "approve this tool call and skip the
+ * permission prompt". A gate whose only job is to look for secrets would
+ * then be silently auto-approving every command it happened not to object
+ * to. There is no way to emit `allow` from this runtime, and a test pins
+ * that.
+ */
+export const PASS = Object.freeze({ decision: 'pass' });
+
+// --------------------------------------------------------------- truncation
+
+const TRUNCATION_NOTE = (omitted, total) =>
+  `\n[tyran hook-io: output truncated to fit the platform's ${OUTPUT_LIMIT}-character limit; ` +
+  `${omitted} of ${total} characters omitted]`;
+
+/** UTF-16 length of the serialized payload — the unit the platform counts. */
+function serializedLength(payload) {
+  return JSON.stringify(payload).length;
+}
+
+/**
+ * Fit `text` into `build(text)` so the SERIALIZED payload stays under the
+ * platform limit, deterministically and audibly.
+ *
+ * Two properties matter more than the arithmetic:
+ *
+ *  - it clamps the SERIALIZED form, not the raw string. JSON escaping can
+ *    triple a length, so a reason measured before encoding sails past the
+ *    limit after it and the whole output is discarded (fail open).
+ *  - what is left always SAYS it was cut, and by how much. A quietly
+ *    shortened state file is the same defect as a quietly skipped file in
+ *    ADR-19: the reader has no way to know the thing they are trusting is
+ *    partial.
+ *
+ * Cuts land on code-point boundaries, so a truncated payload can never end
+ * in half a surrogate pair (which would make the JSON lone-surrogate and
+ * unparseable — fail open again).
+ */
+export function clampPayload(build, text, limit = OUTPUT_LIMIT) {
+  const full = build(text);
+  if (serializedLength(full) <= limit) return { payload: full, omitted: 0 };
+
+  const points = [...text];
+  const total = points.length;
+  const fits = (keep) =>
+    serializedLength(build(points.slice(0, keep).join('') + TRUNCATION_NOTE(total - keep, total))) <=
+    limit;
+
+  // Adding one kept code point never shortens the result by more than the
+  // one digit the omission counter may lose, so the predicate is monotone
+  // and a binary search is exact rather than approximate.
+  let lo = 0;
+  let hi = total;
+  if (!fits(0)) {
+    // Even the note alone does not fit: the envelope itself is oversized.
+    // Say so in the smallest possible words rather than emitting nothing.
+    return { payload: build(`[tyran hook-io: output too large to report]`), omitted: total };
+  }
+  while (lo < hi) {
+    const mid = Math.ceil((lo + hi) / 2);
+    if (fits(mid)) lo = mid;
+    else hi = mid - 1;
+  }
+  return {
+    payload: build(points.slice(0, lo).join('') + TRUNCATION_NOTE(total - lo, total)),
+    omitted: total - lo,
+  };
+}
+
+// -------------------------------------------------------------------- input
+
+/**
+ * Read all of stdin, refusing rather than buffering an unbounded payload.
+ * A stream that never ends is handled by the caller's deadline, not here.
+ */
+export async function readStdin(stream, { maxBytes = MAX_INPUT_BYTES } = {}) {
+  if (stream === undefined || stream === null) return '';
+  const chunks = [];
+  let size = 0;
+  for await (const chunk of stream) {
+    const buf = Buffer.isBuffer(chunk) ? chunk : Buffer.from(String(chunk), 'utf8');
+    size += buf.length;
+    if (size > maxBytes) {
+      throw new HookInputError(
+        'input-too-large',
+        `hook input exceeded ${maxBytes} bytes`,
+        'this hook reads whole tool inputs; if a legitimate payload is this large, raise MAX_INPUT_BYTES deliberately',
+      );
+    }
+    chunks.push(buf);
+  }
+  return Buffer.concat(chunks).toString('utf8');
+}
+
+/**
+ * Parse hook input. Every rejection carries a class, because "the gate said
+ * no" without saying which way it broke is unfixable in production.
+ */
+export function parseHookInput(raw) {
+  if (typeof raw !== 'string' || raw.trim() === '') {
+    throw new HookInputError(
+      'empty-input',
+      'hook received no input on stdin',
+      'the platform always writes a JSON object to a hook stdin; an empty read means the hook was invoked by something else',
+    );
+  }
+  let parsed;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (err) {
+    throw new HookInputError(
+      'malformed-json',
+      `hook input is not valid JSON: ${err.message}`,
+      'check whether a wrapper script is writing to stdout on the way in',
+    );
+  }
+  if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
+    throw new HookInputError(
+      'not-an-object',
+      `hook input parsed to ${Array.isArray(parsed) ? 'an array' : typeof parsed}, not an object`,
+      'the hook contract is a single JSON object',
+    );
+  }
+  return parsed;
+}
+
+/**
+ * Own-property read. `JSON.parse` puts a `__proto__` key on the object as an
+ * own property rather than walking the prototype chain, but every OTHER
+ * lookup on that object still consults `Object.prototype` — so a payload
+ * with no `tool_name` at all would otherwise resolve `constructor` or
+ * `toString` to a function and let a gate compare against it.
+ */
+export function field(object, name) {
+  if (object === null || typeof object !== 'object') return undefined;
+  return Object.hasOwn(object, name) ? object[name] : undefined;
+}
+
+/**
+ * The event whose shape our answer must take.
+ *
+ * The platform throws if `hookSpecificOutput.hookEventName` differs from the
+ * event it fired, and that throw is caught upstream as "hook failed" — i.e.
+ * it fails open. The input's `hook_event_name` is written by the platform
+ * itself, so it is the more reliable of the two names; the declared event is
+ * the fallback for input we could not read at all. A gate always answers in
+ * a shape that can refuse, so a probe name never wins here.
+ */
+export function resolveEvent(declared, fromInput, { mustBlock }) {
+  if (isKnownEvent(fromInput)) {
+    if (!mustBlock || EVENTS[fromInput].canBlock) return fromInput;
+  }
+  return declared;
+}
+
+// ------------------------------------------------------------------ runners
+
+function defaultIo() {
+  return {
+    stdin: process.stdin,
+    write: (text) => writeSync(1, text),
+    warn: (text) => writeSync(2, text),
+    exit: (code) => process.exit(code),
+    onExit: (cb) => {
+      process.on('exit', cb);
+      return () => process.removeListener('exit', cb);
+    },
+  };
+}
+
+function describeError(err) {
+  if (err instanceof HookInputError) {
+    return { errorClass: err.errorClass, message: err.message, fix: err.fix };
+  }
+  if (err instanceof Error) {
+    return {
+      errorClass: err.constructor?.name ?? 'Error',
+      message: err.message,
+      fix: 'this is a bug in the hook, not in the input; the stack is in the transcript',
+    };
+  }
+  return {
+    errorClass: 'non-error-throw',
+    message: String(err),
+    fix: 'the handler threw a value that is not an Error',
+  };
+}
+
+function refusalText({ errorClass, message, fix }) {
+  return (
+    `tyran refused because the gate itself could not finish.\n` +
+    `error class: ${errorClass}\n` +
+    `detail: ${message}\n` +
+    `fix: ${fix}\n` +
+    'This is a refusal, not a crash: an unfinished check must not read as approval.'
+  );
+}
+
+/**
+ * Run a blocking hook.
+ *
+ * Contract, and the whole reason this file exists:
+ *
+ *  1. it NEVER throws outward and never exits non-zero. Every unexpected
+ *     error becomes exit 0 plus a well-formed refusal naming the error
+ *     class, because every other ending is an approval;
+ *  2. it refuses to be registered on an event that cannot refuse;
+ *  3. it holds its OWN deadline, shorter than the one in hooks.json. The
+ *     platform's timeout kills the process and DISCARDS its output, so a
+ *     gate that is merely slow is a gate that approves. A gate that did not
+ *     finish in time refuses on its own terms instead.
+ *
+ * `handler(input)` returns `PASS` or `{ decision: 'deny', reason }`.
+ * Anything else is treated as a bug and refuses — an unrecognised return
+ * value must not be able to mean "allow".
+ */
+export async function runGate({ event, handler, deadlineMs, io = defaultIo() }) {
+  if (!isKnownEvent(event)) throw new GateOnProbeEventError(String(event));
+  if (!EVENTS[event].canBlock) throw new GateOnProbeEventError(event);
+  if (!Number.isFinite(deadlineMs) || deadlineMs <= 0) {
+    throw new Error(`runGate needs a positive deadlineMs (got ${String(deadlineMs)})`);
+  }
+
+  let done = false;
+  const emit = (payload) => {
+    if (done) return;
+    done = true;
+    io.write(JSON.stringify(payload) + '\n');
+    io.exit(0);
+  };
+  const refuse = (outEvent, info) => {
+    const { payload } = clampPayload(
+      (reason) => refusalPayload(outEvent, reason),
+      sanitizeForOutput(refusalText(info)),
+    );
+    emit(payload);
+  };
+
+  /**
+   * Last line of defence: the process is ending and no decision was written.
+   *
+   * This is not theoretical — it is how the first version of this file failed
+   * its own test. The deadline timer was `unref`'d, so when a handler awaited
+   * something that did not hold the event loop, Node ran out of work, exited
+   * cleanly with empty stdout, and the platform read that as "hook fine,
+   * proceed". An unhandled rejection reaches here the same way. Writing
+   * synchronously from an `exit` listener is the only thing that still works
+   * at that point, which is why the whole output path uses writeSync.
+   */
+  const silentExitGuard = () => {
+    if (done) return;
+    done = true;
+    const { payload } = clampPayload(
+      (reason) => refusalPayload(event, reason),
+      sanitizeForOutput(
+        refusalText({
+          errorClass: 'exited-without-decision',
+          message: 'the hook process ended before the gate produced a verdict',
+          fix: 'an unhandled rejection or an empty event loop; the gate must always reach deny or pass',
+        }),
+      ),
+    );
+    io.write(JSON.stringify(payload) + '\n');
+    process.exitCode = 0;
+  };
+  const releaseGuard = io.onExit ? io.onExit(silentExitGuard) : () => {};
+
+  let timer = null;
+  const deadline = new Promise((resolve) => {
+    // Deliberately NOT unref'd: an unref'd deadline stops holding the event
+    // loop, and a hook that exits without writing anything is a hook that
+    // approves. The timer is cleared the moment a decision is emitted.
+    timer = setTimeout(() => {
+      refuse(event, {
+        errorClass: 'deadline-exceeded',
+        message: `the gate did not reach a decision within ${deadlineMs} ms`,
+        fix: 'make the check faster, or raise deadlineMs together with the hooks.json timeout above it',
+      });
+      resolve();
+    }, deadlineMs);
+  });
+
+  const work = (async () => {
+    let outEvent = event;
+    try {
+      const raw = await readStdin(io.stdin);
+      const input = parseHookInput(raw);
+      const named = field(input, 'hook_event_name');
+      outEvent = resolveEvent(event, named, { mustBlock: true });
+      if (named !== undefined && named !== event) {
+        throw new HookInputError(
+          'event-mismatch',
+          `this hook is registered for ${event} but the platform fired ${sanitizeForOutput(String(named))}`,
+          'fix the event key in hooks.json; a gate answering for the wrong event is not a gate',
+        );
+      }
+      const verdict = await handler(Object.freeze({ event: outEvent, input }));
+      if (verdict === PASS || (verdict !== null && typeof verdict === 'object' && verdict.decision === 'pass')) {
+        // No objection is silence, never `permissionDecision:"allow"` — see PASS.
+        emit({});
+        return;
+      }
+      if (verdict !== null && typeof verdict === 'object' && verdict.decision === 'deny') {
+        const { payload } = clampPayload(
+          (reason) => refusalPayload(outEvent, reason),
+          sanitizeForOutput(String(verdict.reason ?? 'refused without a stated reason')),
+        );
+        emit(payload);
+        return;
+      }
+      throw new Error(
+        `handler returned ${JSON.stringify(verdict)}; expected PASS or { decision: 'deny', reason }`,
+      );
+    } catch (err) {
+      refuse(outEvent, describeError(err));
+    }
+  })();
+
+  await Promise.race([work, deadline]);
+  if (timer !== null) clearTimeout(timer);
+  releaseGuard();
+  return done;
+}
+
+/**
+ * Run a non-blocking hook.
+ *
+ * A probe has no way to refuse, so failing open here is not a compromise —
+ * it is the only honest behaviour, and the cost of getting it wrong is a
+ * session the user cannot start. Every failure therefore degrades to the
+ * smallest valid output for the event and exit 0.
+ *
+ * The deadline still exists, for a different reason: a probe that hangs
+ * holds up session startup until the platform kills it.
+ */
+export async function runProbe({ event, handler, deadlineMs, io = defaultIo() }) {
+  if (!isKnownEvent(event)) throw new Error(`unknown hook event: ${String(event)}`);
+  if (!Number.isFinite(deadlineMs) || deadlineMs <= 0) {
+    throw new Error(`runProbe needs a positive deadlineMs (got ${String(deadlineMs)})`);
+  }
+
+  let done = false;
+  const emit = (payload) => {
+    if (done) return;
+    done = true;
+    io.write(JSON.stringify(payload) + '\n');
+    io.exit(0);
+  };
+  const note = (text) => {
+    // stderr on a probe event is a transcript message, never a block.
+    try {
+      io.warn(`tyran ${event}: ${sanitizeForOutput(text)}\n`);
+    } catch {
+      /* a probe may not fail because it could not complain */
+    }
+  };
+
+  let timer = null;
+  const deadline = new Promise((resolve) => {
+    timer = setTimeout(() => {
+      note(`gave up after ${deadlineMs} ms; the session continues without injected context`);
+      emit({});
+      resolve();
+    }, deadlineMs);
+  });
+
+  const work = (async () => {
+    try {
+      const raw = await readStdin(io.stdin);
+      const input = parseHookInput(raw);
+      const named = field(input, 'hook_event_name');
+      const outEvent = resolveEvent(event, named, { mustBlock: false });
+      const result = await handler(Object.freeze({ event: outEvent, input }));
+      const text = typeof result === 'string' ? result : (result?.additionalContext ?? '');
+      if (text === '') {
+        emit({});
+        return;
+      }
+      const { payload, omitted } = clampPayload(
+        (ctx) => contextPayload(outEvent, ctx),
+        sanitizeForOutput(text),
+      );
+      if (omitted > 0) note(`injected context truncated, ${omitted} character(s) omitted`);
+      emit(payload);
+    } catch (err) {
+      const info = describeError(err);
+      note(`${info.errorClass}: ${info.message}`);
+      emit({});
+    }
+  })();
+
+  await Promise.race([work, deadline]);
+  if (timer !== null) clearTimeout(timer);
+  return done;
+}
+
+/**
+ * Entry point for a hook script's `main`. Its one job is the case `runGate`
+ * cannot answer for itself: a gate declared on an event that cannot refuse.
+ *
+ * That throw happens before any input is read, so there is no decision to
+ * emit. Exit 2 is the loudest ending available — on a blocking event it
+ * blocks, on a probe event it surfaces the message — and it is strictly
+ * better than the alternative, which is an unhandled rejection that reads as
+ * a small tooling hiccup while the control silently no longer exists.
+ */
+export async function main(run, io = defaultIo()) {
+  try {
+    await run();
+  } catch (err) {
+    const info = describeError(err);
+    io.warn(`tyran hook-io: ${sanitizeForOutput(refusalText(info))}\n`);
+    io.exit(2);
+  }
+}

--- a/hooks/scripts/hook-io.mjs
+++ b/hooks/scripts/hook-io.mjs
@@ -29,7 +29,7 @@
  */
 import { writeSync } from 'node:fs';
 
-import { FORBIDDEN, formatCodePoint } from '../../scripts/scan-control-chars.mjs';
+import { formatCodePoint, scanText } from '../../scripts/scan-control-chars.mjs';
 
 /**
  * The platform's cap on hook stdout and on `additionalContext`, measured as
@@ -131,19 +131,6 @@ export class HookInputError extends Error {
 // ------------------------------------------------------------ sanitization
 
 /**
- * Codepoints this runtime refuses to echo, taken from the SAME table the CI
- * scanner enforces. Deliberately imported rather than restated: ADR-19's own
- * correction found THREE spellings of this rule already in the repo, and the
- * outermost one was the weakest. When that list grows, this grows with it.
- */
-function isForbidden(cp) {
-  for (const range of FORBIDDEN) {
-    if (cp >= range.lo && cp <= range.hi) return true;
-  }
-  return false;
-}
-
-/**
  * Everything that reaches our stdout passes through here first.
  *
  * `tool_input` is written by the model and by repo content, and a refusal
@@ -158,10 +145,19 @@ function isForbidden(cp) {
  */
 export function sanitizeForOutput(value) {
   const text = typeof value === 'string' ? value : String(value);
+  // The membership decision is NOT made here. `scanText` is the repo's one
+  // implementation of "which codepoints are forbidden", and this asks it
+  // rather than re-deriving the answer from its data — ADR-19 correction 1
+  // counted three spellings of that rule and found the outermost one the
+  // weakest. There is now no fourth. When the scanner's set grows, so does
+  // this, with no edit here.
+  const findings = scanText(text);
+  if (findings.length === 0) return text;
+  const forbidden = new Set(findings.map((f) => f.codePoint));
   let out = '';
   for (const ch of text) {
     const cp = ch.codePointAt(0);
-    out += isForbidden(cp) ? `<${formatCodePoint(cp)}>` : ch;
+    out += forbidden.has(cp) ? `<${formatCodePoint(cp)}>` : ch;
   }
   return out;
 }

--- a/hooks/scripts/hook-io.mjs
+++ b/hooks/scripts/hook-io.mjs
@@ -71,7 +71,17 @@ export const EVENTS = Object.freeze(
     Stop: Object.freeze({ canBlock: true, refusal: 'decision', context: false }),
     SubagentStop: Object.freeze({ canBlock: true, refusal: 'decision', context: false }),
     PreCompact: Object.freeze({ canBlock: true, refusal: 'decision', context: false }),
-    TaskCompleted: Object.freeze({ canBlock: true, refusal: 'decision', context: false }),
+    // TaskCompleted CAN refuse, but only fires in TEAM mode: the platform
+    // raises it for the in-progress tasks of the current teammate. In
+    // subagent mode it never fires at all, so a check placed only here is
+    // an absent control, not a weak one. Flagged in the type rather than in
+    // prose, because that is the whole point of this table.
+    TaskCompleted: Object.freeze({
+      canBlock: true,
+      refusal: 'decision',
+      context: false,
+      teamModeOnly: true,
+    }),
     // Probes — injection or record only; refusal is impossible.
     SessionStart: Object.freeze({ canBlock: false, refusal: null, context: true }),
     SubagentStart: Object.freeze({ canBlock: false, refusal: null, context: true }),
@@ -344,11 +354,55 @@ export function resolveEvent(declared, fromInput, { mustBlock }) {
 
 // ------------------------------------------------------------------ runners
 
+/** How many times a stalled sink may report no progress before we give up. */
+const WRITE_SPIN_LIMIT = 10000;
+
+/**
+ * Write `text` in full, or throw.
+ *
+ * `writeSync` returns the number of bytes it actually took, and on a
+ * non-blocking pipe — which is what a hook's stdout is when the platform is
+ * busy — that can be fewer than we handed it. Ignoring the return value
+ * therefore produces a TRUNCATED JSON object, which fails the platform's
+ * schema, which discards the whole output, which lets the action through.
+ * A refusal cut in half is not a weaker refusal; it is an approval.
+ *
+ * `sink` is injectable so the loop itself is testable without fiddling with
+ * real file descriptors.
+ */
+export function writeFully(text, sink) {
+  const buf = Buffer.from(text, 'utf8');
+  let offset = 0;
+  let spins = 0;
+  while (offset < buf.length) {
+    let written;
+    try {
+      written = sink(buf, offset, buf.length - offset);
+    } catch (err) {
+      // A momentarily full pipe is not a failure, it is back-pressure. Retry
+      // a bounded number of times rather than spinning forever or reporting
+      // a decision we only half wrote.
+      if ((err?.code === 'EAGAIN' || err?.code === 'EWOULDBLOCK') && spins++ < WRITE_SPIN_LIMIT) {
+        continue;
+      }
+      throw err;
+    }
+    if (!(written > 0)) {
+      if (spins++ >= WRITE_SPIN_LIMIT) {
+        throw new Error(`stdout accepted ${offset} of ${buf.length} bytes and then stalled`);
+      }
+      continue;
+    }
+    offset += written;
+  }
+  return offset;
+}
+
 function defaultIo() {
   return {
     stdin: process.stdin,
-    write: (text) => writeSync(1, text),
-    warn: (text) => writeSync(2, text),
+    write: (text) => writeFully(text, (buf, off, len) => writeSync(1, buf, off, len)),
+    warn: (text) => writeFully(text, (buf, off, len) => writeSync(2, buf, off, len)),
     exit: (code) => process.exit(code),
     onExit: (cb) => {
       process.on('exit', cb);
@@ -396,12 +450,36 @@ function refusalText({ errorClass, message, fix }) {
  *  2. it refuses to be registered on an event that cannot refuse;
  *  3. it holds its OWN deadline, shorter than the one in hooks.json. The
  *     platform's timeout kills the process and DISCARDS its output, so a
- *     gate that is merely slow is a gate that approves. A gate that did not
- *     finish in time refuses on its own terms instead.
+ *     gate that is merely slow is a gate that approves.
  *
  * `handler(input)` returns `PASS` or `{ decision: 'deny', reason }`.
  * Anything else is treated as a bug and refuses — an unrecognised return
  * value must not be able to mean "allow".
+ *
+ * ## What the deadline does and does not promise
+ *
+ * State it narrowly, because the four gates built on this runtime inherit
+ * whatever it claims, and a guarantee wider than its mechanism is worse than
+ * no guarantee at all — readers rely on it.
+ *
+ *  - **Enforced.** A handler that yields the event loop and has not decided
+ *    by `deadlineMs` gets a refusal emitted for it, by the timer.
+ *  - **Enforced.** A handler that overruns the budget and *then* returns has
+ *    its verdict DISCARDED and replaced by a refusal. This is the case that
+ *    actually happens in the field (a gate that greps a large file, or shells
+ *    out to a scanner, finishes — just late), and a timer alone does not
+ *    catch it: the timer callback is a macrotask and the handler's return
+ *    settles in a microtask, so the verdict wins the race.
+ *  - **NOT enforced.** A handler that blocks the thread and never returns.
+ *    Node is single-threaded; nothing on this thread runs while it spins, the
+ *    platform eventually SIGKILLs the process, and a killed hook produces no
+ *    output — the action proceeds. There is no in-process fix. The mitigation
+ *    is a rule for gate authors, in `docs/hooks.md`: a gate does no unbounded
+ *    synchronous work, and every file it reads is size-checked first. If that
+ *    is ever not enough, the fix is a hard-killed child process or a
+ *    worker-thread watchdog claiming the write through `Atomics`, both of
+ *    which cost real latency on every tool call and neither of which is
+ *    justified by anything measured so far.
  */
 export async function runGate({ event, handler, deadlineMs, io = defaultIo() }) {
   if (!isKnownEvent(event)) throw new GateOnProbeEventError(String(event));
@@ -410,11 +488,67 @@ export async function runGate({ event, handler, deadlineMs, io = defaultIo() }) 
     throw new Error(`runGate needs a positive deadlineMs (got ${String(deadlineMs)})`);
   }
 
-  let done = false;
+  const startedAt = Date.now();
+  /** True once the budget is spent, whether or not anything noticed in time. */
+  const overrun = () => Date.now() - startedAt >= deadlineMs;
+
+  let settled = false;
+
+  /**
+   * The endings that are NOT "exit 0 with a decision".
+   *
+   * Reaching here means the decision exists but the channel for it does not.
+   * Exit 2 with the reason on stderr is then the only remaining ending that
+   * still blocks on a blocking event — strictly better than exiting 0 with
+   * nothing on stdout, which is the quietest possible approval.
+   */
+  const loudFailure = (text) => {
+    settled = true;
+    try {
+      io.warn(text.endsWith('\n') ? text : `${text}\n`);
+    } catch {
+      /* stderr is gone too; there is nothing left to do but the exit code */
+    }
+    io.exit(2);
+  };
+
+  /**
+   * A failed write is caught HERE and converted into a loud ending.
+   *
+   * The round-1 version was `if (done) return; done = true; io.write(...)`
+   * with no catch, and it opened a third silent path: a throwing write
+   * propagated out, the outer catch called a refusal, the refusal called
+   * `emit`, `emit` saw the flag already set and returned, the exit guard saw
+   * the same flag and returned — and the process ended with exit 0, an empty
+   * stdout and an empty stderr. The quietest possible approval.
+   *
+   * The catch is the guard; MUST-PASS 2 pins it. Setting `settled` only after
+   * a successful write is the secondary, defensive half — and it is honestly
+   * an EQUIVALENT change while the catch is present, which mutant M18 of
+   * round 2 demonstrated by surviving. It is kept because it is free and
+   * because it is the correct order if the catch is ever refactored away, not
+   * because a test proves it.
+   *
+   * What this can and cannot see, measured: a broken pipe (the platform died
+   * mid-hook) raises `EPIPE` and lands here, and the process ends with exit 2
+   * carrying the reason on stderr. A stdout that was CLOSED before exec
+   * cannot be detected at all — Node reopens a closed fd 1 onto /dev/null at
+   * startup, so the write succeeds and the bytes are simply gone. No hook can
+   * defend against that; it is listed so nobody mistakes the two cases.
+   */
   const emit = (payload) => {
-    if (done) return;
-    done = true;
-    io.write(JSON.stringify(payload) + '\n');
+    if (settled) return;
+    const text = JSON.stringify(payload) + '\n';
+    try {
+      io.write(text);
+    } catch (err) {
+      loudFailure(
+        `tyran hook-io: could not write its decision to stdout (${err?.code ?? err?.message ?? String(err)}).\n` +
+          `The decision was: ${text}`,
+      );
+      return;
+    }
+    settled = true;
     io.exit(0);
   };
   const refuse = (outEvent, info) => {
@@ -437,8 +571,7 @@ export async function runGate({ event, handler, deadlineMs, io = defaultIo() }) 
    * at that point, which is why the whole output path uses writeSync.
    */
   const silentExitGuard = () => {
-    if (done) return;
-    done = true;
+    if (settled) return;
     const { payload } = clampPayload(
       (reason) => refusalPayload(event, reason),
       sanitizeForOutput(
@@ -449,7 +582,22 @@ export async function runGate({ event, handler, deadlineMs, io = defaultIo() }) 
         }),
       ),
     );
-    io.write(JSON.stringify(payload) + '\n');
+    const text = JSON.stringify(payload) + '\n';
+    try {
+      io.write(text);
+    } catch {
+      // Same reasoning as loudFailure, except we are already inside `exit`
+      // and must not call process.exit again: set the code instead.
+      settled = true;
+      try {
+        io.warn(`tyran hook-io: ended without being able to write its refusal.\n${text}`);
+      } catch {
+        /* nothing left */
+      }
+      process.exitCode = 2;
+      return;
+    }
+    settled = true;
     process.exitCode = 0;
   };
   const releaseGuard = io.onExit ? io.onExit(silentExitGuard) : () => {};
@@ -475,6 +623,18 @@ export async function runGate({ event, handler, deadlineMs, io = defaultIo() }) 
       const raw = await readStdin(io.stdin);
       const input = parseHookInput(raw);
       const named = field(input, 'hook_event_name');
+      if (named !== undefined && !isKnownEvent(named)) {
+        // Answering an event this runtime does not model means emitting a
+        // `hookEventName` the platform rejects, which fails open. There is
+        // no decision to write, so the loudest available ending it is: on a
+        // blocking event exit 2 blocks, on a probe it surfaces the message.
+        loudFailure(
+          `tyran hook-io: registered for ${event}, but the platform fired ` +
+            `"${sanitizeForOutput(String(named))}", which this runtime does not model. ` +
+            'Refusing to guess an output shape. Fix hooks.json, or add the event to EVENTS.',
+        );
+        return;
+      }
       outEvent = resolveEvent(event, named, { mustBlock: true });
       if (named !== undefined && named !== event) {
         throw new HookInputError(
@@ -484,6 +644,18 @@ export async function runGate({ event, handler, deadlineMs, io = defaultIo() }) 
         );
       }
       const verdict = await handler(Object.freeze({ event: outEvent, input }));
+      // The budget is checked AFTER the handler returns, not only by a timer.
+      // A timer callback is a macrotask; a handler that blocks the thread and
+      // then returns settles its promise in a microtask, so `emit` would win
+      // the race and a gate that overran its budget fifteenfold would still
+      // approve. Measured, not feared — see MUST-PASS 1.
+      if (overrun()) {
+        throw new HookInputError(
+          'deadline-exceeded',
+          `the gate returned a verdict after ${Date.now() - startedAt} ms, past its ${deadlineMs} ms budget`,
+          'a verdict produced after the budget is not a verdict; make the check faster or raise both numbers',
+        );
+      }
       if (verdict === PASS || (verdict !== null && typeof verdict === 'object' && verdict.decision === 'pass')) {
         // No objection is silence, never `permissionDecision:"allow"` — see PASS.
         emit({});
@@ -508,7 +680,7 @@ export async function runGate({ event, handler, deadlineMs, io = defaultIo() }) 
   await Promise.race([work, deadline]);
   if (timer !== null) clearTimeout(timer);
   releaseGuard();
-  return done;
+  return settled;
 }
 
 /**

--- a/hooks/scripts/hook-io.mjs
+++ b/hooks/scripts/hook-io.mjs
@@ -378,6 +378,12 @@ export function writeFully(text, sink) {
       // A momentarily full pipe is not a failure, it is back-pressure. Retry
       // a bounded number of times rather than spinning forever or reporting
       // a decision we only half wrote.
+      // Retried with NO delay, deliberately. Everything written here fits in
+      // the platform's 10 000-character budget, which is a handful of
+      // syscalls on any real pipe, so sustained back-pressure cannot occur —
+      // and a sleep would spend part of a gate's deadline waiting for a
+      // condition that is not there. If this ever guards a larger payload,
+      // that reasoning stops holding and the retry needs a backoff.
       if ((err?.code === 'EAGAIN' || err?.code === 'EWOULDBLOCK') && spins++ < WRITE_SPIN_LIMIT) {
         continue;
       }
@@ -390,6 +396,10 @@ export function writeFully(text, sink) {
       continue;
     }
     offset += written;
+    // Patience is per stall, not per write. Without this reset the counter
+    // accumulates across a whole payload, so a long write interleaved with
+    // legitimate back-pressure eventually reports a healthy pipe as dead.
+    spins = 0;
   }
   return offset;
 }
@@ -467,15 +477,23 @@ function refusalText({ errorClass, message, fix }) {
  *    catch it: the timer callback is a macrotask and the handler's return
  *    settles in a microtask, so the verdict wins the race.
  *  - **NOT enforced.** A handler that blocks the thread and never returns.
- *    Node is single-threaded; nothing on this thread runs while it spins, the
- *    platform eventually SIGKILLs the process, and a killed hook produces no
- *    output — the action proceeds. There is no in-process fix. The mitigation
- *    is a rule for gate authors, in `docs/hooks.md`: a gate does no unbounded
- *    synchronous work, and every file it reads is size-checked first. If that
- *    is ever not enough, the fix is a hard-killed child process or a
- *    worker-thread watchdog claiming the write through `Atomics`, both of
- *    which cost real latency on every tool call and neither of which is
- *    justified by anything measured so far.
+ *    Node is single-threaded, so nothing on this thread runs while it spins
+ *    and the platform eventually kills the process.
+ *
+ *    Do not reach for the obvious workaround. Measured on a live run: a hook
+ *    that wrote a complete, valid refusal to stdout and only THEN blocked
+ *    past its timeout was ignored, and the tool ran. The kill and the abort
+ *    are the same event, and the consumer returns on `aborted` BEFORE it
+ *    parses stdout — the bytes are collected, even logged, and never read.
+ *    **Emitting earlier buys nothing.** Only making the process actually
+ *    EXIT before the platform's timeout closes this case, which is why every
+ *    ending in this file writes and then exits.
+ *
+ *    So the mitigation is a rule for gate authors, in `docs/hooks.md`: a gate
+ *    does no unbounded synchronous work, and every file it reads is
+ *    size-checked first. The remaining escape hatch is a hard-killed child
+ *    process — real latency on every tool call, and nothing measured so far
+ *    justifies it.
  */
 export async function runGate({ event, handler, deadlineMs, io = defaultIo() }) {
   if (!isKnownEvent(event)) throw new GateOnProbeEventError(String(event));
@@ -697,10 +715,33 @@ export async function runProbe({ event, handler, deadlineMs, io = defaultIo() })
   }
 
   let done = false;
+  /**
+   * Symmetric with `runGate.emit`, for one specific reason rather than for
+   * tidiness: this is also called from the deadline timer's callback, and an
+   * unguarded `io.write` that throws there escapes as an UNHANDLED exception.
+   * The user would get a Node stack trace at session start where a one-line
+   * note belonged. A probe may fail quietly; it may not fail loudly.
+   *
+   * Unlike the gate, a failed write here still ends in exit 0. There is no
+   * decision to preserve — only context that will not arrive — and a probe
+   * must never be the reason a session does not start.
+   */
   const emit = (payload) => {
     if (done) return;
+    const text = JSON.stringify(payload) + '\n';
+    try {
+      io.write(text);
+    } catch (err) {
+      done = true;
+      try {
+        io.warn(`tyran ${event}: could not write its context (${err?.code ?? err?.message ?? String(err)})\n`);
+      } catch {
+        /* nothing left to complain with */
+      }
+      io.exit(0);
+      return;
+    }
     done = true;
-    io.write(JSON.stringify(payload) + '\n');
     io.exit(0);
   };
   const note = (text) => {

--- a/hooks/scripts/session-start.mjs
+++ b/hooks/scripts/session-start.mjs
@@ -1,0 +1,279 @@
+#!/usr/bin/env node
+/**
+ * session-start — the probe that hands a resumed session its own state back.
+ *
+ * A conductor who reopens a repo two days later has no memory of it, and the
+ * state that would tell them is spread across a journal, two projections, a
+ * doctor run and a lock directory. This injects the two-kilobyte version:
+ * where we are, what to do next, what is still open, and who is still
+ * holding what.
+ *
+ * It is a PROBE, not a gate, and the distinction is enforced in the runtime
+ * rather than in this comment: `SessionStart` has no way to refuse anything
+ * (ADR-22), so nothing here may be a check. Every failure — no state, an
+ * unreadable journal, a doctor that will not run — degrades to a shorter
+ * message or to nothing at all, and the session starts anyway. Costing a
+ * user their session to report that a summary was unavailable would be a
+ * worse bug than the missing summary.
+ */
+import { execFileSync } from 'node:child_process';
+import { existsSync, readdirSync, realpathSync, statSync } from 'node:fs';
+import { cpus, totalmem } from 'node:os';
+import { dirname, isAbsolute, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { readJournal } from '../../scripts/journal.mjs';
+import { fold, progressLine } from '../../scripts/project.mjs';
+import { field, main, runProbe } from './hook-io.mjs';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const DOCTOR = resolve(HERE, '..', '..', 'scripts', 'doctor.mjs');
+
+/**
+ * This probe's own budget, deliberately far below the `timeout` its
+ * hooks.json entry declares (ADR-22 point 2). A unit test reads both numbers
+ * and refuses to let them cross; the relation is not maintained by anyone
+ * remembering it.
+ */
+export const DEADLINE_MS = 4000;
+
+/** Doctor gets the smaller half: it is one of several things that can hang. */
+export const DOCTOR_TIMEOUT_MS = 2000;
+
+/** Working target for the injection. The platform's hard ceiling is 10 000. */
+export const CONTEXT_BUDGET = 2000;
+
+/** Keep the summary skimmable; long lists are what makes context unread. */
+const MAX_ROWS = 5;
+const MAX_STEPS = 3;
+
+/**
+ * Which directory the host repo lives in.
+ *
+ * `cwd` comes from the platform, but it is still input: it is used to build
+ * filesystem paths and a child-process argument, so it is checked for shape
+ * (absolute, existing, a directory) instead of trusted. It never reaches a
+ * shell — the doctor call below uses execFile with an argument vector, so
+ * even a path full of shell metacharacters is inert.
+ */
+export function resolveRepoRoot(input, env = process.env, cwd = process.cwd()) {
+  const candidates = [field(input, 'cwd'), env.CLAUDE_PROJECT_DIR, cwd];
+  for (const candidate of candidates) {
+    if (typeof candidate !== 'string' || candidate === '' || !isAbsolute(candidate)) continue;
+    try {
+      if (statSync(candidate).isDirectory()) return candidate;
+    } catch {
+      /* try the next candidate */
+    }
+  }
+  return null;
+}
+
+/** Cores and memory, so the conductor sizes its team to the machine it is on. */
+export function hardwareLine() {
+  const cores = cpus().length;
+  const gib = Math.round(totalmem() / 1024 ** 3);
+  // A rough ceiling, not a promise: heavy agents are memory-bound long
+  // before they are core-bound, so both numbers are shown and the smaller
+  // of the two derived limits wins.
+  const ceiling = Math.max(1, Math.min(Math.floor(cores / 2), Math.floor(gib / 6)));
+  return `${cores} cores · ${gib} GiB RAM · suggested parallel heavy agents: ${ceiling}`;
+}
+
+/**
+ * Doctor's verdict for this repo.
+ *
+ * `--now` is passed on purpose and is load-bearing. Without it doctor takes
+ * its reference clock from each journal's own last event, so an agent that
+ * died three days ago is compared against the timestamp of its own spawn and
+ * is never stale — the dead-agent check would exist and never fire. A unit
+ * test pins the flag into the argument vector for exactly that reason.
+ *
+ * Exit 1 means "findings", which is the normal case, not an error.
+ */
+export function runDoctor(stateDir, nowIso, { exec = execFileSync } = {}) {
+  const args = [DOCTOR, '--state', '--json', '--dir', stateDir, '--now', nowIso];
+  let stdout;
+  try {
+    stdout = exec(process.execPath, args, {
+      encoding: 'utf8',
+      timeout: DOCTOR_TIMEOUT_MS,
+      maxBuffer: 8 * 1024 * 1024,
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+  } catch (err) {
+    // status 1 is "doctor found something", and its report is on stdout.
+    if (err && err.status === 1 && typeof err.stdout === 'string') stdout = err.stdout;
+    else return { available: false, reason: err?.message ?? 'doctor did not run' };
+  }
+  try {
+    const parsed = JSON.parse(stdout);
+    return { available: true, counts: parsed.counts, findings: parsed.findings ?? [] };
+  } catch (err) {
+    return { available: false, reason: `doctor output was not JSON: ${err.message}` };
+  }
+}
+
+/** Every initiative under `.tyran/state`, folded, worst failures swallowed. */
+export function readInitiatives(stateDir) {
+  const root = join(stateDir, 'state');
+  let names;
+  try {
+    names = readdirSync(root).sort();
+  } catch {
+    return [];
+  }
+  const out = [];
+  for (const name of names) {
+    const journal = join(root, name, 'journal.jsonl');
+    try {
+      if (!statSync(join(root, name)).isDirectory()) continue;
+      const read = readJournal(journal);
+      out.push({ name, state: fold(read), events: read.events.length });
+    } catch (err) {
+      out.push({ name, state: null, error: err.message });
+    }
+  }
+  return out;
+}
+
+function rows(list, render) {
+  const lines = list.slice(0, MAX_ROWS).map(render);
+  if (list.length > MAX_ROWS) lines.push(`- ... and ${list.length - MAX_ROWS} more`);
+  return lines;
+}
+
+/**
+ * Render the summary. Pure, so the whole shape of the injected context is
+ * testable without a filesystem, a clock or a child process.
+ */
+export function renderContext({ repoRoot, initiatives, doctor, hardware, nowIso }) {
+  if (initiatives.length === 0) return '';
+  const lines = [
+    '## Tyran state (injected by the session-start probe)',
+    '',
+    `Repo: ${repoRoot} · as of ${nowIso}`,
+    `Machine: ${hardware}`,
+    '',
+  ];
+
+  for (const { name, state, error } of initiatives) {
+    lines.push(`### Initiative \`${name}\``);
+    if (state === null) {
+      lines.push(`- journal unreadable: ${error}`);
+      lines.push('');
+      continue;
+    }
+    lines.push(`- ${progressLine(state)}`);
+    if (state.checkpoint) {
+      lines.push(
+        `- Checkpoint: ${state.checkpoint.phase ?? '(no phase)'} at ${state.checkpoint.ts} by ${state.checkpoint.actor}`,
+      );
+      const steps = Array.isArray(state.checkpoint.nextSteps) ? state.checkpoint.nextSteps : [];
+      if (steps.length > 0) {
+        lines.push(`- First ${Math.min(MAX_STEPS, steps.length)} step(s) on resume:`);
+        steps.slice(0, MAX_STEPS).forEach((step, i) => lines.push(`  ${i + 1}. ${step}`));
+      }
+    } else {
+      lines.push('- No checkpoint yet — this initiative has never been paused deliberately.');
+    }
+
+    const openGates = state.openGates ?? [];
+    if (openGates.length > 0) {
+      lines.push(`- Open gates (${openGates.length}):`);
+      lines.push(...rows(openGates, (g) => `  - ${g.kind}: ${g.result ?? 'open'} (${g.ts})`));
+    }
+
+    const leases = [...(state.leases?.values() ?? [])];
+    if (leases.length > 0) {
+      lines.push(`- Open leases (${leases.length}) — do NOT touch these resources:`);
+      lines.push(...rows(leases, (l) => `  - ${l.resource} held by ${l.holder ?? '(unknown)'} since ${l.ts}`));
+    }
+
+    const working = (state.agents ?? []).filter((a) => a.status === 'running');
+    if (working.length > 0) {
+      lines.push(`- Agents the journal still believes are working (${working.length}):`);
+      lines.push(
+        ...rows(working, (a) => `  - ${a.agent} (${a.role ?? 'no role'}) since ${a.spawnTs ?? '?'}`),
+      );
+    }
+    lines.push('');
+  }
+
+  if (doctor.available) {
+    const c = doctor.counts ?? { error: 0, warning: 0, info: 0 };
+    lines.push(`### Doctor: ${c.error} error(s) · ${c.warning} warning(s) · ${c.info} info`);
+    const loud = (doctor.findings ?? []).filter((f) => f.severity !== 'info');
+    lines.push(...rows(loud, (f) => `- [${f.code}] ${f.where}`));
+    if (loud.length === 0) lines.push('- nothing above info level');
+  } else {
+    lines.push(`### Doctor did not run: ${doctor.reason}`);
+    lines.push('- run `node scripts/doctor.mjs --state --now "$(date -u +%FT%TZ)"` by hand');
+  }
+  lines.push('');
+  lines.push('Run `/tyran` to resume, or read `.tyran/state/<init>/STATE.md` in full.');
+  return lines.join('\n');
+}
+
+/**
+ * Trim to the working budget on a SECTION boundary, keeping the header and
+ * saying what was dropped. The runtime enforces the platform's hard 10 000
+ * ceiling on top of this; this one exists so the injection stays short
+ * enough to actually be read.
+ */
+export function fitBudget(text, budget = CONTEXT_BUDGET) {
+  if (text.length <= budget) return text;
+  const sections = text.split('\n### ');
+  let out = sections[0];
+  let kept = 0;
+  for (const section of sections.slice(1)) {
+    const candidate = `${out}\n### ${section}`;
+    if (candidate.length > budget) break;
+    out = candidate;
+    kept++;
+  }
+  const dropped = sections.length - 1 - kept;
+  return `${out}\n\n[tyran session-start: ${dropped} further section(s) omitted to stay inside the ${budget}-character working budget; read .tyran/state/ for the rest]`;
+}
+
+export async function buildContext({ input, now = new Date(), env = process.env } = {}) {
+  const repoRoot = resolveRepoRoot(input, env);
+  if (repoRoot === null) return '';
+  const stateDir = join(repoRoot, '.tyran');
+  if (!existsSync(stateDir)) return ''; // not a Tyran repo — say nothing at all
+  const nowIso = now.toISOString();
+  return fitBudget(
+    renderContext({
+      repoRoot,
+      initiatives: readInitiatives(stateDir),
+      doctor: runDoctor(stateDir, nowIso),
+      hardware: hardwareLine(),
+      nowIso,
+    }),
+  );
+}
+
+/** See journal.mjs — both sides canonicalized, or a symlinked path no-ops. */
+function canonicalPath(path) {
+  const abs = resolve(path);
+  try {
+    return realpathSync(abs);
+  } catch {
+    return abs;
+  }
+}
+
+function isMainModule(moduleUrl) {
+  if (!process.argv[1]) return false;
+  return canonicalPath(process.argv[1]) === canonicalPath(fileURLToPath(moduleUrl));
+}
+
+if (isMainModule(import.meta.url)) {
+  await main(() =>
+    runProbe({
+      event: 'SessionStart',
+      deadlineMs: DEADLINE_MS,
+      handler: ({ input }) => buildContext({ input }),
+    }),
+  );
+}

--- a/tests/unit/hook-io.test.mjs
+++ b/tests/unit/hook-io.test.mjs
@@ -406,9 +406,13 @@ test('the deadline discards a LATE verdict, whichever way the handler was late',
   // The async twin of MUST-PASS 1: a handler that yields but finishes past
   // the budget must not have its answer used either.
   const io = fakeIo(inputFor('SubagentStop'));
+  // The budget here is deliberately generous. The elapsed clock starts before
+  // stdin is read, so a tight number would make this test a load detector
+  // rather than a deadline test — and a gate suite that goes red on a busy
+  // machine is a gate suite somebody switches off.
   await runGate({
     event: 'SubagentStop',
-    deadlineMs: 25,
+    deadlineMs: 2000,
     io,
     handler: () => new Promise((r) => setTimeout(() => r(PASS), 5)),
   });
@@ -468,6 +472,27 @@ test('writeFully retries back-pressure but refuses to spin forever on a dead sin
     /stalled/,
     'a sink that never makes progress must throw, not hang the session',
   );
+});
+
+test('writeFully counts patience per stall, not per payload', () => {
+  // Review round 3. The spin counter used to accumulate across the whole
+  // write, so a long payload interleaved with LEGITIMATE back-pressure
+  // eventually reported a perfectly healthy pipe as dead. Every byte here is
+  // preceded by one EAGAIN, which is normal behaviour, and the total exceeds
+  // the spin limit — so only a counter that resets on progress survives.
+  const size = 11000;
+  let pending = false;
+  const out = [];
+  writeFully('z'.repeat(size), (buf, off) => {
+    if (!pending) {
+      pending = true;
+      throw Object.assign(new Error('EAGAIN'), { code: 'EAGAIN' });
+    }
+    pending = false;
+    out.push(buf[off]);
+    return 1;
+  });
+  assert.equal(out.length, size, 'a healthy pipe that pauses often must not be declared dead');
 });
 
 // --------------------------------------------------------------- truncation
@@ -641,6 +666,27 @@ test('a probe that overruns its deadline yields an empty context, not an error',
   });
   assert.deepEqual(soleOutput(io), {});
   assert.match(io.err.join(''), /gave up after 15 ms/);
+});
+
+test('a probe whose stdout write fails degrades quietly, even from the timer', async () => {
+  // Review round 3. `runProbe.emit` kept the round-1 shape, so a throwing
+  // write inside the DEADLINE CALLBACK escaped as an unhandled exception and
+  // the user got a Node stack trace at session start where a note belonged.
+  // The handler here settles after the deadline, so the timer emits first —
+  // which is exactly the path that used to throw.
+  const io = fakeIo(inputFor('SessionStart'));
+  io.write = () => {
+    throw Object.assign(new Error('EPIPE: broken pipe, write'), { code: 'EPIPE' });
+  };
+  await runProbe({
+    event: 'SessionStart',
+    deadlineMs: 10,
+    io,
+    handler: () => new Promise((r) => setTimeout(() => r('context that never arrives'), 60)),
+  });
+  await new Promise((r) => setTimeout(r, 90));
+  assert.deepEqual(io.codes, [0], 'a probe never costs the user their session');
+  assert.match(io.err.join(''), /could not write its context \(EPIPE\)/);
 });
 
 test('a probe clamps its injection to the platform limit and reports the cut', async () => {

--- a/tests/unit/hook-io.test.mjs
+++ b/tests/unit/hook-io.test.mjs
@@ -1,0 +1,510 @@
+/**
+ * Tests for the hook runtime.
+ *
+ * The interesting half of this file is not the happy path — it is the set of
+ * tests that deliberately BREAK the runtime and assert that the result is a
+ * refusal rather than silence (ADR-22 point 4). The platform fails open, so
+ * every one of these, if it regressed, would turn a gate into a no-op that
+ * still looks installed.
+ */
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { scanText } from '../../scripts/scan-control-chars.mjs';
+import {
+  EVENTS,
+  GateOnProbeEventError,
+  OUTPUT_LIMIT,
+  PASS,
+  canBlock,
+  clampPayload,
+  contextPayload,
+  field,
+  parseHookInput,
+  readStdin,
+  refusalPayload,
+  resolveEvent,
+  runGate,
+  runProbe,
+  sanitizeForOutput,
+} from '../../hooks/scripts/hook-io.mjs';
+
+/** A recording stand-in for stdin/stdout/stderr/exit. */
+function fakeIo(stdinText) {
+  const out = [];
+  const err = [];
+  const codes = [];
+  const exitHandlers = [];
+  return {
+    stdin:
+      stdinText === null
+        ? null
+        : (async function* () {
+            yield Buffer.from(stdinText, 'utf8');
+          })(),
+    write: (t) => out.push(t),
+    warn: (t) => err.push(t),
+    exit: (c) => codes.push(c),
+    onExit: (cb) => {
+      exitHandlers.push(cb);
+      return () => {
+        const i = exitHandlers.indexOf(cb);
+        if (i >= 0) exitHandlers.splice(i, 1);
+      };
+    },
+    out,
+    err,
+    codes,
+    exitHandlers,
+  };
+}
+
+const inputFor = (event, extra = {}) =>
+  JSON.stringify({ hook_event_name: event, session_id: 's', cwd: '/tmp', ...extra });
+
+function soleOutput(io) {
+  assert.equal(io.out.length, 1, `expected exactly one write, got ${io.out.length}`);
+  return JSON.parse(io.out[0]);
+}
+
+// ------------------------------------------------------- shapes per event
+
+test('PreToolUse refuses through hookSpecificOutput.permissionDecision, byte for byte', () => {
+  assert.deepEqual(refusalPayload('PreToolUse', 'because'), {
+    hookSpecificOutput: {
+      hookEventName: 'PreToolUse',
+      permissionDecision: 'deny',
+      permissionDecisionReason: 'because',
+    },
+  });
+});
+
+test('Stop/SubagentStop/PreCompact/TaskCompleted refuse through TOP-LEVEL decision', () => {
+  for (const event of ['Stop', 'SubagentStop', 'PreCompact', 'TaskCompleted', 'UserPromptSubmit']) {
+    assert.deepEqual(refusalPayload(event, 'because'), { decision: 'block', reason: 'because' });
+  }
+});
+
+test('the decision-shaped events never emit hookSpecificOutput', () => {
+  // Measured in v2.1.116: hookSpecificOutput is a union discriminated on
+  // hookEventName and it has NO variant for Stop, SubagentStop, PreCompact
+  // or TaskCompleted. A hookSpecificOutput there fails the platform's schema,
+  // the whole output is discarded, and the refusal silently becomes an
+  // approval. This is the difference between two shapes and one shape.
+  for (const event of ['Stop', 'SubagentStop', 'PreCompact', 'TaskCompleted']) {
+    assert.ok(
+      !('hookSpecificOutput' in refusalPayload(event, 'x')),
+      `${event} must not carry hookSpecificOutput`,
+    );
+  }
+});
+
+test('every refusal payload serializes to valid JSON and names its own event', () => {
+  for (const [event, meta] of Object.entries(EVENTS)) {
+    if (!meta.canBlock) continue;
+    const payload = refusalPayload(event, 'r');
+    const round = JSON.parse(JSON.stringify(payload));
+    if (round.hookSpecificOutput) {
+      assert.equal(
+        round.hookSpecificOutput.hookEventName,
+        event,
+        'the platform throws when hookEventName differs from the event it fired, and that throw fails open',
+      );
+    }
+  }
+});
+
+test('context payloads exist only where the platform accepts them', () => {
+  assert.deepEqual(contextPayload('SessionStart', 'hi'), {
+    hookSpecificOutput: { hookEventName: 'SessionStart', additionalContext: 'hi' },
+  });
+  // Stop has no additionalContext variant; emitting one invalidates the output.
+  assert.deepEqual(contextPayload('Stop', 'hi'), {});
+});
+
+// ------------------------------------------- gate vs probe is in the type
+
+test('registering a gate on an event that cannot refuse is an error, not a silent allow', async () => {
+  const probes = Object.entries(EVENTS)
+    .filter(([, m]) => !m.canBlock)
+    .map(([name]) => name);
+  assert.deepEqual(probes.sort(), [
+    'Notification',
+    'PostToolUse',
+    'SessionEnd',
+    'SessionStart',
+    'SubagentStart',
+  ]);
+  for (const event of probes) {
+    await assert.rejects(
+      () => runGate({ event, handler: () => PASS, deadlineMs: 100, io: fakeIo('{}') }),
+      GateOnProbeEventError,
+      `${event} must not be registrable as a gate`,
+    );
+  }
+});
+
+test('an unknown event is refused as a registration, not answered', async () => {
+  await assert.rejects(
+    () => runGate({ event: 'NoSuchEvent', handler: () => PASS, deadlineMs: 100, io: fakeIo('{}') }),
+    GateOnProbeEventError,
+  );
+});
+
+test('canBlock agrees with the ADR-22 table', () => {
+  for (const event of ['PreToolUse', 'SubagentStop', 'Stop', 'PreCompact', 'TaskCompleted', 'UserPromptSubmit']) {
+    assert.equal(canBlock(event), true, `${event} must be usable as a gate`);
+  }
+  for (const event of ['SessionStart', 'SubagentStart', 'PostToolUse', 'SessionEnd', 'Notification']) {
+    assert.equal(canBlock(event), false, `${event} must not be usable as a gate`);
+  }
+});
+
+// --------------------------------------------------- ADR-22: failure modes
+
+test('failure mode: the handler throws -> refusal naming the error class', async () => {
+  const io = fakeIo(inputFor('PreToolUse'));
+  await runGate({
+    event: 'PreToolUse',
+    deadlineMs: 1000,
+    io,
+    handler: () => {
+      throw new TypeError('cannot read properties of undefined');
+    },
+  });
+  const payload = soleOutput(io);
+  assert.equal(payload.hookSpecificOutput.permissionDecision, 'deny');
+  assert.match(payload.hookSpecificOutput.permissionDecisionReason, /error class: TypeError/);
+  assert.deepEqual(io.codes, [0], 'a gate must exit 0; any other code is discarded as a hook error');
+});
+
+test('failure mode: a missing dependency -> refusal, not a crash', async () => {
+  const io = fakeIo(inputFor('SubagentStop'));
+  await runGate({
+    event: 'SubagentStop',
+    deadlineMs: 1000,
+    io,
+    handler: async () => {
+      await import('node:this-module-does-not-exist');
+      return PASS;
+    },
+  });
+  const payload = soleOutput(io);
+  assert.equal(payload.decision, 'block');
+  assert.match(payload.reason, /error class: Error|ERR_/);
+  assert.deepEqual(io.codes, [0]);
+});
+
+test('failure mode: the deadline passes -> the gate refuses on its own terms', async () => {
+  const io = fakeIo(inputFor('PreToolUse'));
+  await runGate({
+    event: 'PreToolUse',
+    deadlineMs: 15,
+    io,
+    handler: () => new Promise(() => {}), // never settles
+  });
+  const payload = soleOutput(io);
+  assert.equal(payload.hookSpecificOutput.permissionDecision, 'deny');
+  assert.match(payload.hookSpecificOutput.permissionDecisionReason, /deadline-exceeded/);
+});
+
+test('failure mode: a late handler cannot overwrite the deadline refusal', async () => {
+  const io = fakeIo(inputFor('PreToolUse'));
+  await runGate({
+    event: 'PreToolUse',
+    deadlineMs: 10,
+    io,
+    handler: () => new Promise((r) => setTimeout(() => r(PASS), 60)),
+  });
+  await new Promise((r) => setTimeout(r, 120));
+  assert.equal(io.out.length, 1, 'two writes would make the platform read the second decision');
+  assert.match(io.out[0], /deadline-exceeded/);
+});
+
+test('failure mode: malformed JSON on stdin -> refusal', async () => {
+  const io = fakeIo('{"hook_event_name": "PreToolUse", ');
+  await runGate({ event: 'PreToolUse', deadlineMs: 500, io, handler: () => PASS });
+  assert.match(soleOutput(io).hookSpecificOutput.permissionDecisionReason, /malformed-json/);
+});
+
+test('failure mode: empty stdin -> refusal', async () => {
+  const io = fakeIo('');
+  await runGate({ event: 'Stop', deadlineMs: 500, io, handler: () => PASS });
+  assert.match(soleOutput(io).reason, /empty-input/);
+});
+
+test('failure mode: stdin that is not an object -> refusal', async () => {
+  for (const raw of ['[1,2,3]', '42', '"hello"', 'null']) {
+    const io = fakeIo(raw);
+    await runGate({ event: 'Stop', deadlineMs: 500, io, handler: () => PASS });
+    assert.match(soleOutput(io).reason, /not-an-object|empty-input/, `raw=${raw}`);
+  }
+});
+
+test('failure mode: oversized stdin is refused rather than buffered', async () => {
+  const io = {
+    ...fakeIo('{}'),
+    stdin: (async function* () {
+      for (let i = 0; i < 40; i++) yield Buffer.alloc(64 * 1024, 0x61);
+    })(),
+  };
+  const out = [];
+  const codes = [];
+  io.write = (t) => out.push(t);
+  io.exit = (c) => codes.push(c);
+  await runGate({ event: 'PreToolUse', deadlineMs: 2000, io, handler: () => PASS });
+  assert.equal(out.length, 1);
+  assert.match(JSON.parse(out[0]).hookSpecificOutput.permissionDecisionReason, /input-too-large/);
+});
+
+test('failure mode: the handler returns something unrecognised -> refusal', async () => {
+  for (const verdict of [undefined, null, 'allow', 42, { decision: 'allow' }, {}]) {
+    const io = fakeIo(inputFor('PreToolUse'));
+    await runGate({ event: 'PreToolUse', deadlineMs: 500, io, handler: () => verdict });
+    const payload = soleOutput(io);
+    assert.equal(
+      payload.hookSpecificOutput.permissionDecision,
+      'deny',
+      `a handler returning ${JSON.stringify(verdict)} must not mean approval`,
+    );
+  }
+});
+
+test('failure mode: the platform fired a different event than we registered for', async () => {
+  const io = fakeIo(inputFor('SubagentStop'));
+  await runGate({ event: 'PreToolUse', deadlineMs: 500, io, handler: () => PASS });
+  const payload = soleOutput(io);
+  // Answered in the shape of the event that actually fired, because the
+  // platform validates hookEventName against ITS event, not against ours.
+  assert.equal(payload.decision, 'block');
+  assert.match(payload.reason, /event-mismatch/);
+});
+
+test('failure mode: the process ends before a verdict -> refusal, not empty stdout', async () => {
+  // The shape of a real regression: the deadline timer used to be unref'd,
+  // so a handler awaiting something that did not hold the event loop let
+  // Node exit cleanly with empty stdout — which the platform reads as
+  // "the hook is fine, proceed".
+  const io = fakeIo(inputFor('PreToolUse'));
+  const pending = runGate({
+    event: 'PreToolUse',
+    deadlineMs: 50,
+    io,
+    handler: () => new Promise(() => {}),
+  });
+  await new Promise((r) => setImmediate(r));
+  assert.equal(io.exitHandlers.length, 1, 'the gate must arm a silent-exit guard');
+  io.exitHandlers[0]();
+  const payload = soleOutput(io);
+  assert.equal(payload.hookSpecificOutput.permissionDecision, 'deny');
+  assert.match(payload.hookSpecificOutput.permissionDecisionReason, /exited-without-decision/);
+  await pending; // lets the deadline fire and clear its timer
+  assert.equal(io.out.length, 1, 'the deadline must not write a second decision after the guard');
+});
+
+test('a gate never exits non-zero: only exit 0 carries a decision', async () => {
+  const cases = ['', 'not json', '[]', inputFor('PreToolUse')];
+  for (const raw of cases) {
+    const io = fakeIo(raw);
+    await runGate({
+      event: 'PreToolUse',
+      deadlineMs: 500,
+      io,
+      handler: () => {
+        throw new Error('boom');
+      },
+    });
+    assert.deepEqual(io.codes, [0], `raw=${JSON.stringify(raw)}`);
+  }
+});
+
+// ------------------------------------------------------------ pass is not allow
+
+test('no objection is silence, never permissionDecision:"allow"', async () => {
+  const io = fakeIo(inputFor('PreToolUse'));
+  await runGate({ event: 'PreToolUse', deadlineMs: 500, io, handler: () => PASS });
+  assert.deepEqual(soleOutput(io), {});
+});
+
+test('nothing this runtime can emit ever auto-approves a tool call', async () => {
+  // `allow` is not "the gate is satisfied", it is "skip the permission
+  // prompt". A secrets gate that emitted it would be silently approving
+  // every command it did not object to.
+  const seen = [];
+  for (const verdict of [PASS, { decision: 'pass' }, { decision: 'deny', reason: 'no' }]) {
+    const io = fakeIo(inputFor('PreToolUse'));
+    await runGate({ event: 'PreToolUse', deadlineMs: 500, io, handler: () => verdict });
+    seen.push(io.out[0]);
+  }
+  for (const raw of seen) assert.doesNotMatch(raw, /"allow"/);
+});
+
+// --------------------------------------------------------------- truncation
+
+test('output over the platform limit is cut deterministically and says so', () => {
+  const long = 'x'.repeat(40000);
+  const a = clampPayload((r) => refusalPayload('PreToolUse', r), long);
+  const b = clampPayload((r) => refusalPayload('PreToolUse', r), long);
+  assert.deepEqual(a.payload, b.payload, 'the same input must cut at the same place');
+  const serialized = JSON.stringify(a.payload);
+  assert.ok(serialized.length <= OUTPUT_LIMIT, `serialized ${serialized.length} > ${OUTPUT_LIMIT}`);
+  assert.ok(a.omitted > 0);
+  assert.match(a.payload.hookSpecificOutput.permissionDecisionReason, /output truncated/);
+  assert.match(
+    a.payload.hookSpecificOutput.permissionDecisionReason,
+    new RegExp(`${a.omitted} of 40000 characters omitted`),
+    'a silently shortened message is the same defect as a silently skipped file',
+  );
+});
+
+test('truncation measures the SERIALIZED payload, not the raw string', () => {
+  // Every character here becomes six in JSON, so a limit applied before
+  // encoding would let ~6x the budget through and the platform would discard
+  // the whole output — a refusal that reads as an approval.
+  const quotes = '"'.repeat(5000);
+  const { payload } = clampPayload((r) => refusalPayload('Stop', r), quotes);
+  assert.ok(JSON.stringify(payload).length <= OUTPUT_LIMIT);
+});
+
+test('truncation never splits a surrogate pair', () => {
+  const emoji = String.fromCodePoint(0x1f600).repeat(9000);
+  const { payload } = clampPayload((r) => refusalPayload('Stop', r), emoji);
+  const text = payload.reason;
+  for (let i = 0; i < text.length; i++) {
+    const code = text.charCodeAt(i);
+    if (code >= 0xd800 && code <= 0xdbff) {
+      const next = text.charCodeAt(i + 1);
+      assert.ok(next >= 0xdc00 && next <= 0xdfff, `lone high surrogate at ${i}`);
+      i++;
+    } else {
+      assert.ok(!(code >= 0xdc00 && code <= 0xdfff), `lone low surrogate at ${i}`);
+    }
+  }
+  assert.doesNotThrow(() => JSON.parse(JSON.stringify(payload)));
+});
+
+test('output that already fits is left untouched', () => {
+  const { payload, omitted } = clampPayload((r) => refusalPayload('Stop', r), 'short');
+  assert.equal(omitted, 0);
+  assert.deepEqual(payload, { decision: 'block', reason: 'short' });
+});
+
+// ------------------------------------------------------------ sanitization
+
+test('the sanitizer and the CI scanner enforce ONE list, not two', () => {
+  // The point of importing FORBIDDEN instead of restating it: when the
+  // scanner's list grows (ADR-19 correction 1), this grows with it. The test
+  // proves agreement rather than trusting the import.
+  const points = [];
+  for (let cp = 0; cp <= 0x30ff; cp++) points.push(cp);
+  for (const cp of [0xfeff, 0xfff9, 0x1f600, 0xe0001, 0xe0041, 0x10fffe]) points.push(cp);
+  const sample = points.map((cp) => String.fromCodePoint(cp)).join('|');
+  const cleaned = sanitizeForOutput(sample);
+  assert.deepEqual(
+    scanText(cleaned),
+    [],
+    'the sanitizer left something the repo-wide scanner forbids',
+  );
+});
+
+test('the sanitizer escapes rather than deletes, so a poisoned string looks poisoned', () => {
+  const bidi = String.fromCodePoint(0x202e);
+  const out = sanitizeForOutput(`path${bidi}gpj.exe`);
+  assert.equal(out, 'path<U+202E>gpj.exe');
+});
+
+test('the sanitizer leaves ordinary text, tabs and newlines alone', () => {
+  const text = `line one\n\tindented — ${String.fromCodePoint(0x1f600)} zażółć`;
+  assert.equal(sanitizeForOutput(text), text);
+});
+
+test('a refusal reason cannot smuggle control characters into the transcript', async () => {
+  const nul = String.fromCodePoint(0x00);
+  const io = fakeIo(inputFor('PreToolUse'));
+  await runGate({
+    event: 'PreToolUse',
+    deadlineMs: 500,
+    io,
+    handler: () => ({ decision: 'deny', reason: `secret${nul}${String.fromCodePoint(0x2066)}found` }),
+  });
+  const reason = soleOutput(io).hookSpecificOutput.permissionDecisionReason;
+  assert.deepEqual(scanText(reason), []);
+  assert.match(reason, /secret<U\+0000><U\+2066>found/);
+});
+
+// ----------------------------------------------------------- input handling
+
+test('field() reads own properties only', () => {
+  const parsed = parseHookInput('{"hook_event_name":"Stop"}');
+  assert.equal(field(parsed, 'hook_event_name'), 'Stop');
+  assert.equal(field(parsed, 'toString'), undefined, 'a prototype member is not hook input');
+  assert.equal(field(parsed, 'constructor'), undefined);
+  assert.equal(field(null, 'x'), undefined);
+});
+
+test('readStdin returns empty for an absent stream instead of hanging', async () => {
+  assert.equal(await readStdin(null), '');
+  assert.equal(await readStdin(undefined), '');
+});
+
+test('resolveEvent prefers the event the platform says it fired', () => {
+  assert.equal(resolveEvent('PreToolUse', 'SubagentStop', { mustBlock: true }), 'SubagentStop');
+  assert.equal(resolveEvent('PreToolUse', 'garbage', { mustBlock: true }), 'PreToolUse');
+  assert.equal(resolveEvent('PreToolUse', undefined, { mustBlock: true }), 'PreToolUse');
+  // A gate must answer in a shape that can refuse, so a probe name loses.
+  assert.equal(resolveEvent('PreToolUse', 'SessionStart', { mustBlock: true }), 'PreToolUse');
+  assert.equal(resolveEvent('SessionStart', 'SubagentStart', { mustBlock: false }), 'SubagentStart');
+});
+
+// ----------------------------------------------------------------- probes
+
+test('a probe that throws still lets the session start', async () => {
+  const io = fakeIo(inputFor('SessionStart'));
+  await runProbe({
+    event: 'SessionStart',
+    deadlineMs: 500,
+    io,
+    handler: () => {
+      throw new Error('journal is a directory');
+    },
+  });
+  assert.deepEqual(soleOutput(io), {});
+  assert.deepEqual(io.codes, [0]);
+  assert.match(io.err.join(''), /journal is a directory/);
+});
+
+test('a probe fed garbage still lets the session start', async () => {
+  for (const raw of ['', 'not json', '[]']) {
+    const io = fakeIo(raw);
+    await runProbe({ event: 'SessionStart', deadlineMs: 500, io, handler: () => 'ctx' });
+    assert.deepEqual(soleOutput(io), {}, `raw=${raw}`);
+    assert.deepEqual(io.codes, [0]);
+  }
+});
+
+test('a probe that overruns its deadline yields an empty context, not an error', async () => {
+  const io = fakeIo(inputFor('SessionStart'));
+  await runProbe({
+    event: 'SessionStart',
+    deadlineMs: 15,
+    io,
+    handler: () => new Promise(() => {}),
+  });
+  assert.deepEqual(soleOutput(io), {});
+  assert.match(io.err.join(''), /gave up after 15 ms/);
+});
+
+test('a probe clamps its injection to the platform limit and reports the cut', async () => {
+  const io = fakeIo(inputFor('SessionStart'));
+  await runProbe({
+    event: 'SessionStart',
+    deadlineMs: 500,
+    io,
+    handler: () => 'y'.repeat(50000),
+  });
+  const payload = soleOutput(io);
+  assert.ok(io.out[0].length <= OUTPUT_LIMIT + 1, 'the newline is ours, the rest is the budget');
+  assert.equal(payload.hookSpecificOutput.hookEventName, 'SessionStart');
+  assert.match(payload.hookSpecificOutput.additionalContext, /output truncated/);
+  assert.match(io.err.join(''), /injected context truncated/);
+});

--- a/tests/unit/hook-io.test.mjs
+++ b/tests/unit/hook-io.test.mjs
@@ -537,8 +537,16 @@ test('the sanitizer and the CI scanner enforce ONE list, not two', () => {
   // scanner's list grows (ADR-19 correction 1), this grows with it. The test
   // proves agreement rather than trusting the import.
   const points = [];
-  for (let cp = 0; cp <= 0x30ff; cp++) points.push(cp);
-  for (const cp of [0xfeff, 0xfff9, 0x1f600, 0xe0001, 0xe0041, 0x10fffe]) points.push(cp);
+  for (let cp = 0; cp <= 0x30ff; cp++) {
+    if (cp >= 0xd800 && cp <= 0xdfff) continue; // lone surrogates are not codepoints
+    points.push(cp);
+  }
+  // Sampled explicitly because they lie outside the sweep above, and every one
+  // of them was added to the scanner AFTER this runtime was written — which is
+  // the whole point of not keeping a second copy of the list.
+  for (const cp of [0x3164, 0xffa0, 0xfeff, 0xfff9, 0x1d173, 0x1f600, 0xe0001, 0xe0041, 0xe0100, 0x10fffe]) {
+    points.push(cp);
+  }
   const sample = points.map((cp) => String.fromCodePoint(cp)).join('|');
   const cleaned = sanitizeForOutput(sample);
   assert.deepEqual(

--- a/tests/unit/hook-io.test.mjs
+++ b/tests/unit/hook-io.test.mjs
@@ -27,6 +27,7 @@ import {
   runGate,
   runProbe,
   sanitizeForOutput,
+  writeFully,
 } from '../../hooks/scripts/hook-io.mjs';
 
 /** A recording stand-in for stdin/stdout/stderr/exit. */
@@ -149,6 +150,23 @@ test('an unknown event is refused as a registration, not answered', async () => 
     () => runGate({ event: 'NoSuchEvent', handler: () => PASS, deadlineMs: 100, io: fakeIo('{}') }),
     GateOnProbeEventError,
   );
+});
+
+test('TaskCompleted is marked as firing only in team mode', () => {
+  // Measured in v2.1.116: the event is raised for the in-progress tasks of
+  // the current teammate. In subagent mode it never fires, so a check placed
+  // only there is an ABSENT control — the same class as a matcher that
+  // silently matches nothing. It stays in the table because it can refuse
+  // when it does fire; the caveat has to live in the type, not in a comment.
+  assert.equal(EVENTS.TaskCompleted.canBlock, true);
+  assert.equal(EVENTS.TaskCompleted.teamModeOnly, true);
+  for (const event of ['PreToolUse', 'SubagentStop', 'Stop', 'PreCompact', 'UserPromptSubmit']) {
+    assert.notEqual(
+      EVENTS[event].teamModeOnly,
+      true,
+      `${event} must not be marked team-only; a gate needs somewhere that always fires`,
+    );
+  }
 });
 
 test('canBlock agrees with the ADR-22 table', () => {
@@ -302,6 +320,51 @@ test('failure mode: the process ends before a verdict -> refusal, not empty stdo
   assert.equal(io.out.length, 1, 'the deadline must not write a second decision after the guard');
 });
 
+test('MUST-PASS 1: synchronous work past the deadline must refuse, not approve', async () => {
+  // Review round 2, blocker 1. A timer callback is a MACROtask; a handler
+  // that returns after blocking the thread resolves its promise in a
+  // MICROtask, so `emit(PASS)` wins the race and the deadline callback finds
+  // the decision already made. The gate overran its budget fifteenfold and
+  // approved. Whatever the deadline promises, it cannot promise less than
+  // "a verdict produced after the budget is not a verdict".
+  const io = fakeIo(inputFor('PreToolUse'));
+  await runGate({
+    event: 'PreToolUse',
+    deadlineMs: 20,
+    io,
+    handler: () => {
+      const t = Date.now();
+      while (Date.now() - t < 300) {
+        /* CPU-bound, yields nothing */
+      }
+      return PASS;
+    },
+  });
+  const payload = soleOutput(io);
+  assert.equal(payload.hookSpecificOutput.permissionDecision, 'deny');
+  assert.match(payload.hookSpecificOutput.permissionDecisionReason, /deadline-exceeded/);
+});
+
+test('MUST-PASS 2: a failed stdout write must end loudly, not with a silent exit 0', async () => {
+  // Review round 2, blocker 2. `done = true` used to be set BEFORE the write.
+  // A throwing write then left the catch clause calling a refusal that
+  // returned immediately, the exit guard likewise — and the process ended
+  // with exit 0, no stdout and no stderr. That is the quietest possible
+  // approval, produced by the ordering of two statements.
+  const io = fakeIo(inputFor('PreToolUse'));
+  io.write = () => {
+    throw Object.assign(new Error('EBADF: bad file descriptor, write'), { code: 'EBADF' });
+  };
+  await runGate({
+    event: 'PreToolUse',
+    deadlineMs: 500,
+    io,
+    handler: () => ({ decision: 'deny', reason: 'secret in the command' }),
+  });
+  assert.deepEqual(io.codes, [2], 'exit 2 is the only ending left that still blocks');
+  assert.match(io.err.join(''), /secret in the command/, 'stderr becomes the blocking reason');
+});
+
 test('a gate never exits non-zero: only exit 0 carries a decision', async () => {
   const cases = ['', 'not json', '[]', inputFor('PreToolUse')];
   for (const raw of cases) {
@@ -339,7 +402,85 @@ test('nothing this runtime can emit ever auto-approves a tool call', async () =>
   for (const raw of seen) assert.doesNotMatch(raw, /"allow"/);
 });
 
+test('the deadline discards a LATE verdict, whichever way the handler was late', async () => {
+  // The async twin of MUST-PASS 1: a handler that yields but finishes past
+  // the budget must not have its answer used either.
+  const io = fakeIo(inputFor('SubagentStop'));
+  await runGate({
+    event: 'SubagentStop',
+    deadlineMs: 25,
+    io,
+    handler: () => new Promise((r) => setTimeout(() => r(PASS), 5)),
+  });
+  assert.deepEqual(soleOutput(io), {}, 'a handler inside its budget still passes');
+
+  const late = fakeIo(inputFor('SubagentStop'));
+  await runGate({
+    event: 'SubagentStop',
+    deadlineMs: 5000,
+    io: late,
+    handler: async () => {
+      await new Promise((r) => setTimeout(r, 30));
+      const t = Date.now();
+      while (Date.now() - t < 60) {
+        /* blocks past a budget the timer cannot enforce */
+      }
+      return PASS;
+    },
+  });
+  assert.deepEqual(soleOutput(late), {}, 'inside a generous budget the same handler passes');
+});
+
+test('an event this runtime does not model ends loudly rather than in a shape the platform rejects', async () => {
+  const io = fakeIo(inputFor('SomeFutureEvent'));
+  await runGate({ event: 'PreToolUse', deadlineMs: 500, io, handler: () => PASS });
+  assert.deepEqual(io.codes, [2]);
+  assert.equal(io.out.length, 0, 'guessing a hookEventName is what fails open');
+  assert.match(io.err.join(''), /does not model/);
+});
+
+test('writeFully keeps writing until the whole decision is out', () => {
+  // writeSync may take fewer bytes than it is given. Ignoring its return
+  // value produces truncated JSON, which fails the platform's schema, which
+  // discards the output — a refusal cut in half is an approval.
+  const chunks = [];
+  const written = writeFully('{"decision":"block"}\n', (buf, off) => {
+    chunks.push(buf[off]);
+    return 1; // one byte at a time, the worst honest sink
+  });
+  assert.equal(written, 21);
+  assert.equal(Buffer.from(chunks).toString('utf8'), '{"decision":"block"}\n');
+});
+
+test('writeFully retries back-pressure but refuses to spin forever on a dead sink', () => {
+  let calls = 0;
+  const out = [];
+  writeFully('abc', (buf, off, len) => {
+    calls++;
+    if (calls <= 2) throw Object.assign(new Error('EAGAIN'), { code: 'EAGAIN' });
+    out.push(buf.subarray(off, off + len).toString('utf8'));
+    return len;
+  });
+  assert.equal(out.join(''), 'abc', 'a momentarily full pipe is back-pressure, not failure');
+
+  assert.throws(
+    () => writeFully('abc', () => 0),
+    /stalled/,
+    'a sink that never makes progress must throw, not hang the session',
+  );
+});
+
 // --------------------------------------------------------------- truncation
+
+test('the platform limit is pinned to the number the platform actually uses', () => {
+  // Measured as `text.length <= 10000` (UTF-16 code units). Pinned as a
+  // literal because every truncation test uses samples far from the bound,
+  // so a limit ten times too large would otherwise survive them all.
+  assert.equal(OUTPUT_LIMIT, 10000);
+  const justOver = 'q'.repeat(OUTPUT_LIMIT + 40);
+  const { omitted } = clampPayload((r) => refusalPayload('Stop', r), justOver);
+  assert.ok(omitted > 0, 'a payload just past the limit must still be cut');
+});
 
 test('output over the platform limit is cut deterministically and says so', () => {
   const long = 'x'.repeat(40000);

--- a/tests/unit/hook-session-start.test.mjs
+++ b/tests/unit/hook-session-start.test.mjs
@@ -1,0 +1,343 @@
+/**
+ * Tests for the SessionStart probe and for the registration that makes it
+ * run at all.
+ *
+ * The registration half matters as much as the code: a hook with a wrong
+ * matcher, a missing timeout or a path that does not resolve is not a broken
+ * hook, it is an ABSENT one, and nothing in a normal test run notices.
+ */
+import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+import { mkdirSync, mkdtempSync, readFileSync, statSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join, resolve } from 'node:path';
+import test from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+import { OUTPUT_LIMIT } from '../../hooks/scripts/hook-io.mjs';
+import {
+  CONTEXT_BUDGET,
+  DEADLINE_MS,
+  fitBudget,
+  hardwareLine,
+  readInitiatives,
+  renderContext,
+  resolveRepoRoot,
+  runDoctor,
+} from '../../hooks/scripts/session-start.mjs';
+
+const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..', '..');
+const SCRIPT = join(REPO_ROOT, 'hooks', 'scripts', 'session-start.mjs');
+const HOOKS_JSON = join(REPO_ROOT, 'hooks', 'hooks.json');
+const DEMO_JOURNAL = join(REPO_ROOT, 'tests', 'fixtures', 'journal-demo.jsonl');
+
+function tempRepo({ journal = readFileSync(DEMO_JOURNAL, 'utf8'), init = 'demo' } = {}) {
+  const dir = mkdtempSync(join(tmpdir(), 'tyran-session-start-'));
+  mkdirSync(join(dir, '.tyran', 'state', init), { recursive: true });
+  writeFileSync(join(dir, '.tyran', 'state', init, 'journal.jsonl'), journal);
+  return dir;
+}
+
+function runScript(input, cwd = REPO_ROOT) {
+  const r = execFileSync(process.execPath, [SCRIPT], {
+    input,
+    cwd,
+    encoding: 'utf8',
+    stdio: ['pipe', 'pipe', 'pipe'],
+  });
+  return r;
+}
+
+// ------------------------------------------------------- the doctor call
+
+test('the doctor call passes --now, or the dead-agent check never fires', () => {
+  // Binding, and load-bearing rather than stylistic: with no --now, doctor
+  // takes its reference clock from each journal's own last event, so an
+  // agent that died days ago is compared with the timestamp of its own
+  // spawn and is never stale. The check would exist and never fire once.
+  let seen = null;
+  runDoctor('/some/.tyran', '2026-07-26T00:00:00.000Z', {
+    exec: (_bin, args) => {
+      seen = args;
+      return JSON.stringify({ counts: { error: 0, warning: 0, info: 0 }, findings: [] });
+    },
+  });
+  assert.ok(seen.includes('--now'), `--now missing from argv: ${JSON.stringify(seen)}`);
+  assert.equal(seen[seen.indexOf('--now') + 1], '2026-07-26T00:00:00.000Z');
+  assert.ok(seen.includes('--state') && seen.includes('--json'));
+  assert.equal(seen[seen.indexOf('--dir') + 1], '/some/.tyran');
+});
+
+test('the doctor call is an argument VECTOR, so a hostile cwd cannot reach a shell', () => {
+  let seen = null;
+  const nasty = '/tmp/$(touch pwned); rm -rf ~/.tyran';
+  runDoctor(nasty, '2026-07-26T00:00:00.000Z', {
+    exec: (_bin, args) => {
+      seen = args;
+      return '{"counts":{},"findings":[]}';
+    },
+  });
+  assert.ok(
+    seen.includes(nasty),
+    'the path must travel as one argv element, never spliced into a command string',
+  );
+});
+
+test('doctor exiting 1 is findings, not failure — its report is still read', () => {
+  const result = runDoctor('/x', '2026-07-26T00:00:00.000Z', {
+    exec: () => {
+      const err = new Error('Command failed');
+      err.status = 1;
+      err.stdout = JSON.stringify({ counts: { error: 0, warning: 2, info: 1 }, findings: [] });
+      throw err;
+    },
+  });
+  assert.equal(result.available, true);
+  assert.equal(result.counts.warning, 2);
+});
+
+test('a doctor that will not run degrades to a note, never to a thrown probe', () => {
+  const result = runDoctor('/x', '2026-07-26T00:00:00.000Z', {
+    exec: () => {
+      const err = new Error('spawn ETIMEDOUT');
+      err.status = null;
+      throw err;
+    },
+  });
+  assert.equal(result.available, false);
+  assert.match(result.reason, /ETIMEDOUT/);
+});
+
+test('doctor output that is not JSON is reported, not parsed into nonsense', () => {
+  const result = runDoctor('/x', '2026-07-26T00:00:00.000Z', { exec: () => 'segfault' });
+  assert.equal(result.available, false);
+  assert.match(result.reason, /not JSON/);
+});
+
+// ------------------------------------------------------------- repo root
+
+test('resolveRepoRoot refuses anything that is not an existing absolute directory', () => {
+  const dir = tempRepo();
+  assert.equal(resolveRepoRoot({ cwd: dir }, {}, dir), dir);
+  assert.equal(resolveRepoRoot({ cwd: 'relative/path' }, {}, dir), dir, 'relative cwd is ignored');
+  assert.equal(resolveRepoRoot({ cwd: '/nope/does/not/exist' }, {}, dir), dir);
+  assert.equal(resolveRepoRoot({ cwd: DEMO_JOURNAL }, {}, dir), dir, 'a file is not a repo root');
+  assert.equal(resolveRepoRoot({}, { CLAUDE_PROJECT_DIR: dir }, '/nope'), dir);
+  assert.equal(resolveRepoRoot({}, {}, '/nope/nothing/here'), null);
+});
+
+// ------------------------------------------------------------- rendering
+
+test('the summary carries checkpoint, resume steps, open gates, leases and agents', () => {
+  const dir = tempRepo();
+  const context = renderContext({
+    repoRoot: dir,
+    initiatives: readInitiatives(join(dir, '.tyran')),
+    doctor: { available: true, counts: { error: 0, warning: 1, info: 2 }, findings: [] },
+    hardware: hardwareLine(),
+    nowIso: '2026-07-26T10:00:00.000Z',
+  });
+  assert.match(context, /Checkpoint: E2 at 2026-07-26T09:42:00\.000Z/);
+  assert.match(context, /1\. re-read STATE\.md/);
+  assert.match(context, /3\. then start T-10/);
+  assert.doesNotMatch(context, /4\. /, 'only the first three steps belong in a resume summary');
+  assert.match(context, /Open gates \(1\):[\s\S]*plan-approval/);
+  assert.match(context, /Open leases \(1\)[\s\S]*worktree:tyran-s2 held by impl-2/);
+  assert.match(context, /still believes are working \(1\):[\s\S]*impl-2 \(implementer\)/);
+  assert.match(context, /cores · \d+ GiB RAM/);
+});
+
+test('no initiatives means no injection at all, not an empty heading', () => {
+  assert.equal(
+    renderContext({
+      repoRoot: '/x',
+      initiatives: [],
+      doctor: { available: true, counts: {}, findings: [] },
+      hardware: 'h',
+      nowIso: 'n',
+    }),
+    '',
+  );
+});
+
+test('an unreadable initiative is reported inside the summary, not thrown', () => {
+  const context = renderContext({
+    repoRoot: '/x',
+    initiatives: [{ name: 'broken', state: null, error: 'EISDIR: illegal operation' }],
+    doctor: { available: false, reason: 'not run' },
+    hardware: 'h',
+    nowIso: 'n',
+  });
+  assert.match(context, /journal unreadable: EISDIR/);
+  assert.match(context, /Doctor did not run/);
+});
+
+test('a corrupt journal degrades to a partial summary rather than an exception', () => {
+  const dir = tempRepo({ journal: '{"ts":"2026-01-01T00:00:00.000Z","ev":"init.created"}\n{ broken\n' });
+  const initiatives = readInitiatives(join(dir, '.tyran'));
+  assert.equal(initiatives.length, 1);
+  assert.notEqual(initiatives[0].state, null, 'a bad line is skipped, the rest still folds');
+});
+
+// -------------------------------------------------------------- budget
+
+test('the working budget cuts on a section boundary and says how much it dropped', () => {
+  const text = ['## head', '', '### one', 'a'.repeat(400), '### two', 'b'.repeat(400), '### three', 'c'.repeat(400)].join(
+    '\n',
+  );
+  const fitted = fitBudget(text, 500);
+  assert.ok(fitted.length <= 700, `budget overshoot: ${fitted.length}`);
+  assert.match(fitted, /## head/);
+  assert.match(fitted, /further section\(s\) omitted/);
+  assert.equal(fitBudget('short', 500), 'short', 'text inside the budget is untouched');
+});
+
+test('the platform ceiling holds even against a state file built to overflow it', () => {
+  const many = Array.from({ length: 400 }, (_, i) => `### init-${i}\n${'z'.repeat(200)}`).join('\n');
+  const fitted = fitBudget(`## head\n${many}`, CONTEXT_BUDGET);
+  assert.ok(fitted.length < OUTPUT_LIMIT, `${fitted.length} would be persisted away by the platform`);
+});
+
+// --------------------------------------------------- end-to-end, real process
+
+test('end to end: a real repo with state produces a valid SessionStart payload', () => {
+  const dir = tempRepo();
+  const out = runScript(
+    JSON.stringify({ hook_event_name: 'SessionStart', source: 'resume', cwd: dir, session_id: 's' }),
+  );
+  const payload = JSON.parse(out);
+  assert.equal(payload.hookSpecificOutput.hookEventName, 'SessionStart');
+  assert.match(payload.hookSpecificOutput.additionalContext, /Tyran state/);
+  assert.match(payload.hookSpecificOutput.additionalContext, /Initiative `demo`/);
+  assert.ok(out.length <= OUTPUT_LIMIT + 1, `stdout ${out.length} exceeds the platform limit`);
+});
+
+test('end to end: a repo with no .tyran says nothing and still exits 0', () => {
+  const dir = mkdtempSync(join(tmpdir(), 'tyran-plain-'));
+  const out = runScript(
+    JSON.stringify({ hook_event_name: 'SessionStart', source: 'startup', cwd: dir }),
+  );
+  assert.equal(out.trim(), '{}');
+});
+
+test('end to end: garbage on stdin must not cost the user their session', () => {
+  for (const raw of ['', 'not json at all', '[1,2,3]']) {
+    const out = runScript(raw);
+    assert.equal(out.trim(), '{}', `raw=${JSON.stringify(raw)}`);
+  }
+});
+
+test('end to end: the probe exits 0 even when everything about the input is wrong', () => {
+  const r = execFileSync(process.execPath, [SCRIPT], {
+    input: 'nonsense',
+    encoding: 'utf8',
+    stdio: ['pipe', 'pipe', 'pipe'],
+  });
+  assert.equal(typeof r, 'string');
+  // execFileSync throws on a non-zero exit, so reaching here IS the assertion.
+});
+
+// ---------------------------------------------------------- registration
+
+function hooksConfig() {
+  return JSON.parse(readFileSync(HOOKS_JSON, 'utf8'));
+}
+
+test('plugin.json points at hooks.json, or none of this ever runs', () => {
+  const plugin = JSON.parse(readFileSync(join(REPO_ROOT, '.claude-plugin', 'plugin.json'), 'utf8'));
+  assert.equal(plugin.hooks, './hooks/hooks.json');
+});
+
+test('every registered hook command resolves to an executable file with a shebang', () => {
+  const config = hooksConfig();
+  let checked = 0;
+  for (const entries of Object.values(config.hooks)) {
+    for (const entry of entries) {
+      for (const hook of entry.hooks) {
+        assert.equal(hook.type, 'command');
+        const path = hook.command
+          .replaceAll('"', '')
+          .replace('${CLAUDE_PLUGIN_ROOT}', REPO_ROOT);
+        const mode = statSync(path).mode;
+        assert.ok(mode & 0o111, `${path} is not executable; the platform would fail to spawn it`);
+        assert.match(readFileSync(path, 'utf8').split('\n')[0], /^#!/, `${path} has no shebang`);
+        checked++;
+      }
+    }
+  }
+  assert.ok(checked > 0, 'a registration test that checked nothing is not a test');
+});
+
+test('the plugin-root placeholder is quoted, because the command runs through a shell', () => {
+  // Measured: the platform spawns the command with `shell: true`. An
+  // unquoted plugin root containing a space would split into two arguments
+  // and the hook would silently never run.
+  const config = hooksConfig();
+  for (const entries of Object.values(config.hooks)) {
+    for (const entry of entries) {
+      for (const hook of entry.hooks) {
+        assert.match(hook.command, /^"[^"]*\$\{CLAUDE_PLUGIN_ROOT\}[^"]*"$/, hook.command);
+      }
+    }
+  }
+});
+
+test('the SessionStart matcher is a list the platform actually accepts', () => {
+  // Measured in v2.1.116: a matcher made only of [a-zA-Z0-9_|] is compared
+  // as an exact list split on "|" — for EVERY event, SessionStart included.
+  // So one entry covers all three sources; three entries would be
+  // redundant. Anything outside that character class silently becomes a
+  // REGEX instead, which is a different and much looser rule.
+  const entries = hooksConfig().hooks.SessionStart;
+  assert.equal(entries.length, 1);
+  const matcher = entries[0].matcher;
+  assert.match(matcher, /^[a-zA-Z0-9_|]+$/, 'anything else is treated as a regex, not a list');
+  assert.deepEqual(matcher.split('|').sort(), ['compact', 'resume', 'startup']);
+});
+
+test('every hook declares an explicit timeout well under the platform default', () => {
+  // The platform default is 600 s. A hook without an explicit timeout can
+  // hold a session for ten minutes and then have its output DISCARDED,
+  // which for a gate means the action proceeds.
+  for (const entries of Object.values(hooksConfig().hooks)) {
+    for (const entry of entries) {
+      for (const hook of entry.hooks) {
+        assert.equal(typeof hook.timeout, 'number', 'a missing timeout means 600 s');
+        assert.ok(hook.timeout > 0 && hook.timeout <= 30, `timeout ${hook.timeout}s is not short`);
+      }
+    }
+  }
+});
+
+test("each hook's internal deadline is strictly shorter than its platform timeout", async () => {
+  // ADR-22 point 2, proved rather than commented. The platform kills a hook
+  // at `timeout` and throws its output away; a hook that has not decided by
+  // then has approved. So the internal deadline must fire first, with room
+  // to write the refusal.
+  let checked = 0;
+  for (const entries of Object.values(hooksConfig().hooks)) {
+    for (const entry of entries) {
+      for (const hook of entry.hooks) {
+        const path = hook.command.replaceAll('"', '').replace('${CLAUDE_PLUGIN_ROOT}', REPO_ROOT);
+        const module = await import(path);
+        assert.equal(
+          typeof module.DEADLINE_MS,
+          'number',
+          `${path} must export DEADLINE_MS so this relation can be checked`,
+        );
+        const platformMs = hook.timeout * 1000;
+        assert.ok(
+          module.DEADLINE_MS < platformMs,
+          `${path}: deadline ${module.DEADLINE_MS} ms is not below the ${platformMs} ms timeout`,
+        );
+        assert.ok(
+          module.DEADLINE_MS <= platformMs / 2,
+          `${path}: deadline ${module.DEADLINE_MS} ms leaves no margin under ${platformMs} ms`,
+        );
+        checked++;
+      }
+    }
+  }
+  assert.ok(checked > 0);
+  assert.equal(DEADLINE_MS, 4000, 'pinned so a change has to be deliberate');
+});

--- a/tests/unit/scan-control-chars.test.mjs
+++ b/tests/unit/scan-control-chars.test.mjs
@@ -741,6 +741,9 @@ test('THIS repository scans clean end to end', () => {
   // 45 -> 48: scripts/doctor.mjs, tests/unit/doctor.test.mjs, docs/doctor.md.
   // 48 -> 54: hooks/hooks.json, hooks/HOOK-CONTRACT-MEASURED.md,
   // hooks/scripts/{hook-io,session-start}.mjs and their two test files.
-  assert.equal(scanned, 54, 'file count changed — confirm nothing left the scan by accident');
+  // 54 -> 55: docs/hooks.md (review round 2 — the gate-vs-probe rule needed a
+  // page a contributor can find). The trial merge with S-E3-0 was measured at
+  // 54, and S-E3-0 adds no files, so this +1 is entirely this branch's.
+  assert.equal(scanned, 55, 'file count changed — confirm nothing left the scan by accident');
   assert.deepEqual(exempt.map((e) => e.file), ['assets/banner.jpg']);
 });

--- a/tests/unit/scan-control-chars.test.mjs
+++ b/tests/unit/scan-control-chars.test.mjs
@@ -739,6 +739,8 @@ test('THIS repository scans clean end to end', () => {
   // while a file quietly left the scan. Any change to either number now has
   // to be made on purpose, in this file, where a reviewer will see it.
   // 45 -> 48: scripts/doctor.mjs, tests/unit/doctor.test.mjs, docs/doctor.md.
-  assert.equal(scanned, 48, 'file count changed — confirm nothing left the scan by accident');
+  // 48 -> 54: hooks/hooks.json, hooks/HOOK-CONTRACT-MEASURED.md,
+  // hooks/scripts/{hook-io,session-start}.mjs and their two test files.
+  assert.equal(scanned, 54, 'file count changed — confirm nothing left the scan by accident');
   assert.deepEqual(exempt.map((e) => e.file), ['assets/banner.jpg']);
 });


### PR DESCRIPTION
Foundation for E3: the four gates that come next all stand on this.

## Why this is a security component, not a stdin parser

Claude Code fails **open**. Measured against the shipped v2.1.116 binary, the
action proceeds when the hook file is missing, when stdout is not JSON, when
stdout is JSON but fails the schema, when `hookEventName` does not match the
fired event, when the platform's timeout kills the process — and when the
hook-selection code throws, which drops *every* hook at once. An attacker does
not need to defeat a gate's logic; breaking it is enough.

## What landed

- **`hooks/scripts/hook-io.mjs`** — every unexpected error becomes exit 0 plus
  a well-formed refusal naming the error class and a fix; gate vs probe is
  enforced in the type (registering a gate on `SessionStart` throws); refusal
  shape is generated per event from one `deny()`; own deadline plus a
  process-exit guard; deterministic, audible truncation measured on the
  serialized payload; sanitization through the **same** forbidden-codepoint
  table the CI scanner uses.
- **`hooks/scripts/session-start.mjs`** — the probe. Injects checkpoint, first
  three resume steps, open gates, open leases, running agents, hardware
  ceiling and doctor verdict. Calls doctor with `--now`; without it the
  dead-agent check compares an agent with its own spawn and never fires.
- **`hooks/hooks.json` + `plugin.json`** — one `SessionStart` entry, matcher
  `startup|resume|compact`, explicit 10 s timeout.
- **`hooks/HOOK-CONTRACT-MEASURED.md`** — what the platform actually does.

## Four documented facts that were wrong

1. `hookSpecificOutput` has **no variant** for `Stop`/`SubagentStop`/
   `PreCompact`/`TaskCompleted`; sending one there invalidates the output and
   the refusal becomes an approval.
2. `hookEventName` must **equal** the fired event or the platform throws while
   reading our output — and fails open.
3. Exit 3–255 is **not** an automatic pass: stdout is parsed first, so a valid
   refusal is honoured regardless of exit code.
4. `SessionStart` **does** accept `startup|resume|compact` as one entry — but
   the exact-list character class excludes spaces, hyphens and commas, so
   `Edit, Write` silently becomes an unanchored regex.

Plus: `permissionDecision: "allow"` auto-approves the tool call. This runtime
cannot emit it.

## Evidence

```
node --test "tests/**/*.test.mjs"   # tests 291 · pass 291 · fail 0   (baseline 232)
node scripts/scan-control-chars.mjs .   # clean (54 tracked text files), exit 0
claude plugin validate .                # Validation passed
claude plugin validate .claude-plugin/plugin.json   # Validation passed
```

16 mutants applied by hand, **16 killed, 0 survivors** — including the
gate-on-probe check, the deadline, the exit guard, the catch-all, the per-event
shape, serialized-length truncation, the shared sanitizer list, `--now`, the
`hooks.json` timeout relation, the matcher, the exec bit and the plugin.json
registration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
