### PR TITLE
fix(policy-gate): treat a journal --data argument as prose, like -m

### DIFF
--- a/docs/policy-gate.md
+++ b/docs/policy-gate.md
@@ -275,11 +275,17 @@ refused. Raising it into the validator's list would close that and would change
 what every policy file is allowed to say — a separate decision, deliberately
 not taken here.
 
-The argument of `-m` / `--message` / `-F` / `--file` / `-t` / `--template` is
-removed from the text first, so `git commit -m "fix .env loading"` is not a
-refusal. That is the same move `stripHeredocBodies` makes in the shared lexer,
-for the same measured reason: a commit message is data, and lexing data as a
-program was the largest single source of false alarms there.
+The argument of `-m` / `--message` / `-F` / `--file` / `-t` / `--template` /
+`--data` is removed from the text first, so `git commit -m "fix .env loading"`
+is not a refusal — and neither is a `journal.mjs append ... --data '{...}'`
+whose prose merely *mentions* a dotenv-shaped filename. That last one was
+measured twice on one install (a journal entry describing a migration run
+against a test env file was refused as if it published the file), and its
+cost was the worst kind: conductors stopped writing certain filenames into
+their own ledger, which is the journal failing at its one job. This is the
+same move `stripHeredocBodies` makes in the shared lexer, for the same
+measured reason: a commit message is data, and lexing data as a program was
+the largest single source of false alarms there.
 
 ### The declared floor for the shell rules
 

--- a/hooks/scripts/policy-gate.mjs
+++ b/hooks/scripts/policy-gate.mjs
@@ -1250,8 +1250,17 @@ function escapeRoute(cls, unsupervised) {
  * direction of its incompleteness is a FALSE REFUSAL, never a silent pass: a
  * message flag this list misses produces an over-strict gate, not a hole.
  * That is the only shape of enumeration this file allows.
+ *
+ * `--data` is here for the same reason as `-m`, and the cost of its absence
+ * was measured twice on one install: `journal.mjs append ... --data '{...}'`
+ * carries a JSON blob of PROSE — a decision's text, a report's summary — and
+ * a journal entry merely DESCRIBING a dotenv-shaped filename ("applied the
+ * migration against .env.test") was indistinguishable to this gate from a
+ * command PUBLISHING that file. The refusal pushed conductors into a
+ * convention of never writing certain filenames into their own ledger, which
+ * is the journal failing at its one job of recording what happened.
  */
-const MESSAGE_FLAGS = Object.freeze(['-m', '--message', '-F', '--file', '-t', '--template', '-am', '-ma']);
+const MESSAGE_FLAGS = Object.freeze(['-m', '--message', '-F', '--file', '-t', '--template', '-am', '-ma', '--data']);
 
 /**
  * Remove the ARGUMENT of a message-bearing option before the tokens are taken.
@@ -1271,7 +1280,7 @@ const MESSAGE_FLAGS = Object.freeze(['-m', '--message', '-F', '--file', '-t', '-
  */
 export function stripMessageArguments(command) {
   return String(command).replace(
-    /(^|\s)(-m|--message|-F|--file|-t|--template|-am|-ma)(=|\s+)("[^"]*"|'[^']*'|\S+)/g,
+    /(^|\s)(-m|--message|-F|--file|-t|--template|-am|-ma|--data)(=|\s+)("[^"]*"|'[^']*'|\S+)/g,
     '$1',
   );
 }

--- a/tests/unit/hook-policy-gate.test.mjs
+++ b/tests/unit/hook-policy-gate.test.mjs
@@ -1379,6 +1379,30 @@ test('B2: an ordinary command is not slowed down or refused by the path rules', 
   }
 });
 
+test('B2: a journal `--data` argument is prose, exactly like a commit message', async () => {
+  // `journal.mjs append` takes its event payload as `--data '{...}'` — a JSON
+  // blob of prose. Without `--data` in MESSAGE_FLAGS, a journal entry merely
+  // DESCRIBING a dotenv-shaped filename was indistinguishable to this gate
+  // from a command publishing one, and the refusal reproduced across two
+  // initiatives on one install: the ledger of record could not say "applied
+  // the migration against the test env file" by that file's name. A journal
+  // that must talk around facts is failing at its one job.
+  //
+  // KILLS: removing `--data` from MESSAGE_FLAGS / stripMessageArguments.
+  const dir = deployRepo();
+  for (const command of [
+    `node scripts/journal.mjs append .tyran/state/x/journal.jsonl decision x --actor conductor --data '{"text":"applied migration 160 against .env.test, TEST first, then PROD"}'`,
+    `node scripts/journal.mjs append j.jsonl decision x --data='{"text":"anchored grep on .env.local returned 1 line"}'`,
+  ]) {
+    assert.equal(await ask(bashInput(command, dir), dir), PASS, command);
+  }
+  // The flag exempts its ARGUMENT, never the rest of the command line: a
+  // credential-shaped path outside the quoted blob still refuses.
+  const got = await ask(bashInput(`cat .env --data 'x'`, dir), dir);
+  assert.equal(got.decision, 'deny');
+  assert.match(got.reason, /credential-shaped/);
+});
+
 test('B3: the refusal names the protected glob that ACTUALLY matched', async () => {
   // THE REPAIRING MUTANT LIVES HERE, and the reason is the finding rather than
   // the bug. Round two probed `classifyPath` with a one-rule policy to ask


### PR DESCRIPTION
**Problem.** `journal.mjs append` takes its event payload as `--data '{...}'`
— a JSON blob of prose. `MESSAGE_FLAGS` exempts `-m/--message/-F/--file/-t/
--template` as prose before path tokens are scanned, but not `--data`, so a
journal entry merely DESCRIBING a dotenv-shaped filename ("applied the
migration against the test env file", by name) is indistinguishable from a
command publishing that file. Reproduced twice on one install (teza D-003,
nowy-front D-013); the standing workaround was a convention of never writing
certain filenames into the ledger of record.

**Fix.** One array entry (`--data` in `MESSAGE_FLAGS`) + the same
alternation in `stripMessageArguments`, per that list's own doctrine: an
enumeration whose misses are false refusals, never silent passes.
`docs/policy-gate.md` updated in the same commit.

**Tests.** Two real journal-append spellings (space and `=` forms) pass; a
credential-shaped path OUTSIDE the quoted blob still refuses. RED without
the fix (verified), suite 939/939 with it.

**Known residuals (reviewer notes, false-refusal direction only, left for
a follow-up):** (N1) the `'[^']*'` alternative stops at the first `'`, so
journal.mjs's own `sq()` chain (`'…'\''…'`) is not stripped when the prose
carries an apostrophe; (N2) doctor.mjs emits ANSI-C `$'…'` for non-ASCII
payloads (the normal case for Polish journal prose), which matches neither
quote form — the fix helps ASCII prose fully and Polish prose only partly;
(N3) if `secretReadRules` ever learns `@`-prefixed paths (`curl --data
@.env` is invisible today), `--data` here would re-hide it — worth a
comment at the `MESSAGE_FLAGS` definition.

> Branch restored from the night initiative's patch backup (the original
> clone was lost); suite re-verified green before push. One unrelated flake
> observed in a single local run (939 total, 1 fail, unreproducible across
> two follow-up runs and green on main) — CI will re-exercise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
