### PR TITLE
Field-reported kernel fixes: unsatisfiable lease protocol, GATED that asks, honest journal lifecycle

### DIFF
--- a/docs/journal.md
+++ b/docs/journal.md
@@ -1,6 +1,6 @@
 # Journal reference
 
-`scripts/journal.mjs` · 53 unit tests
+`scripts/journal.mjs` · 54 unit tests
 
 This page is the schema contract; extending the event set is a reviewed core
 change.
@@ -33,7 +33,7 @@ The journal is the append-only source of truth for an initiative:
 | `spawn` | `agent`, `role` | agent started (+ `model`, `ticket`, `worktree`); `agent` must have no open spawn — see below |
 | `report` | `agent`, `verdict` | agent finished (+ `evidence[]: {cmd, exit, counts}`); closes that agent's open spawn |
 | `gate` | `kind`, `result` | quality gate outcome (+ `evidence_ref`) |
-| `review` | `ticket`, `verdict`, `by` | independent review verdict (closes the reviewer’s open spawn) |
+| `review` | `ticket`, `verdict`, `by` | independent review verdict (closes the reviewer’s open spawn — role `reviewer` only) |
 | `merge` | `ticket`, `sha` | merged (+ `mode`) |
 | `decision` | `id`, `text` | ledger entry (`append` issues the id when omitted or empty) |
 | `lease.acquired` | `resource`, `holder` | worktree / heavy-slot lease taken |

--- a/docs/journal.md
+++ b/docs/journal.md
@@ -1,6 +1,6 @@
 # Journal reference
 
-`scripts/journal.mjs` · 49 unit tests
+`scripts/journal.mjs` · 53 unit tests
 
 This page is the schema contract; extending the event set is a reviewed core
 change.
@@ -33,9 +33,9 @@ The journal is the append-only source of truth for an initiative:
 | `spawn` | `agent`, `role` | agent started (+ `model`, `ticket`, `worktree`); `agent` must have no open spawn — see below |
 | `report` | `agent`, `verdict` | agent finished (+ `evidence[]: {cmd, exit, counts}`); closes that agent's open spawn |
 | `gate` | `kind`, `result` | quality gate outcome (+ `evidence_ref`) |
-| `review` | `ticket`, `verdict`, `by` | independent review verdict |
+| `review` | `ticket`, `verdict`, `by` | independent review verdict (closes the reviewer’s open spawn) |
 | `merge` | `ticket`, `sha` | merged (+ `mode`) |
-| `decision` | `id`, `text` | ledger entry (IDs issued via `next-id`) |
+| `decision` | `id`, `text` | ledger entry (`append` issues the id when omitted or empty) |
 | `lease.acquired` | `resource`, `holder` | worktree / heavy-slot lease taken |
 | `lease.released` | `resource`, `holder` | lease returned |
 | `checkpoint` | `phase`, `next_steps` | resume surface (re-injected after compaction) |
@@ -65,9 +65,10 @@ The journal is the append-only source of truth for an initiative:
   whose agent already has a `spawn` with no `report` — see below.
 - **Lease protocol honesty:** a `lease.released` by a non-holder does not
   free the lease — it is surfaced in `tail().mismatchedReleases`.
-- **IDs never from memory:** `journal.mjs next-id <file> D` scans the file
-  and returns `D-<max+1>` — duplicate ledger numbers after a compaction
-  become impossible.
+- **IDs never from memory:** omit `id` (or leave it empty) and `append`
+  scans the file and issues `D-<max+1>` itself — duplicate or blank ledger
+  numbers after a compaction become impossible. `journal.mjs next-id <file> D`
+  previews the next value without appending.
 - **Resume surface:** `journal.mjs tail <file>` returns the latest
   `checkpoint` and all unreleased leases — exactly what the `SessionStart`
   hook re-injects.
