### PR TITLE
fix(secrets-gate): size gh pr create over the PR's own head, not --all

### DIFF
--- a/hooks/scripts/secrets-gate.mjs
+++ b/hooks/scripts/secrets-gate.mjs
@@ -662,7 +662,100 @@ export function planCommand(command, startDir) {
       triggers.push('a git push (every commit not already on the target remote is scanned)');
     }
     if (ghPublishes) {
-      note(dir, { scanPush: true });
+      // `gh pr create` publishes ONE branch — the PR's head — and adds no git
+      // objects of its own: the head either was already pushed THROUGH this
+      // gate, or gh pushes it as part of creating the PR. Recording the push
+      // with no refs made `pushRange` fall back to `--all --not
+      // --remotes=<target>`, i.e. every unpushed commit on EVERY local
+      // branch. Measured in a checkout carrying ~10 branches for parallel
+      // worktrees: 310 objects / 4,550,272 bytes for that fallback against
+      // 97 objects / ~105 KB for the branch the PR was actually about — a
+      // permanent over-ceiling refusal for as long as ANY sibling worktree
+      // held unpushed work, about bytes the command would never publish. A
+      // `git fetch` cannot heal it and the refusal's own remedy ("push a
+      // smaller range") does not apply to a command that pushes nothing,
+      // which is how a gate teaches people to route around it (ADR-19).
+      //
+      // So the head ref is resolved here and handed to `pushRange`, which
+      // narrows the scan to what a push of that head would publish and
+      // already degrades to the wide range when the ref does not resolve.
+      // Review of the first draft found three ways it narrowed to the WRONG
+      // range, so every rule below is the same inversion this file keeps
+      // arriving at: enumerate what is positively readable, keep the wide
+      // range for everything else.
+      //
+      //  - The subcommand is read POSITIONALLY (`gh pr create ...`), never
+      //    from the token bag: a `--notes "closes pr 5"` on a release must
+      //    not turn it into a PR.
+      //  - QUOTED spans are stripped before flags are read — a `--title` or
+      //    `--body` argument is DATA, the same doctrine as
+      //    `stripHeredocBodies`, and the draft read a `--head` out of a
+      //    body string. The cost: a QUOTED head value (`--head "x"`) reads
+      //    as unparseable and keeps the wide range. Failing to narrow is
+      //    safe.
+      //  - Readable head spellings are enumerated: `--head x`, `--head=x`,
+      //    `-H x`, `-Hx`, `-H=x`. A short CLUSTER carrying `H` behind other
+      //    letters (`-dH x`; `-bHello`, where H merely starts a body value)
+      //    cannot be read without gh's own flag table, so it keeps the wide
+      //    range instead of defaulting to a guess.
+      //  - `pushRefs: []` is `pushRange`'s own encoding of the WIDE range
+      //    (`--all`): when an earlier `git push --all` or an
+      //    unreadable-refspec push in this same line already asked for it,
+      //    the union must not upgrade wide to narrow. Non-empty refs are
+      //    unioned, never replaced.
+      let prHead = null;
+      const stripped = tokensOf(segment.replace(/"[^"]*"|'[^']*'/g, ' '));
+      const g = stripped.findIndex(isGhProgram);
+      if (g !== -1 && stripped[g + 1] === 'pr' && stripped[g + 2] === 'create') {
+        prHead = 'HEAD';
+        let unreadable = false;
+        for (let k = g + 3; k < stripped.length; k++) {
+          const token = stripped[k];
+          let value = null;
+          if (token === '--head' || token === '-H') {
+            const next = stripped[k + 1];
+            if (next === undefined || next.startsWith('-')) {
+              unreadable = true;
+              continue;
+            }
+            value = next;
+            k++;
+          } else if (token.startsWith('--head=')) {
+            value = token.slice('--head='.length);
+          } else if (token.startsWith('-H') && token.length > 2) {
+            // pflag's attached shorthand: `-Hother`, `-H=other`. H first in
+            // the cluster is unambiguously the head flag.
+            value = token[2] === '=' ? token.slice(3) : token.slice(2);
+          } else if (/^-[A-Za-z]+H/.test(token)) {
+            unreadable = true;
+            continue;
+          } else {
+            continue;
+          }
+          if (value === '') {
+            unreadable = true;
+            continue;
+          }
+          // A cross-fork head is `owner:branch`; the ref is the branch part.
+          const ref = value.includes(':') ? value.slice(value.lastIndexOf(':') + 1) : value;
+          // Same rule as a push refspec: a head the shell would rewrite
+          // cannot narrow the range.
+          if (isLiteralRef(ref)) prHead = ref;
+          else unreadable = true;
+        }
+        if (unreadable) prHead = null;
+      }
+      const existing = targets.get(dir);
+      const priorWide =
+        existing !== undefined &&
+        existing.scanPush === true &&
+        !(Array.isArray(existing.pushRefs) && existing.pushRefs.length > 0);
+      if (prHead !== null && !priorWide) {
+        const prior = existing?.pushRefs ?? [];
+        note(dir, { scanPush: true, pushRefs: [...new Set([...prior, prHead])] });
+      } else {
+        note(dir, { scanPush: true });
+      }
       triggers.push('a gh command that publishes');
       if (words.has('release') || words.has('gist')) {
         // These upload files from DISK that may be in no commit at all —

--- a/tests/unit/hook-secrets-gate.test.mjs
+++ b/tests/unit/hook-secrets-gate.test.mjs
@@ -1283,6 +1283,119 @@ test('BL-3: a refspec source with `~` NARROWS the range instead of widening it',
   assert.equal(isLiteralPath('HEAD~130'), false, 'the path rule is deliberately unchanged');
 });
 
+test('BL-3: `gh pr create` is sized over its own head, never over every local branch', () => {
+  // A `gh pr create` records scanPush with no remote and no refspecs, so
+  // `pushRange` fell back to `--all --not --remotes=<target>` — every
+  // unpushed commit on EVERY local branch, which has nothing to do with the
+  // branch the PR is about. Measured in a checkout carrying ~10 branches for
+  // parallel worktrees: 310 objects / 4,550,272 bytes for that fallback
+  // against 97 objects / ~105 KB for the PR's own branch, i.e. a permanent
+  // over-ceiling refusal for as long as any sibling worktree held unpushed
+  // work — and `git fetch`, the remedy that heals a stale-ref refusal on a
+  // real push, cannot change what OTHER branches hold.
+  //
+  // KILLS: reverting the ghPublishes branch to `note(dir, { scanPush: true })`.
+  assert.deepEqual(planCommand('gh pr create --fill', '/repo').targets[0].pushRefs, ['HEAD']);
+  assert.deepEqual(planCommand('gh pr create --title x --head feat/a', '/repo').targets[0].pushRefs, ['feat/a']);
+  assert.deepEqual(planCommand('gh pr create --head=feat/a --base main', '/repo').targets[0].pushRefs, ['feat/a']);
+  assert.deepEqual(planCommand('gh pr create -H feat/a --fill', '/repo').targets[0].pushRefs, ['feat/a']);
+  // pflag's ATTACHED shorthand forms, which gh accepts: review walked the
+  // first draft with them — an unrecognised head form defaulted to a
+  // NARROWING instead of the wide range, so the gate scanned the wrong
+  // branch while the command published another.
+  assert.deepEqual(planCommand('gh pr create -Hfeat/a --fill', '/repo').targets[0].pushRefs, ['feat/a']);
+  assert.deepEqual(planCommand('gh pr create -H=feat/a --fill', '/repo').targets[0].pushRefs, ['feat/a']);
+  // A cross-fork head is `owner:branch`; the ref is the branch part.
+  assert.deepEqual(planCommand('gh pr create --head owner:feat/a', '/repo').targets[0].pushRefs, ['feat/a']);
+  // A head the shell would rewrite cannot narrow: the wide fallback stands.
+  assert.equal(planCommand('gh pr create --head $B', '/repo').targets[0].pushRefs, undefined);
+  // Unreadable head SPELLINGS keep the wide range too — never a guess: a
+  // bare --head with no value, and an H buried in a short cluster (is
+  // `-dH x` a head? is `-bHello` a body value that starts with H? not
+  // decidable without gh's own flag table).
+  assert.equal(planCommand('gh pr create --fill --head', '/repo').targets[0].pushRefs, undefined);
+  assert.equal(planCommand('gh pr create -dH feat/a', '/repo').targets[0].pushRefs, undefined);
+  assert.equal(planCommand('gh pr create -bHello --fill', '/repo').targets[0].pushRefs, undefined);
+  // QUOTED spans are prose, not flags: a --body that MENTIONS --head must
+  // not steer the range, and `pr` inside a --notes string must not turn a
+  // release into a PR (both review findings against the first draft).
+  assert.deepEqual(
+    planCommand('gh pr create --fill --body "do not use --head feat/x here"', '/repo').targets[0].pushRefs,
+    ['HEAD'],
+  );
+  assert.equal(
+    planCommand('gh release create v1 --notes "closes pr 5"', '/repo').targets[0].pushRefs,
+    undefined,
+  );
+  // `gh release create` / `gh gist create` keep the wide range: they upload
+  // from disk and publish no branch, so there is no head to narrow to.
+  assert.equal(planCommand('gh release create v1', '/repo').targets[0].pushRefs, undefined);
+  // A push and a `gh pr create` on one line: NON-EMPTY refs are unioned...
+  assert.deepEqual(
+    planCommand('git push origin feat/b && gh pr create --fill', '/repo').targets[0].pushRefs,
+    ['feat/b', 'HEAD'],
+  );
+  // ...and `pushRefs: []` is pushRange's own encoding of the WIDE range
+  // (--all), which a union must never upgrade to a narrow one. Review's
+  // highest finding against the first draft: both commands below scanned
+  // HEAD only, un-scanning what `git push --all` / an unreadable refspec
+  // had just asked to publish.
+  assert.deepEqual(
+    planCommand('git push --all origin && gh pr create --fill', '/repo').targets[0].pushRefs,
+    [],
+  );
+  assert.deepEqual(
+    planCommand('git push origin $BRANCH && gh pr create --fill', '/repo').targets[0].pushRefs,
+    [],
+  );
+});
+
+test(
+  'BL-3: a `gh pr create` for a pushed branch is not refused over a SIBLING branch’s payload',
+  { skip: NEEDS_SCANNER },
+  () => {
+    // End to end, the shape the field kept hitting: the PR's branch is fully
+    // pushed (its every object already went THROUGH this gate), while a
+    // sibling branch — another worktree's story, parked locally — holds an
+    // unpushed secret. The PR publishes nothing of that sibling, so the gate
+    // must pass; under the `--all` fallback it refused, permanently, and the
+    // only route left was the manual-scan fallback outside the gate.
+    const dir = repo();
+    writeFileSync(join(dir, 'a.txt'), 'ordinary content\n');
+    git(dir, 'add', 'a.txt');
+    git(dir, 'commit', '-qm', 'base');
+    git(dir, 'branch', '-m', 'work');
+    const bare = tempDir('tyran-gate-bare-gh-');
+    execFileSync('git', ['init', '-q', '--bare', bare]);
+    git(dir, 'remote', 'add', 'origin', bare);
+    git(dir, 'push', '-q', 'origin', 'work');
+    // The sibling: unpushed, and carrying the one thing the scanner always finds.
+    git(dir, 'checkout', '-qb', 'other');
+    writeFileSync(join(dir, 'k.pem'), fakeSecret());
+    git(dir, 'add', 'k.pem');
+    git(dir, 'commit', '-qm', 'parked');
+    git(dir, 'checkout', '-q', 'work');
+    assert.equal(verdictOf(runGateScript('gh pr create --fill', dir)), 'pass');
+    // And the head actually named still gets its own range scanned: the same
+    // command pointed AT the sibling branch is refused for the secret —
+    // through every spelling gh accepts, attached shorthand included.
+    for (const command of [
+      'gh pr create --head other --fill',
+      'gh pr create -Hother --fill',
+      'gh pr create -H=other --fill',
+    ]) {
+      const denied = runGateScript(command, dir);
+      assert.equal(verdictOf(denied), 'deny', command);
+      assert.match(reasonOf(denied), /private-key/, command);
+    }
+    // A `git push` that asked for the WIDE range in the same line keeps it:
+    // --all publishes the sibling too, so the secret is still caught.
+    const wide = runGateScript('git push --all origin && gh pr create --fill', dir);
+    assert.equal(verdictOf(wide), 'deny');
+    assert.match(reasonOf(wide), /private-key/);
+  },
+);
+
 test(
   'BL-3: an oversized push is refused for its SIZE, with the remedy that narrows it',
   () => {


### PR DESCRIPTION
**Problem.** A publishing `gh` command records `scanPush` with no remote and
no refspecs, so `pushRange` falls back to `--all --not --remotes=<target>` —
every unpushed commit on EVERY local branch, none of which `gh pr create`
publishes. Measured in a checkout carrying ~10 branches for parallel
worktrees: 310 objects / 4,550,272 bytes for the fallback vs 97 objects /
~105 KB for the PR's own branch → a permanent over-ceiling refusal
(MAX_PAYLOAD_BYTES = 4 MiB) for as long as any sibling worktree holds
unpushed work. `git fetch` cannot heal it and the refusal's remedy ("push a
smaller range") does not apply to a command that pushes nothing. Field-hit
four times on one install (teza, nowy-front W5-5b, raport-na-zadanie,
koszty-llm nocturnal) — each time the agent had to fall back to a manual
gitleaks scan + REST publish outside the gate. A fifth hit landed the
morning after this branch was prepared (notes-journal): 308 objects /
5,408,505 bytes scanned for a command publishing 39 objects / 196,554
bytes, and pruning the four largest offender branches still left the range
over budget — the excess is structural in a many-worktree checkout.

**Fix.** `gh pr create` resolves its head and hands it to `pushRange` as
the refspec; `pushRange` rev-parse-verifies each ref and degrades to the
wide range when it does not resolve. Independent review of the first draft
found three ways it narrowed to the WRONG range; the shipped rules are the
inversion — enumerate what is positively readable, keep the wide range for
the rest: (a) the subcommand is read POSITIONALLY, never from the token
bag, so prose like `--notes "closes pr 5"` cannot turn a release into a
PR; (b) quoted spans are stripped before flags are read (a `--title`/
`--body` is data — same doctrine as `stripHeredocBodies`), so a `--head`
mentioned inside a body string cannot steer the range (cost: a QUOTED head
value reads as unparseable → wide, the safe direction); (c) readable head
spellings are enumerated — `--head x`, `--head=x`, `-H x`, `-Hx`, `-H=x`
(cross-fork `owner:branch` → branch part) — while a bare `--head`, an
expansion-bearing value, or an H buried in a short cluster (`-dH x`,
`-bHello`) keeps the wide range instead of a guess; (d) `pushRefs: []` is
`pushRange`'s own encoding of the WIDE range, so `git push --all && gh pr
create` keeps `--all` — the union never upgrades wide to narrow, non-empty
refs are unioned, never replaced. `gh release/gist create` unchanged.

**Tests.** A `planCommand` table over all head spellings (attached
shorthand and cluster forms included), the quoted-prose cases, and the
wide-union cases; end to end, a fully-pushed branch's PR passes while the
same command pointed at a sibling branch holding an unpushed private key is
refused through every head spelling, and `git push --all` in the same line
still catches the sibling's secret. Core cases go RED with the ghPublishes
branch reverted (verified). Suite 940/940, RC=0.

**Live reproduction, same night:** a journal append whose `--data` prose
mentioned the literal three-word command name was refused by this very
gate (a parenthesis split the prose into its own segment, the word-bag
detection classed it as a publishing command, the wide scan hit the 4 MiB
ceiling). The positional detection in this PR removes exactly that shape.

> Branch restored from the night initiative's patch backup (the original
> clone was lost); suite re-verified green before push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
