### PR TITLE
What the documentation claimed, measured against what the code does

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,9 +1,10 @@
 # Architecture
 
-> **Status:** this page is the design contract for v2 — schemas and hook
-> behavior are final, but the state layer, hooks, and agents land with their
-> epics (see the [roadmap](../README.md#roadmap)). Today the repo ships the
-> plugin skeleton and CI. Present tense below describes the target design.
+> **Status:** the state layer, the enforcement hooks, the conductor and the
+> agent roster are **shipped and tested**. Rows in the tables below that are
+> still design carry an explicit marker; everything unmarked exists in code
+> with tests behind it. See the [roadmap](../README.md#roadmap) for what is
+> still outstanding.
 
 ## The three layers
 
@@ -23,9 +24,46 @@ Layer 3 — LOCAL EVOLUTION (.claude/skills/tyran-local/ in YOUR repo)
   core and the data layer. Loaded natively by Claude Code.
 ```
 
+```mermaid
+flowchart TB
+    subgraph L1["Layer 1 — CORE (the plugin)"]
+        direction LR
+        C1["skills/ · agents/<br/>hooks/ · scripts/"]
+    end
+    subgraph L2["Layer 2 — REPO DATA (.tyran/, committed)"]
+        direction LR
+        C2["config.yaml · knowledge/*.yaml<br/>policies/*.yaml · state/&lt;initiative&gt;/"]
+    end
+    subgraph L3["Layer 3 — LOCAL EVOLUTION (.claude/skills/tyran-local/)"]
+        direction LR
+        C3["repo-specific skills<br/>agent variants · extra hooks"]
+    end
+
+    UPD(["/plugin update"]) -->|"replaces wholesale"| L1
+    L1 -->|"reads as an override layer"| L2
+    RETRO(["tyran:retro"]) -->|"writes"| L2
+    RETRO -->|"writes"| L3
+    L1 -.->|"never writes"| L2
+    L1 -.->|"never writes"| L3
+
+    classDef core fill:#1f2937,stroke:#d4a017,stroke-width:2px,color:#f9fafb
+    classDef data fill:#064e3b,stroke:#34d399,stroke-width:2px,color:#ecfdf5
+    classDef local fill:#3b0764,stroke:#c084fc,stroke-width:2px,color:#faf5ff
+    class C1 core
+    class C2 data
+    class C3 local
+```
+
+**Read the dotted arrows first.** The core never writes into layers 2 and 3,
+which is the entire reason a plugin update cannot destroy what your repo has
+learned: the update replaces layer 1 wholesale, and layer 1 owns nothing your
+repo produced.
+
 After a core update, a delta-review agent compares the new version's
 changelog against layers 2–3 and proposes reconciliation (e.g. "the core
 absorbed a rule your repo learned locally — delete the local duplicate").
+🎯 **Designed, not built** — the layout is real and the layers are separate
+today; the reconciling agent does not exist yet.
 
 ## State: the journal
 
@@ -41,6 +79,34 @@ projections** with a `GENERATED — do not edit` header (see
 crash mid-write can at worst produce one truncated final line, which the
 reader discards. No database, no build step, git-friendly diffs.
 
+An initiative, end to end — every arrow below is an event in that journal:
+
+```mermaid
+sequenceDiagram
+    autonumber
+    actor Op as Operator
+    participant C as Conductor<br/>(/tyran)
+    participant J as journal.jsonl
+    participant A as implementer
+    participant R as reviewer
+
+    Op->>C: describes the work
+    C->>J: init.created · plan.accepted
+    Note over C,J: the plan gate is the last<br/>question until something breaks
+    C->>J: ticket.created ×N
+    C->>A: spawn (worktree + lease)
+    C->>J: spawn · lease.acquired
+    A-->>C: report with RAW command output
+    Note right of A: SubagentStop gate REFUSES<br/>a report with no evidence
+    C->>J: report · lease.released
+    C->>R: spawn (never the author)
+    R-->>C: APPROVE / CHANGES-REQUESTED
+    C->>J: review
+    C->>J: merge
+    Note over C,J: Stop gate REFUSES to end<br/>an initiative with no retrospective
+    C->>J: retro.entry
+```
+
 ## Enforcement: the hooks
 
 | Event | What Tyran does | Blocking |
@@ -49,11 +115,52 @@ reader discards. No database, no build step, git-friendly diffs.
 | `SubagentStop` | evidence gate: implementer/reviewer reports must contain raw command output — otherwise the report is rejected with a reason | **yes** |
 | `PreToolUse` (Bash) | secrets gate: staged diff through gitleaks before commit/push; `--no-verify`, bare force-push blocked | **yes** |
 | `PreToolUse` (Write/Edit/Bash) | policy gate: autonomy classes (P1/P2/P3) and self-improvement path classes (AUTO/GATED/KERNEL) | **yes** |
-| `TaskCompleted` | no completion without a matching evidence event in the journal | **yes** |
-| `SubagentStart` / `PreCompact` | telemetry events; checkpoint archive before compaction | no |
+| `Stop` | retro gate: an initiative whose tickets are all merged and which has no retrospective recorded since the last merge refuses ONE turn | **yes** |
+| `PreCompact` | checkpoint archive before compaction | no |
+| `TaskCompleted` | **🎯 DESIGNED, NOT REGISTERED.** The runtime in `hook-io.mjs` knows the event and would let a gate block on it, but `hooks.json` registers nothing there, so nothing runs. Listed here because the type scaffolding exists and misreads as shipped otherwise. | — |
+
+```mermaid
+flowchart LR
+    subgraph P["Claude Code emits"]
+        E1["SessionStart"]
+        E2["PreToolUse<br/>Bash"]
+        E3["PreToolUse<br/>Write · Edit · MCP"]
+        E4["SubagentStop"]
+        E5["Stop"]
+        E6["PreCompact"]
+    end
+
+    E1 --> H1["session-start<br/>re-inject checkpoint"]
+    E2 --> H2["secrets-gate"]
+    E3 --> H3["write-guard"]
+    E2 & E3 --> H4["policy-gate"]
+    E4 --> H5["evidence-gate"]
+    E5 --> H6["retro-gate"]
+    E6 --> H7["pre-compact<br/>archive checkpoint"]
+
+    H2 --> B{{"BLOCKS"}}
+    H3 --> B
+    H4 --> B
+    H5 --> B
+    H6 --> B
+    H1 --> N{{"reports only"}}
+    H7 --> N
+
+    classDef blocks fill:#7f1d1d,stroke:#f87171,stroke-width:2px,color:#fef2f2
+    classDef probe fill:#1e3a5f,stroke:#60a5fa,stroke-width:2px,color:#eff6ff
+    class B blocks
+    class N probe
+```
 
 Design rule: **critical gates fail loudly.** If a gate itself breaks, it
 denies with an explanation — it never silently allows.
+
+The exception, stated because it is the one that matters: hooks **fail open**
+at the platform level. A gate whose file is missing or whose matcher can
+never match does not become a weaker check — the action simply proceeds, with
+nothing printed anywhere. That is why `tyran doctor --hooks` exists, and why
+a dead gate and a healthy gate are indistinguishable from inside a session
+without it.
 
 ## Agents
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,7 +1,7 @@
 # Configuration
 
-> **Status:** schema is design-final (see [architecture](./architecture.md));
-> the setup epic ships the generator. Field names below are the contract.
+> **Status:** shipped. `/tyran:setup` writes this file via
+> `scripts/scan-repo.mjs`, and `scripts/schema.mjs` validates it.
 
 All per-repo configuration lives in `.tyran/config.yaml` — committed, human
 reviewable, written by `/tyran:setup` and editable by hand.

--- a/docs/doctor.md
+++ b/docs/doctor.md
@@ -1,6 +1,6 @@
 # Doctor reference
 
-> **Status:** shipped — `scripts/doctor.mjs --state` with 54 unit tests.
+> **Status:** shipped — `scripts/doctor.mjs --state` with 76 unit tests.
 > It **diagnoses, it never repairs.** Every finding carries a severity, a
 > location and a command you can paste.
 

--- a/docs/journal.md
+++ b/docs/journal.md
@@ -1,6 +1,6 @@
 # Journal reference
 
-> **Status:** shipped — `scripts/journal.mjs` with 43 unit tests. This file
+> **Status:** shipped — `scripts/journal.mjs` with 47 unit tests. This file
 > is the schema contract; extending the event set is a reviewed core change.
 
 The journal is the append-only source of truth for an initiative:

--- a/docs/projections.md
+++ b/docs/projections.md
@@ -1,6 +1,6 @@
 # Projections reference
 
-> **Status:** shipped — `scripts/project.mjs` with 46 unit tests, including
+> **Status:** shipped — `scripts/project.mjs` with 48 unit tests, including
 > byte-exact golden files. The journal stays the only source of truth;
 > everything on this page is a disposable view of it.
 

--- a/docs/self-improvement.md
+++ b/docs/self-improvement.md
@@ -1,8 +1,10 @@
 # Self-improvement — how Tyran learns your repo
 
-> **Status:** design contract — the retro agent and its guardrails land with
-> the self-improvement epic (after the state layer and enforcement hooks
-> exist, deliberately in that order). Present tense describes the target.
+> **Status:** shipped. `agents/retro.md` carries the curator and its filter,
+> `skills/retro/SKILL.md` runs it, and a `Stop` gate
+> (`hooks/scripts/retro-gate.mjs`) refuses one turn when an initiative ends
+> without a retrospective. Still outstanding: the update delta-review that
+> reconciles a new core version with what your repo has learned.
 
 This is Tyran's centerpiece: **you bring the harness, it does the
 improving.** The more initiatives you run, the better it fits your repo and

--- a/tests/unit/docs-claims.test.mjs
+++ b/tests/unit/docs-claims.test.mjs
@@ -1,0 +1,107 @@
+/**
+ * Numeric claims in the documentation, checked against the thing they claim.
+ *
+ * Three status lines in `docs/` each froze a test count — 43, 46, 54 — and by
+ * the time anyone looked the real numbers were 47, 48 and 76. Nothing was
+ * wrong with the code; the documentation had simply drifted away from it
+ * while every test stayed green. An audit caught it, which is the expensive
+ * way to catch it.
+ *
+ * A number in prose is a claim with no mechanism behind it, and this
+ * repository's whole argument is that such claims decay. So the numbers stay
+ * — they are genuinely useful to a reader deciding whether to trust a
+ * component — and this file makes them checkable. Drift now fails CI on the
+ * day it is introduced rather than on the day someone audits.
+ */
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+import { readFileSync, readdirSync } from 'node:fs';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const ROOT = fileURLToPath(new URL('../../', import.meta.url));
+const DOCS = join(ROOT, 'docs');
+
+/**
+ * Which test file backs which document's count.
+ *
+ * Explicit rather than inferred from the filename: `projections.md` is backed
+ * by `project.test.mjs`, and a clever mapping would have to encode that
+ * anyway. An unmapped document carrying a count is a FAILURE below, not a
+ * skip — otherwise a new doc could quietly opt itself out of the check.
+ */
+const BACKED_BY = Object.freeze({
+  'journal.md': 'journal.test.mjs',
+  'projections.md': 'project.test.mjs',
+  'doctor.md': 'doctor.test.mjs',
+});
+
+const CLAIM = /(\d+)\s+unit tests/;
+
+/**
+ * The env a nested `node --test` needs in order to say anything at all.
+ *
+ * Measured: spawned with the parent runner's environment inherited, the child
+ * produces ZERO BYTES on stdout — the parent sets `NODE_TEST_CONTEXT`, and a
+ * child that sees it reports through a channel this process is not reading.
+ * Clearing it (and `NODE_OPTIONS`, which can carry runner flags of its own)
+ * restores ordinary TAP output.
+ *
+ * The failure mode this avoids is worth naming: an empty string parses to no
+ * match, and a laxer implementation would have turned that into a count of 0
+ * or a silent skip. The assertion below refuses to guess instead.
+ */
+function childEnv() {
+  const env = { ...process.env, NODE_OPTIONS: '' };
+  delete env.NODE_TEST_CONTEXT;
+  return env;
+}
+
+function countTests(testFile) {
+  // `node --test` exits non-zero if any test fails; we want the COUNT either
+  // way, so read the output rather than trusting the exit code.
+  let stdout;
+  try {
+    stdout = execFileSync(process.execPath, ['--test', '--test-reporter=tap', join('tests', 'unit', testFile)], {
+      cwd: ROOT,
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'pipe'],
+      env: childEnv(),
+    });
+  } catch (error) {
+    stdout = String(error.stdout ?? '');
+  }
+  const m = /^# tests (\d+)$/m.exec(stdout);
+  assert.ok(m, `could not read a test count out of ${testFile} (child produced ${stdout.length} bytes)`);
+  return Number(m[1]);
+}
+
+const docsWithClaims = readdirSync(DOCS)
+  .filter((f) => f.endsWith('.md'))
+  .map((f) => ({ file: f, text: readFileSync(join(DOCS, f), 'utf8') }))
+  .filter(({ text }) => CLAIM.test(text));
+
+test('every document that claims a test count is mapped to the file it claims about', () => {
+  // Guards the guard. A new doc with an unmapped count would otherwise be
+  // silently exempt, which is the exact shape of hole this file exists to
+  // close.
+  for (const { file } of docsWithClaims) {
+    assert.ok(BACKED_BY[file], `docs/${file} claims a test count but is not mapped in BACKED_BY`);
+  }
+  assert.ok(docsWithClaims.length > 0, 'no document claims a count — did the pattern stop matching?');
+});
+
+for (const [doc, testFile] of Object.entries(BACKED_BY)) {
+  test(`docs/${doc} states the real number of tests in ${testFile}`, () => {
+    const text = readFileSync(join(DOCS, doc), 'utf8');
+    const claimed = Number(CLAIM.exec(text)[1]);
+    const actual = countTests(testFile);
+    assert.equal(
+      claimed,
+      actual,
+      `docs/${doc} says ${claimed} unit tests, ${testFile} has ${actual}. ` +
+        'Update the document — a number in prose that nothing checks is how the last three drifted.',
+    );
+  });
+}

--- a/tests/unit/scan-control-chars.test.mjs
+++ b/tests/unit/scan-control-chars.test.mjs
@@ -906,6 +906,7 @@ test('THIS repository scans clean end to end', () => {
     'tests/pressure/.gitkeep',
     'tests/unit/agents.test.mjs',
     'tests/unit/desc-budget.test.mjs',
+    'tests/unit/docs-claims.test.mjs',
     'tests/unit/doctor.test.mjs',
     'tests/unit/hook-evidence-gate.test.mjs',
     'tests/unit/hook-io.test.mjs',


### PR DESCRIPTION
Audit findings, all in one direction: the docs were older than the product.

- **`TaskCompleted` was listed as a registered blocking gate.** It is registered nowhere — the runtime knows the event, `hooks.json` puts nothing there. False guarantee, now marked designed-not-registered.
- Three status headers claimed their own subject was unbuilt (retro loop, setup generator, the repo overall). All shipped days ago.
- Three frozen test counts had drifted: 43→47, 46→48, 54→76.

The counts get a **mechanism, not a correction**: `docs-claims.test.mjs` runs the file each doc claims about and fails on disagreement, and fails too when a doc carries an unmapped count.

Writing it surfaced a platform detail: a nested `node --test` under the parent runner's env emits **zero bytes** (`NODE_TEST_CONTEXT` redirects reporting). A laxer implementation reads that as zero and passes.

Three **Mermaid** diagrams replace prose flows — three layers, initiative lifecycle as journal events, event→gate→blocking. GitHub renders them natively.

```
# tests 852 / # pass 852 / # fail 0    RC=0
scan-control-chars: clean (91 tracked text files)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)