@@ -183,6 +184,6 @@ node scripts/journal.mjs query       <file> [--ev E] [--init I] [--ticket T] [--
 node scripts/journal.mjs validate    <file>        # exit 1 on errors; warnings do not fail
 node scripts/journal.mjs next-id     <file> <prefix>
 node scripts/journal.mjs tail        <file>
-node scripts/journal.mjs open-spawns <file>        # agents with no report yet
+node scripts/journal.mjs open-spawns <file>        # agents with no report or review yet
 node scripts/journal.mjs close-spawn <file> <init> <agent> --reason R [--verdict V] [--actor A]
 ```

--- a/docs/policy-gate.md
+++ b/docs/policy-gate.md
@@ -25,11 +25,11 @@ are **supervision**, not merely which actor is running: a subagent's tool calls
 never surface a permission prompt, and neither do a main loop's under
 `acceptEdits` or `bypassPermissions`.
 
-| path class | supervised main loop | subagent, or prompts off |
-|---|---|---|
-| `AUTO` | pass | pass |
-| `GATED` | pass — the platform's own permission prompt **is** the approval | **deny** |
-| `KERNEL` | **deny** | **deny** |
+| path class | supervised main loop | main loop under `acceptEdits` | subagent, or other prompt-less modes |
+|---|---|---|---|
+| `AUTO` | pass | pass | pass |
+| `GATED` | pass — the platform's own permission prompt **is** the approval | **ask** — the gate summons the prompt itself | **deny** |
+| `KERNEL` | **deny** | **deny** | **deny** |
 | **no rule matches, inside `.tyran/` `.claude/` `hooks/`** | the policy's `default:` — `GATED` in the shipped template | |
 | **no rule matches, anywhere else** | pass — see below | pass |
 | **outside the repository** | **deny** | **deny** |
@@ -60,13 +60,19 @@ outside the repository is still `KERNEL`, and `hooks/**` and
 `.tyran/policies/**` are still refused unconditionally, before any rule is
 consulted.
 
-**`GATED` passes in a supervised main loop.** On `PreToolUse` the platform
-offers a gate exactly two answers: `deny`, and silence. There is no "ask" — and
-`permissionDecision: "allow"` is not one either, since it *auto-approves* the
-call and skips the user's prompt. So `GATED` is enforced where no one is asked,
-and delegated where an approval channel already exists. That is what makes
-supervision an axis rather than a detail: treating `acceptEdits` as supervised
-would have made the whole row decorative in the mode agents actually run in.
+**`GATED` passes in a supervised main loop, and asks under `acceptEdits`.**
+On `PreToolUse` a gate has three answers: `deny`, silence, and
+`permissionDecision: "ask"`, which renders the user's own prompt even in a
+mode that auto-accepts edits. (`"allow"` is none of these — it *auto-approves*
+the call and skips the prompt, so this runtime cannot emit it.) So `GATED` is
+delegated where the platform prompts anyway, asked where the MAIN loop has a
+prompt surface that `acceptEdits` merely mutes, and denied where no prompt can
+render at all: every subagent, `bypassPermissions`, and any mode the gate does
+not recognise — an ask a mode might not render must fail toward deny, never
+toward approval. Field measurement, before the ask column existed: under
+`acceptEdits` the operator's own conductor could not perform a GATED write
+anywhere, while the refusal text pointed at a main session that refused the
+same way.
 
 ## The deployment class
 

--- a/hooks/scripts/hook-io.mjs
+++ b/hooks/scripts/hook-io.mjs
@@ -182,6 +182,34 @@ export function refusalPayload(event, reason) {
   return { decision: 'block', reason };
 }
 
+/**
+ * The ask payload for `event` — a REAL question to the user, not a refusal.
+ *
+ * "ask" renders the user's own permission prompt even in a mode that
+ * auto-accepts edits, which is what lets a gate delegate one decision to the
+ * operator instead of choosing between deny and silence. It is only
+ * expressible where the platform models permissionDecision (PreToolUse);
+ * every other event refuses the registration the same way refusalPayload
+ * does, because an ask nobody can render would degrade to silence, and
+ * silence is a pass (ADR-19: an exclusion may never be quiet).
+ */
+export function askPayload(event, reason) {
+  const meta = EVENTS[event];
+  if (meta === undefined || meta.refusal === null) {
+    throw new GateOnProbeEventError(String(event));
+  }
+  if (meta.refusal !== 'permissionDecision') {
+    throw new Error(`"ask" is only expressible where the platform models permissionDecision, not on ${String(event)}`);
+  }
+  return {
+    hookSpecificOutput: {
+      hookEventName: event,
+      permissionDecision: 'ask',
+      permissionDecisionReason: reason,
+    },
+  };
+}
+
 /** The context-injection payload for `event`, or `{}` where it accepts none. */
 export function contextPayload(event, additionalContext) {
   const meta = EVENTS[event];
@@ -458,9 +486,11 @@ function refusalText({ errorClass, message, fix }) {
  *     platform's timeout kills the process and DISCARDS its output, so a
  *     gate that is merely slow is a gate that approves.
  *
- * `handler(input)` returns `PASS` or `{ decision: 'deny', reason }`.
- * Anything else is treated as a bug and refuses — an unrecognised return
- * value must not be able to mean "allow".
+ * `handler(input)` returns `PASS`, `{ decision: 'deny', reason }` or —
+ * on events that model permissionDecision — `{ decision: 'ask', reason }`,
+ * which renders the user's own prompt for exactly this call. Anything else
+ * is treated as a bug and refuses — an unrecognised return value must not
+ * be able to mean "allow".
  *
  * ## What the deadline does and does not promise
  *
@@ -683,8 +713,16 @@ export async function runGate({ event, handler, deadlineMs, io = defaultIo() }) 
         emit(payload);
         return;
       }
+      if (verdict !== null && typeof verdict === 'object' && verdict.decision === 'ask') {
+        const { payload } = clampPayload(
+          (reason) => askPayload(outEvent, reason),
+          sanitizeForOutput(String(verdict.reason ?? 'asked without a stated reason')),
+        );
+        emit(payload);
+        return;
+      }
       throw new Error(
-        `handler returned ${JSON.stringify(verdict)}; expected PASS or { decision: 'deny', reason }`,
+        `handler returned ${JSON.stringify(verdict)}; expected PASS or { decision: 'deny' | 'ask', reason }`,
       );
     } catch (err) {
       refuse(outEvent, describeError(err));

--- a/hooks/scripts/policy-gate.mjs
+++ b/hooks/scripts/policy-gate.mjs
@@ -853,25 +853,31 @@ export function pathTargets(toolInput) {
  *
  * The full matrix, and every cell is a decision rather than a fall-through:
  *
- * | class    | supervised main loop | unsupervised (subagent, or prompts off) |
- * |----------|----------------------|------------------------------------------|
- * | AUTO     | pass                 | pass                                     |
- * | GATED    | pass — the platform's own prompt IS the approval | **deny**      |
- * | KERNEL   | **deny**             | **deny**                                 |
- * | unmatched| = the policy's `default:` (GATED in the shipped template) |     |
+ * | class    | supervised main loop | main, prompts off (askable) | subagent / other |
+ * |----------|----------------------|-----------------------------|------------------|
+ * | AUTO     | pass                 | pass                        | pass             |
+ * | GATED    | pass — the platform's own prompt IS the approval | **ask** — the gate summons the prompt itself | **deny** |
+ * | KERNEL   | **deny**             | **deny**                    | **deny**         |
+ * | unmatched| = the policy's `default:` (GATED in the shipped template) |  |  |
  *
- * The GATED row is the one worth arguing. On PreToolUse the platform offers
- * exactly two answers, `deny` and silence; there is no "ask" this runtime can
- * emit, and inventing one means editing hook-io, which is a different
- * decision than this story's. So GATED is delegated where an approval channel
- * already exists — the user's own permission prompt — and enforced where it
- * does not. That is why supervision, not just actor, is an axis: under
- * `acceptEdits` the main loop has no prompt either, and treating it as
- * supervised would have made the whole row decorative.
+ * The GATED row is the one worth arguing. hook-io can emit a third answer —
+ * an "ask" — which renders the user's own prompt even in a mode that
+ * auto-accepts edits, so GATED can mean what ADR-06 says it means wherever a
+ * prompt can render. `askable` is that fact as an argument: the caller sets
+ * it only for the MAIN loop under `acceptEdits`, the mode agents actually
+ * run in. It stays false under `bypassPermissions` and unknown modes — an
+ * ask a mode might not render must fail toward deny, never toward approval —
+ * and false for every subagent, whose calls have no prompt surface at all.
+ * Measured before this cell existed: under `acceptEdits` the operator's own
+ * conductor could not perform a GATED write anywhere, while the refusal text
+ * pointed at a main session that refused exactly the same way.
  */
-export function verdictForClass(cls, unsupervised) {
+export function verdictForClass(cls, unsupervised, askable = false) {
   if (cls === 'KERNEL') return 'deny';
-  if (cls === 'GATED') return unsupervised ? 'deny' : 'pass';
+  if (cls === 'GATED') {
+    if (!unsupervised) return 'pass';
+    return askable ? 'ask' : 'deny';
+  }
   if (cls === 'AUTO') return 'pass';
   // An unrecognised class cannot be resolved to a permission. validatePolicy
   // rejects one, so reaching here means the resolver and the validator
@@ -1032,6 +1038,10 @@ export async function decide({ input, runner = runChild, startedAt = Date.now(),
   const root = repoRootOf(input, env);
   const unsupervised = isUnsupervised(input);
   const actor = actorOf(input);
+  // The one mode where an unsupervised main loop still renders an ask.
+  // Deliberately not "any unsupervised main": bypassPermissions and unknown
+  // modes must keep the hard deny — see verdictForClass's matrix.
+  const askable = actor === 'main' && field(input, 'permission_mode') === 'acceptEdits';
 
   if (toolName === 'Bash') return await decideBash({ input, toolInput, root, runner, budget });
 
@@ -1146,7 +1156,7 @@ export async function decide({ input, runner = runChild, startedAt = Date.now(),
     if (normalized !== null && decidingRule(policy, normalized) === null && !isGoverned(normalized)) {
       continue;
     }
-    const verdict = verdictForClass(cls, unsupervised);
+    const verdict = verdictForClass(cls, unsupervised, askable);
 
     // ADR-21, applied as a check rather than as a refactor: the rule this
     // refusal names and the class the resolver returned must agree. They are
@@ -1162,6 +1172,19 @@ export async function decide({ input, runner = runChild, startedAt = Date.now(),
     }
 
     if (verdict === 'pass') continue;
+    if (verdict === 'ask') {
+      return {
+        decision: 'ask',
+        reason:
+          `tyran policy-gate: this write is GATED — your approval IS the gate. ` +
+          `${describeTarget(target, normalized)}\n` +
+          `class: ${safePolicyText(cls)} · actor: ${actor} · permission_mode: ` +
+          `${safePolicyText(String(field(input, 'permission_mode') ?? '(absent)'))}\n` +
+          `rule: ${quoteRule(policy, normalized, cls)}\n` +
+          'Approve to perform exactly this write, once. Decline and the agent is told to put ' +
+          'the change in its report instead.',
+      };
+    }
     return {
       decision: 'deny',
       reason:

--- a/hooks/scripts/secrets-gate.mjs
+++ b/hooks/scripts/secrets-gate.mjs
@@ -705,8 +705,10 @@ export function planCommand(command, startDir) {
       if (!lower.includes('core.hookspath')) return false;
       if (lower.includes('core.hookspath=')) return true;
       if (!words.has('config')) return false;
-      const next = raw[i + 1];
-      return next !== undefined && !next.startsWith('-');
+      // ANY following token can be the value: git stores "-evildir" verbatim
+      // rather than rejecting it as a flag (review finding, verified against
+      // real git). A query puts the key LAST, so key-then-anything is a set.
+      return raw[i + 1] !== undefined;
     });
     if (hooksPathOverride) {
       denials.push({

--- a/hooks/scripts/secrets-gate.mjs
+++ b/hooks/scripts/secrets-gate.mjs
@@ -694,11 +694,25 @@ export function planCommand(command, startDir) {
         break;
       }
     }
-    if (raw.some((t) => t.toLowerCase().includes('core.hookspath'))) {
+    // Only the OVERRIDE forms disable hooks: `core.hooksPath=DIR` in any
+    // spelling, or `git config core.hooksPath DIR` (a following value). A bare
+    // query — `git config [--get] core.hooksPath` — reads the very state this
+    // rule protects, and refusing it was measured mid-incident: the command run
+    // to find out WHICH hook had just refused a push was itself refused. A gate
+    // that blocks reading its own subject teaches routing around, not caution.
+    const hooksPathOverride = raw.some((t, i) => {
+      const lower = t.toLowerCase();
+      if (!lower.includes('core.hookspath')) return false;
+      if (lower.includes('core.hookspath=')) return true;
+      if (!words.has('config')) return false;
+      const next = raw[i + 1];
+      return next !== undefined && !next.startsWith('-');
+    });
+    if (hooksPathOverride) {
       denials.push({
         code: DENIAL_CODES.HOOKS_PATH,
         detail: "`core.hooksPath` is being overridden, which disables git's hooks for this command",
-        remedy: 'run the command without -c core.hooksPath=...',
+        remedy: 'run the command without -c core.hooksPath=... (a bare `git config core.hooksPath` query is fine)',
       });
     }
     if (gitCommit && tokens.some((t) => isShortCluster(t) && t.includes('n'))) {

--- a/scripts/journal.mjs
+++ b/scripts/journal.mjs
@@ -15,7 +15,7 @@
  *   node journal.mjs validate    <file>
  *   node journal.mjs next-id     <file> <prefix>   # e.g. prefix D -> D-7
  *   node journal.mjs tail        <file>            # last checkpoint + open items
- *   node journal.mjs open-spawns <file>            # agents with no report yet
+ *   node journal.mjs open-spawns <file>            # agents with no report or review yet
  *   node journal.mjs close-spawn <file> <init> <agent> --reason R [--verdict V]
  * Exit: 0 ok · 1 validation/finding error · 2 usage/IO error
  */
@@ -179,7 +179,8 @@ export function agentNameProblem(name) {
 
 /**
  * Pair `spawn` events with `report` events by agent name, in file order:
- * a report closes the OLDEST still-open spawn of that name (FIFO). This is
+ * a report closes the OLDEST still-open spawn of that name (FIFO), and a
+ * `review` closes its reviewer the same way, correlated by `data.by`. This is
  * the one and only pairing rule — `append` enforces that it can never be
  * ambiguous (ADR-18: at most one open spawn per name), so consumers such as
  * the projection generator implement a guarantee, not a heuristic.
@@ -210,10 +211,18 @@ export function pairSpawns(events) {
    */
   const ambiguous = new Map(); // agent -> the largest number of spawns open at once
   for (const e of events) {
-    if (e?.ev !== 'spawn' && e?.ev !== 'report') continue;
-    const agent = e.data?.agent;
+    if (e?.ev !== 'spawn' && e?.ev !== 'report' && e?.ev !== 'review') continue;
+    // A reviewer never files a `report` about itself — its verdict IS its
+    // completion. Measured in the field: reviewers spawned per iron rule 3
+    // stayed "still working" in the session-start probe for days, because
+    // only reports closed spawns. A review's correlator is `data.by`.
+    const isReview = e.ev === 'review';
+    const agent = isReview ? e.data?.by : e.data?.agent;
     const problem = agentNameProblem(agent);
     if (problem) {
+      // A review is a verdict record first; an uncorrelatable `by` is not an
+      // agent-lifecycle defect, so it stays out of the unusable set.
+      if (isReview) continue;
       badNames.set(JSON.stringify(agent ?? null), problem);
       unusable.push({ event: e, problem });
       continue; // unusable as a correlator; validate() reports it
@@ -229,13 +238,20 @@ export function pairSpawns(events) {
         const spawn = queue.shift();
         pairs.push({ spawn, report: e });
         if (queue.length === 0) open.delete(agent);
+      } else if (isReview) {
+        // A review by a never-spawned (or already-closed) actor is ordinary —
+        // a verdict does not require a lifecycle to close.
+      } else if (e.data?.closed_by === 'close-spawn') {
+        // Journals written before reviews closed spawns carry a close-spawn
+        // report right after the review that now closes the same spawn:
+        // redundant, not orphaned — flagging it would fail history retroactively.
       } else orphanReports.push(e);
     }
   }
   return { open, orphanReports, badNames, pairs, unusable, ambiguous };
 }
 
-/** Agents whose `spawn` has no matching `report` yet — the "still working" set. */
+/** Agents whose `spawn` has no matching `report` or `review` yet — the "still working" set. */
 export function openSpawns(file) {
   const { open } = pairSpawns(readJournal(file).events);
   return [...open.values()].flat().map((e) => ({
@@ -663,8 +679,11 @@ function main() {
         // the exact failure the rule names, with nothing objecting.
         //
         // A rule in prose loses to a mechanism that makes the mistake
-        // impossible. This is that mechanism, and an explicit id still wins.
-        if (ID_ISSUED_FOR[ev] !== undefined && data.id === undefined) {
+        // impossible. This is that mechanism, and an explicit id still wins —
+        // but `"id":""` is not explicit: a conductor recovering from next-id's
+        // usage error supplied exactly that, three times, and the ledger kept
+        // three permanently blank ids nothing can reference.
+        if (ID_ISSUED_FOR[ev] !== undefined && (data.id === undefined || data.id === '')) {
           data.id = nextId(file, ID_ISSUED_FOR[ev]);
         }
         const written = append(file, { ev, init, actor: flags.actor ?? 'conductor', data });

--- a/scripts/journal.mjs
+++ b/scripts/journal.mjs
@@ -180,7 +180,10 @@ export function agentNameProblem(name) {
 /**
  * Pair `spawn` events with `report` events by agent name, in file order:
  * a report closes the OLDEST still-open spawn of that name (FIFO), and a
- * `review` closes its reviewer the same way, correlated by `data.by`. This is
+ * `review` closes its reviewer the same way, correlated by `data.by` — but
+ * only a spawn whose `role` is `reviewer`: `by` is a free string, and a
+ * collision with a still-working implementer's name must not mark that
+ * implementer reported with a verdict it never earned. This is
  * the one and only pairing rule — `append` enforces that it can never be
  * ambiguous (ADR-18: at most one open spawn per name), so consumers such as
  * the projection generator implement a guarantee, not a heuristic.
@@ -234,7 +237,8 @@ export function pairSpawns(events) {
       if (depth > 1 && depth > (ambiguous.get(agent) ?? 0)) ambiguous.set(agent, depth);
     } else {
       const queue = open.get(agent);
-      if (queue?.length) {
+      const closable = queue?.length && (!isReview || queue[0].data?.role === 'reviewer');
+      if (closable) {
         const spawn = queue.shift();
         pairs.push({ spawn, report: e });
         if (queue.length === 0) open.delete(agent);

--- a/site/src/content/docs/journal.mdx
+++ b/site/src/content/docs/journal.mdx
@@ -6,7 +6,7 @@ import { FileTree } from '@astrojs/starlight/components';
 import Provenance from '../../components/Provenance.astro';
 
 <Provenance>
-`scripts/journal.mjs` · 49 unit tests
+`scripts/journal.mjs` · 53 unit tests
 </Provenance>
 
 This page is the schema contract; extending the event set is a reviewed core
@@ -51,9 +51,9 @@ The journal is the append-only source of truth for an initiative:
 | `spawn` | `agent`, `role` | agent started (+ `model`, `ticket`, `worktree`); `agent` must have no open spawn — see below |
 | `report` | `agent`, `verdict` | agent finished (+ `evidence[]: {cmd, exit, counts}`); closes that agent's open spawn |
 | `gate` | `kind`, `result` | quality gate outcome (+ `evidence_ref`) |
-| `review` | `ticket`, `verdict`, `by` | independent review verdict |
+| `review` | `ticket`, `verdict`, `by` | independent review verdict (closes the reviewer’s open spawn) |
 | `merge` | `ticket`, `sha` | merged (+ `mode`) |
-| `decision` | `id`, `text` | ledger entry (IDs issued via `next-id`) |
+| `decision` | `id`, `text` | ledger entry (`append` issues the id when omitted or empty) |
 | `lease.acquired` | `resource`, `holder` | worktree / heavy-slot lease taken |
 | `lease.released` | `resource`, `holder` | lease returned |
 | `checkpoint` | `phase`, `next_steps` | resume surface (re-injected after compaction) |
@@ -107,9 +107,10 @@ flowchart TB
   whose agent already has a `spawn` with no `report` — see below.
 - **Lease protocol honesty:** a `lease.released` by a non-holder does not
   free the lease — it is surfaced in `tail().mismatchedReleases`.
-- **IDs never from memory:** `journal.mjs next-id <file> D` scans the file
-  and returns `D-<max+1>` — duplicate ledger numbers after a compaction
-  become impossible.
+- **IDs never from memory:** omit `id` (or leave it empty) and `append`
+  scans the file and issues `D-<max+1>` itself — duplicate or blank ledger
+  numbers after a compaction become impossible. `journal.mjs next-id <file> D`
+  previews the next value without appending.
 - **Resume surface:** `journal.mjs tail <file>` returns the latest
   `checkpoint` and all unreleased leases — exactly what the `SessionStart`
   hook re-injects.
@@ -225,6 +226,6 @@ node scripts/journal.mjs query       <file> [--ev E] [--init I] [--ticket T] [--
 node scripts/journal.mjs validate    <file>        # exit 1 on errors; warnings do not fail
 node scripts/journal.mjs next-id     <file> <prefix>
 node scripts/journal.mjs tail        <file>
-node scripts/journal.mjs open-spawns <file>        # agents with no report yet
+node scripts/journal.mjs open-spawns <file>        # agents with no report or review yet
 node scripts/journal.mjs close-spawn <file> <init> <agent> --reason R [--verdict V] [--actor A]
 ```

--- a/site/src/content/docs/journal.mdx
+++ b/site/src/content/docs/journal.mdx
@@ -6,7 +6,7 @@ import { FileTree } from '@astrojs/starlight/components';
 import Provenance from '../../components/Provenance.astro';
 
 <Provenance>
-`scripts/journal.mjs` · 53 unit tests
+`scripts/journal.mjs` · 54 unit tests
 </Provenance>
 
 This page is the schema contract; extending the event set is a reviewed core
@@ -51,7 +51,7 @@ The journal is the append-only source of truth for an initiative:
 | `spawn` | `agent`, `role` | agent started (+ `model`, `ticket`, `worktree`); `agent` must have no open spawn — see below |
 | `report` | `agent`, `verdict` | agent finished (+ `evidence[]: {cmd, exit, counts}`); closes that agent's open spawn |
 | `gate` | `kind`, `result` | quality gate outcome (+ `evidence_ref`) |
-| `review` | `ticket`, `verdict`, `by` | independent review verdict (closes the reviewer’s open spawn) |
+| `review` | `ticket`, `verdict`, `by` | independent review verdict (closes the reviewer’s open spawn — role `reviewer` only) |
 | `merge` | `ticket`, `sha` | merged (+ `mode`) |
 | `decision` | `id`, `text` | ledger entry (`append` issues the id when omitted or empty) |
 | `lease.acquired` | `resource`, `holder` | worktree / heavy-slot lease taken |

--- a/site/src/content/docs/policy-gate.mdx
+++ b/site/src/content/docs/policy-gate.mdx
@@ -32,11 +32,11 @@ are **supervision**, not merely which actor is running: a subagent's tool calls
 never surface a permission prompt, and neither do a main loop's under
 `acceptEdits` or `bypassPermissions`.
 
-| path class | supervised main loop | subagent, or prompts off |
-|---|---|---|
-| `AUTO` | pass | pass |
-| `GATED` | pass — the platform's own permission prompt **is** the approval | **deny** |
-| `KERNEL` | **deny** | **deny** |
+| path class | supervised main loop | main loop under `acceptEdits` | subagent, or other prompt-less modes |
+|---|---|---|---|
+| `AUTO` | pass | pass | pass |
+| `GATED` | pass — the platform's own permission prompt **is** the approval | **ask** — the gate summons the prompt itself | **deny** |
+| `KERNEL` | **deny** | **deny** | **deny** |
 | **no rule matches, inside `.tyran/` `.claude/` `hooks/`** | the policy's `default:` — `GATED` in the shipped template | |
 | **no rule matches, anywhere else** | pass — see below | pass |
 | **outside the repository** | **deny** | **deny** |
@@ -67,13 +67,19 @@ outside the repository is still `KERNEL`, and `hooks/**` and
 `.tyran/policies/**` are still refused unconditionally, before any rule is
 consulted.
 
-**`GATED` passes in a supervised main loop.** On `PreToolUse` the platform
-offers a gate exactly two answers: `deny`, and silence. There is no "ask" — and
-`permissionDecision: "allow"` is not one either, since it *auto-approves* the
-call and skips the user's prompt. So `GATED` is enforced where no one is asked,
-and delegated where an approval channel already exists. That is what makes
-supervision an axis rather than a detail: treating `acceptEdits` as supervised
-would have made the whole row decorative in the mode agents actually run in.
+**`GATED` passes in a supervised main loop, and asks under `acceptEdits`.**
+On `PreToolUse` a gate has three answers: `deny`, silence, and
+`permissionDecision: "ask"`, which renders the user's own prompt even in a
+mode that auto-accepts edits. (`"allow"` is none of these — it *auto-approves*
+the call and skips the prompt, so this runtime cannot emit it.) So `GATED` is
+delegated where the platform prompts anyway, asked where the MAIN loop has a
+prompt surface that `acceptEdits` merely mutes, and denied where no prompt can
+render at all: every subagent, `bypassPermissions`, and any mode the gate does
+not recognise — an ask a mode might not render must fail toward deny, never
+toward approval. Field measurement, before the ask column existed: under
+`acceptEdits` the operator's own conductor could not perform a GATED write
+anywhere, while the refusal text pointed at a main session that refused the
+same way.
 
 ## The deployment class
 

--- a/skills/code-review/SKILL.md
+++ b/skills/code-review/SKILL.md
@@ -46,7 +46,15 @@ gap nobody notices.
   is broken? Delete a line of the implementation in your head and ask which
   test goes red — if the answer is none, the test asserts nothing. Watch for a
   test that pins the CURRENT output rather than the CORRECT one, which converts
-  a bug into a requirement.
+  a bug into a requirement. And watch what the test's OWN inputs are made of:
+  a fixture that hand-builds a value another function normally derives (a
+  mapper, a parser, a coercion) exercises only the consumer of that value,
+  never the step that derives it, and can pin THAT step's defect as correct
+  without ever calling it. A three-state flag silently collapsed to two states
+  survived two review rounds this way — every guard test hand-built the
+  post-coercion object, and the only two tests that called the real producer
+  were themselves asserting the coerced, wrong value. Trace at least one test
+  through the real producer, not a stand-in for its output.
 - **Resource lifecycle.** What is opened, started, spawned or leased, and where
   it is closed — including on the path where an exception is thrown.
 - **The gate itself.** If the change touches a check, ask what that check can

--- a/skills/run/SKILL.md
+++ b/skills/run/SKILL.md
@@ -143,8 +143,19 @@ open one.
    and **signals about the PROCESS itself**: what slowed the work, what the
    handoff was missing, what a gate let through — this is the raw material
    `tyran:retro` reads). After a compaction or restart, read these FIRST.
-   - **IDs never come from memory** — `journal.mjs next-id` issues them.
-     After a compaction, memory hands out the same number twice.
+   - **A file write is not a git commit.** `journal.mjs append` only ever
+     touches the working tree. Stage and commit `.tyran/state/<initiative>/**`
+     explicitly (never `-A`) at every merge, not only when the initiative
+     closes — a backstop that fires once, at the end, depends on whoever
+     closes the initiative both remembering to check and being permitted to
+     commit, and measured three times in one repository, neither held. An
+     initiative whose journal never reaches history is one `git clean -fd`
+     away from having never happened.
+   - **IDs never come from memory** — omit `id` from a `decision` event's
+     `--data` (or leave it empty) and `append` issues the next one itself.
+     `journal.mjs next-id <file> <prefix>` exists to preview a value ahead of
+     time (prefix `D` → `D-7`); it is not a required preliminary step before
+     `append`. After a compaction, memory hands out the same number twice.
    - **Authorizations and stops are `decision` events.** What you may do
      without asking, and the CLOSED list of situations where you halt, live
      in the journal with the date and the operator's own words. Outside that
@@ -279,6 +290,10 @@ open one.
      existing unexpired lease means the agent refuses to start and reports —
      and ENDS by releasing it. Assigning slots from your own memory is
      forbidden: the lead's memory is the least reliable store in the system.
+     If the policy gate refuses the lease write — an install whose repo-local
+     `autonomy.yaml` predates the `locks/**` AUTO rule — fall back to
+     `lease.acquired`/`lease.released` events in the journal, same holder,
+     purpose and expiry, conductor-written, rather than working unleased.
    - **Preflight a heavy slot** on acquisition: check free disk against a
      threshold, clear known caches above it, and reap the previous holder's
      orphaned processes with SIGTERM rather than `kill -9`.
@@ -322,6 +337,9 @@ open one.
   so is judging the work too small to be worth one. Either way, record a
   `retro.entry` — `kind: skipped` with a reason is a complete answer — and
   the gate is satisfied. You will not be blocked twice.
+  Dispatching the retro as a background agent? Record a `retro.entry` with
+  `kind: spawned` at dispatch time — the gate anchors on the entry, not the
+  agent, and will otherwise stop you once while the retro is still running.
 - **Leases you took, you release.** Before you finish, check the ledger for
   a lease still held by an agent that has already reported. An orphaned lease
   blocks the next initiative from a resource nobody is using, and the person

--- a/templates/policies/autonomy.yaml
+++ b/templates/policies/autonomy.yaml
@@ -32,6 +32,28 @@ rules:
     class: AUTO
     reason: the execution journal is append-only and written by the conductor itself
 
+  # Measured on a real initiative: iron rule 7 says "a handoff BEGINS by taking
+  # the lease" and ENDS by releasing it — but leases live under
+  # `.tyran/initiatives/<slug>/locks/`, which matched NO rule here, so it fell
+  # through to `default: GATED`. A subagent is ALWAYS unsupervised, and
+  # `verdictForClass(GATED, unsupervised)` denies unconditionally. So the lease
+  # protocol the conductor skill mandates could not be satisfied by any
+  # implementer, in any repo, under the shipped template — the agent either
+  # reported the refusal (correct, and what happened) or quietly worked without
+  # the lease, which is the failure mode leases exist to prevent. The conductor
+  # had to write every lease itself, which puts the record of who holds a
+  # resource in the one place iron rule 7 says it must not live: the lead.
+  #
+  # AUTO is the safe class here precisely because these are not history: the
+  # repo's own .gitignore excludes `.tyran/initiatives/*/locks/`, so nothing
+  # under it is version-controlled and the blast radius of a bad write is a
+  # stale lock file, cleared by deleting it. Scoped to `locks/` deliberately
+  # rather than all of `.tyran/initiatives/**`, so anything else that comes to
+  # live under an initiative keeps the stricter default.
+  - path: .tyran/initiatives/*/locks/**
+    class: AUTO
+    reason: runtime worktree and heavy-slot leases, gitignored and not history; GATED denies every subagent unconditionally, which makes the take-your-own-lease protocol of iron rule 7 unsatisfiable
+
   # Was GATED. The cost was measured on a real install: setup had inferred
   # `pnpm test`, which in that repo is bare `vitest` — it never exits, so every
   # agent would have hung forever. The session that FOUND that could not fix it,

--- a/tests/unit/hook-io.test.mjs
+++ b/tests/unit/hook-io.test.mjs
@@ -23,6 +23,7 @@ import {
   parseHookInput,
   readStdin,
   refusalPayload,
+  askPayload,
   resolveEvent,
   runGate,
   runProbe,
@@ -702,4 +703,32 @@ test('a probe clamps its injection to the platform limit and reports the cut', a
   assert.equal(payload.hookSpecificOutput.hookEventName, 'SessionStart');
   assert.match(payload.hookSpecificOutput.additionalContext, /output truncated/);
   assert.match(io.err.join(''), /injected context truncated/);
+});
+
+// ------------------------------------------------ ask: the third answer
+
+test('askPayload emits an ask decision for PreToolUse only', () => {
+  assert.deepEqual(askPayload('PreToolUse', 'because'), {
+    hookSpecificOutput: {
+      hookEventName: 'PreToolUse',
+      permissionDecision: 'ask',
+      permissionDecisionReason: 'because',
+    },
+  });
+  assert.throws(() => askPayload('SessionStart', 'x'), GateOnProbeEventError);
+  assert.throws(() => askPayload('Stop', 'x'), /only expressible/);
+});
+
+test('runGate emits the ask payload when the handler asks', async () => {
+  const io = fakeIo(inputFor('PreToolUse'));
+  await runGate({
+    event: 'PreToolUse',
+    deadlineMs: 1000,
+    io,
+    handler: () => ({ decision: 'ask', reason: 'your call' }),
+  });
+  const payload = soleOutput(io);
+  assert.equal(payload.hookSpecificOutput.permissionDecision, 'ask');
+  assert.equal(payload.hookSpecificOutput.permissionDecisionReason, 'your call');
+  assert.deepEqual(io.codes, [0]);
 });

--- a/tests/unit/hook-policy-gate.test.mjs
+++ b/tests/unit/hook-policy-gate.test.mjs
@@ -176,7 +176,7 @@ const MATRIX = [
   // class. If it ever stops passing for a subagent the template moved, and
   // that should be a decision someone makes, not a diff nobody notices.
   { cls: 'AUTO', path: '.tyran/config.yaml', supervised: 'pass', unsupervised: 'pass' },
-  { cls: 'GATED', path: '.claude/agents/reviewer.md', supervised: 'pass', unsupervised: 'deny' },
+  { cls: 'GATED', path: '.claude/agents/reviewer.md', supervised: 'pass', unsupervised: 'deny', mainPromptsOff: 'ask' },
   { cls: 'KERNEL', path: 'hooks/scripts/secrets-gate.mjs', supervised: 'deny', unsupervised: 'deny' },
   { cls: 'KERNEL', path: '.tyran/policies/autonomy.yaml', supervised: 'deny', unsupervised: 'deny' },
   // The unmatched row, which is TWO rows. Neither is a fall-through.
@@ -184,7 +184,7 @@ const MATRIX = [
   // Inside the governed namespace — Tyran's own artefacts, which the policy is
   // meant to enumerate — an unmatched path takes the policy's `default:`,
   // GATED in the shipped template, and behaves exactly like the GATED rows.
-  { cls: 'default (GATED), governed', path: '.tyran/something-new.yaml', supervised: 'pass', unsupervised: 'deny' },
+  { cls: 'default (GATED), governed', path: '.tyran/something-new.yaml', supervised: 'pass', unsupervised: 'deny', mainPromptsOff: 'ask' },
   { cls: 'KERNEL (hook registry)', path: '.claude/settings.json', supervised: 'deny', unsupervised: 'deny' },
   { cls: 'default (GATED), governed', path: 'hooks/notes.md', supervised: 'deny', unsupervised: 'deny' },
   // Outside it the policy has nothing to say and the gate is silent. Measured
@@ -211,13 +211,15 @@ for (const row of MATRIX) {
     assert.equal(got === PASS || got.decision === 'pass' ? 'pass' : got.decision, row.unsupervised);
   });
 
-  test(`matrix: ${row.cls} · ${row.path} · main loop with prompts off -> ${row.unsupervised}`, async () => {
+  const promptsOff = row.mainPromptsOff ?? row.unsupervised;
+  test(`matrix: ${row.cls} · ${row.path} · main loop with prompts off -> ${promptsOff}`, async () => {
     // The axis is SUPERVISION, not just the actor. Under `acceptEdits` the
-    // main loop has no prompt either, so treating actor as the whole story
-    // would make the GATED row decorative in the mode agents actually run in.
+    // main loop auto-accepts, so it counts as unsupervised — but unlike a
+    // subagent it still HAS a prompt surface, so GATED asks there instead of
+    // denying. The hard deny stays where no prompt can render.
     const root = adopted();
     const got = await askWrite(root, row.path, { mode: 'acceptEdits' });
-    assert.equal(got === PASS || got.decision === 'pass' ? 'pass' : got.decision, row.unsupervised);
+    assert.equal(got === PASS || got.decision === 'pass' ? 'pass' : got.decision, promptsOff);
   });
 }
 
@@ -1705,4 +1707,30 @@ test('loadMainWritablePaths expands ~, and a repo with no config is []', async (
   assert.ok(got[0].startsWith(homedir()), got[0]);
   assert.ok(got[0].endsWith('/plans/**'), got[0]);
   assert.deepEqual(await loadMainWritablePaths(unadopted()), []);
+});
+
+// =============================== GATED asks the main loop under acceptEdits
+
+test('verdictForClass: GATED unsupervised is ask only when askable', () => {
+  assert.equal(verdictForClass('GATED', true, true), 'ask');
+  assert.equal(verdictForClass('GATED', true, false), 'deny');
+  assert.equal(verdictForClass('GATED', true), 'deny'); // askable defaults off: fail-closed
+  assert.equal(verdictForClass('GATED', false, true), 'pass'); // supervised never double-prompts
+  assert.equal(verdictForClass('KERNEL', true, true), 'deny'); // ask never unlocks KERNEL
+  assert.equal(verdictForClass('AUTO', true, true), 'pass');
+});
+
+test('GATED + main + bypassPermissions stays deny — an ask nobody renders must not degrade', async () => {
+  const root = adopted();
+  const got = await askWrite(root, '.claude/agents/reviewer.md', { mode: 'bypassPermissions' });
+  assert.equal(got.decision, 'deny');
+});
+
+test('GATED + main + acceptEdits asks; a subagent in the same mode still gets deny', async () => {
+  const root = adopted();
+  const got = await askWrite(root, '.claude/agents/reviewer.md', { mode: 'acceptEdits' });
+  assert.equal(got.decision, 'ask');
+  assert.match(got.reason, /approv/i);
+  const sub = await askWrite(root, '.claude/agents/reviewer.md', { mode: 'acceptEdits', agentId: 'a1' });
+  assert.equal(sub.decision, 'deny');
 });

--- a/tests/unit/hook-policy-gate.test.mjs
+++ b/tests/unit/hook-policy-gate.test.mjs
@@ -176,6 +176,10 @@ const MATRIX = [
   // class. If it ever stops passing for a subagent the template moved, and
   // that should be a decision someone makes, not a diff nobody notices.
   { cls: 'AUTO', path: '.tyran/config.yaml', supervised: 'pass', unsupervised: 'pass' },
+  // The lease rule exists because iron rule 7's take-your-own-lease protocol
+  // was unsatisfiable without it — measured on two initiatives. This row is
+  // what stops a future template edit from silently reintroducing that.
+  { cls: 'AUTO (leases)', path: '.tyran/initiatives/demo/locks/worktree-a.lease', supervised: 'pass', unsupervised: 'pass' },
   { cls: 'GATED', path: '.claude/agents/reviewer.md', supervised: 'pass', unsupervised: 'deny', mainPromptsOff: 'ask' },
   { cls: 'KERNEL', path: 'hooks/scripts/secrets-gate.mjs', supervised: 'deny', unsupervised: 'deny' },
   { cls: 'KERNEL', path: '.tyran/policies/autonomy.yaml', supervised: 'deny', unsupervised: 'deny' },

--- a/tests/unit/hook-secrets-gate.test.mjs
+++ b/tests/unit/hook-secrets-gate.test.mjs
@@ -1388,3 +1388,16 @@ test('the alias rule costs two commands in fourteen, not a working day', async (
   }
   assert.deepEqual(flagged, ['git -c alias.zz=push zz origin main', 'git config alias.up push']);
 });
+
+test('a read-only core.hooksPath query is not a hooks bypass', () => {
+  // Measured in the field: a mid-incident `git config core.hooksPath` read,
+  // run to find out WHICH hook had just refused a push, was itself refused.
+  assert.deepEqual(planCommand('git config core.hooksPath', '/r').denials, []);
+  assert.deepEqual(planCommand('git config --get core.hooksPath', '/r').denials, []);
+});
+
+test('setting core.hooksPath via git config is still refused', () => {
+  assert.deepEqual(planCommand('git config core.hooksPath /dev/null', '/r').denials.map((d) => d.code), [
+    DENIAL_CODES.HOOKS_PATH,
+  ]);
+});

--- a/tests/unit/hook-secrets-gate.test.mjs
+++ b/tests/unit/hook-secrets-gate.test.mjs
@@ -1401,3 +1401,11 @@ test('setting core.hooksPath via git config is still refused', () => {
     DENIAL_CODES.HOOKS_PATH,
   ]);
 });
+
+test('a dash-prefixed value is still a value: setting the hooks path with it is refused', () => {
+  // Review finding, verified against real git: `git config` stores "-evildir"
+  // as the value rather than rejecting it as a flag, so hooks are disabled.
+  assert.deepEqual(planCommand('git config core.hooksPath -evildir', '/r').denials.map((d) => d.code), [
+    DENIAL_CODES.HOOKS_PATH,
+  ]);
+});

--- a/tests/unit/journal.test.mjs
+++ b/tests/unit/journal.test.mjs
@@ -880,3 +880,55 @@ test('validateJournal messages carry no raw journal values', () => {
     );
   }
 });
+
+// --- field fixes: reviews close reviewer spawns; empty ids are issued ---
+
+const reviewEv = (by, { data = {}, ...over } = {}) => ({
+  ev: 'review',
+  init: 'demo',
+  actor: by,
+  ...over,
+  data: { ticket: 'T-1', verdict: 'APPROVE', by, ...data },
+});
+
+test('a review whose `by` names an open spawn closes it, like a report', () => {
+  const f = tmp();
+  append(f, spawnEv('reviewer-1', { data: { role: 'reviewer' } }));
+  append(f, reviewEv('reviewer-1'));
+  assert.deepEqual(openSpawns(f), []);
+  // the pairing is visible to consumers, verdict included
+  const { pairs } = pairSpawns(readJournal(f).events);
+  assert.equal(pairs.length, 1);
+  assert.equal(pairs[0].report.data.verdict, 'APPROVE');
+  // ADR-18 still holds: the name can be spawned again, once
+  append(f, spawnEv('reviewer-1'));
+  assert.throws(() => append(f, spawnEv('reviewer-1')), /already has an open spawn/);
+});
+
+test('a review with no open spawn of that name is not an orphan', () => {
+  const f = tmp();
+  append(f, reviewEv('never-spawned'));
+  const { orphanReports, unusable } = pairSpawns(readJournal(f).events);
+  assert.deepEqual(orphanReports, []);
+  assert.deepEqual(unusable, []);
+  assert.equal(validateJournal(f).ok, true);
+});
+
+test('legacy close-spawn report after a review-closure is not an orphan', () => {
+  const f = tmp();
+  append(f, spawnEv('reviewer-1'));
+  append(f, reviewEv('reviewer-1')); // closes the spawn under the new rule
+  // a journal written under the old rule then carries the close-spawn report:
+  append(f, reportEv('reviewer-1', { data: { closed_by: 'close-spawn' } }));
+  assert.deepEqual(pairSpawns(readJournal(f).events).orphanReports, []);
+  // a stray ORDINARY report with no spawn is still an orphan
+  append(f, reportEv('reviewer-1'));
+  assert.equal(pairSpawns(readJournal(f).events).orphanReports.length, 1);
+});
+
+test('an explicit empty data.id is issued by CLI append, not stored blank', () => {
+  const f = tmp();
+  execFileSync(process.execPath, [SCRIPT, 'append', f, 'decision', 'demo', '--data', '{"id":"","text":"picked a default"}']);
+  execFileSync(process.execPath, [SCRIPT, 'append', f, 'decision', 'demo', '--data', '{"id":"","text":"second"}']);
+  assert.deepEqual(query(f, { ev: 'decision' }).map((e) => e.data.id), ['D-1', 'D-2']);
+});

--- a/tests/unit/journal.test.mjs
+++ b/tests/unit/journal.test.mjs
@@ -916,7 +916,7 @@ test('a review with no open spawn of that name is not an orphan', () => {
 
 test('legacy close-spawn report after a review-closure is not an orphan', () => {
   const f = tmp();
-  append(f, spawnEv('reviewer-1'));
+  append(f, spawnEv('reviewer-1', { data: { role: 'reviewer' } }));
   append(f, reviewEv('reviewer-1')); // closes the spawn under the new rule
   // a journal written under the old rule then carries the close-spawn report:
   append(f, reportEv('reviewer-1', { data: { closed_by: 'close-spawn' } }));
@@ -931,4 +931,16 @@ test('an explicit empty data.id is issued by CLI append, not stored blank', () =
   execFileSync(process.execPath, [SCRIPT, 'append', f, 'decision', 'demo', '--data', '{"id":"","text":"picked a default"}']);
   execFileSync(process.execPath, [SCRIPT, 'append', f, 'decision', 'demo', '--data', '{"id":"","text":"second"}']);
   assert.deepEqual(query(f, { ev: 'decision' }).map((e) => e.data.id), ['D-1', 'D-2']);
+});
+
+test('a review cannot close a colliding non-reviewer spawn', () => {
+  // Review finding: `by` is a free string; a collision with a still-working
+  // implementer's name must not mark that implementer reported.
+  const f = tmp();
+  append(f, spawnEv('worker-1'));
+  append(f, reviewEv('worker-1'));
+  assert.deepEqual(openSpawns(f).map((s) => s.agent), ['worker-1']);
+  assert.equal(pairSpawns(readJournal(f).events).pairs.length, 0);
+  // and ADR-18 still refuses a second live spawn of the same name
+  assert.throws(() => append(f, spawnEv('worker-1')), /already has an open spawn/);
 });


### PR DESCRIPTION
Seven commits closing kernel gaps measured in the field across three initiatives in an adopted repo (flowhive: `bugs-affinity-pipeline`, `bug-followups`, `batch-dna-reports`). Every behavior change landed fail-first; the full suite is **938/938, exit 0** (baseline 922 + 16 new tests). An independent reviewer read the whole diff, reran everything, filed two CHANGES-REQUESTED findings (both real), and approved the fix delta after reproducing the fail-first claims against the pre-fix tree.

## What's here

| commit | change |
|---|---|
| `f049700` | **Policy template:** `.tyran/initiatives/*/locks/**` → AUTO. Iron rule 7's take-your-own-lease protocol was unsatisfiable as shipped — default GATED denied every subagent's lease write, in any repo. Measured twice. |
| `8ec92bb` | **run skill:** commit initiative state at every merge (K-9 failed as prose three times); describe append's id auto-issue instead of the two-step next-id flow; journal-event lease fallback for pre-fix installs; record `retro.entry kind: spawned` when dispatching a background retro. |
| `9a50481` | **code-review skill:** flag tests whose fixtures hand-build the real producer's output (a three-state flag collapse survived two review rounds this way). |
| `229eedf` | **journal.mjs:** a `review` closes its reviewer's spawn (reviewers never file reports about themselves — every reviewer stayed "still working" forever); `"id":""` now auto-issues like an omitted id. Both doc surfaces updated. |
| `8222ee7` | **secrets-gate:** stop refusing read-only `git config` queries of the hooks-path key; only override/set forms deny — the docs always described an *override* rule. |
| `da3bb75` | **policy-gate:** GATED now emits `permissionDecision: "ask"` for the MAIN loop under `acceptEdits` — the mode agents actually run in — so "the operator approves this one" is real again instead of an unconditional deny pointing at a main session that refused the same way. Subagents, `bypassPermissions`, and unknown modes keep the hard deny. The gate still never spells the platform decision itself (source-string test pins it). |
| `efb0b57` | **Review findings closed:** dash-prefixed values are values (`git config <key> -evildir` really disables hooks — the narrowed rule had a bypass); a review's `by` can only close a spawn whose `role` is `reviewer` (name collisions no longer mark a working implementer as reported). Plus a MATRIX row pinning the lease rule. |

## Notes for the merger

- **No version bump here, deliberately** — per CLAUDE.md a fix merged without bumping `plugin.json`/`marketplace.json`/`package.json` reaches nobody, and publishing is irreversible, so the bump + both tags are left as the operator's release act.
- Existing installs don't re-read the template: the lease rule needs a one-line hand-edit in already-adopted repos' `.tyran/policies/autonomy.yaml` (KERNEL by design).
- One open assumption, flagged by the reviewer: the `"ask"` payload shape is verified by unit tests, not by driving a live session; worth one manual GATED write under `acceptEdits` after merge.
- Pre-existing, untouched: `escapeRoute()`'s deny wording is slightly stale for `bypassPermissions` main-loop denials.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
