### PR TITLE
doctor: an initiative's ledger can be untracked while .tyran/ is not (+ 0.1.9)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
     {
       "name": "tyran",
       "description": "A task conductor for Claude Code: multi-agent orchestration with an enforced evidence contract, repo-specific learning, and update-safe local evolution.",
-      "version": "0.1.8",
+      "version": "0.1.9",
       "source": "./",
       "author": {
         "name": "Jacek Janczura",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "tyran",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "description": "A task conductor for Claude Code: multi-agent orchestration with an enforced evidence contract, repo-specific learning, and update-safe local evolution.",
   "author": {
     "name": "Jacek Janczura",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,45 @@
 # Changelog
 
+## 0.1.9 — 2026-08-10
+
+### `.tyran/` was tracked, and an entire initiative inside it was not
+
+`untrackedTyranDir` is all-or-nothing: one tracked file under `.tyran/` and
+the repo reports healthy. Measured on a real install whose `.tyran/` had been
+tracked for weeks — one initiative directory of six files, including its plan
+and the gate event recording two production database migrations, had NEVER
+been committed, and a second was 33 events behind its committed copy. Both
+passed. `journal.mjs append` writes the working tree and nothing else, so an
+initiative nobody committed is one `git clean -fd` from having never happened,
+and iron rule 1 asks for exactly the commit that nothing was measuring.
+
+`doctor --state` now checks each initiative separately. `initiative-untracked`
+is a **warning** — git has never seen this ledger, wrong at any moment.
+`initiative-uncommitted` is **info** and never fails the check, because that
+is what an initiative in flight looks like ten seconds after any append; it
+earns its keep at a merge boundary. Under a wholly untracked `.tyran/` the
+directory-level finding still reports alone, rather than repeating itself once
+per initiative.
+
+### Four things the conductor skill was letting agents rediscover
+
+- **Interactive shell aliases hang an agent until the tool timeout.** An
+  agent's shell starts from the user's profile, so `alias cp='cp -i'` asks a
+  question nobody answers. Fired three times in one session, in three
+  different agents, and none recognised it first time — the symptom is a
+  timeout, which points at the machine instead of the alias. STEP 0 now probes
+  for it.
+- **A `Test timed out` measured under concurrency is not evidence.** The
+  hardware ceiling bounds agent count, not concurrent heavy phases, so an
+  agent can respect it and still report a red the machine caused. Five such
+  failures in one session, all gone on a serial re-run. Re-run serially before
+  reporting.
+- **An agent that dies on a terminal API error is resumed, not respawned** —
+  its context, its corrected premises and its uncommitted diff survive.
+- **Gitignored env files are missing from a fresh worktree too, and fail
+  quieter than dependencies**: 127 is loud, a skipped gated spec is not, so
+  the worktree reports a cleaner baseline than the repo has.
+
 ## 0.1.8 — 2026-08-08
 
 ### The secrets gate scanned everything except what the command published

--- a/docs/doctor.md
+++ b/docs/doctor.md
@@ -1,6 +1,6 @@
 # Doctor reference
 
-`scripts/doctor.mjs --state` · 79 unit tests
+`scripts/doctor.mjs --state` · 84 unit tests
 
 Doctor **diagnoses, it never repairs.** Every finding carries a severity, a
 location and a command you can paste.
@@ -71,6 +71,8 @@ possible to change one and keep the suite green.
 | `projection-failed` | error | rendering the projection threw |
 | `config-missing` | info | the repo has not been set up (yet) |
 | `tyran-dir-untracked` | warning | nothing under `.tyran/` is tracked by git — worktrees get no config and no policy, so agents run there with no autonomy class at all |
+| `initiative-untracked` | warning | this initiative’s ledger is not in git — `journal.mjs append` writes the working tree only, so an initiative nobody committed is one `git clean -fd` from having never happened |
+| `initiative-uncommitted` | info | the ledger has uncommitted changes — ordinary mid-initiative, a gap at a merge boundary |
 | `policy-missing` | error | `.tyran/` exists with no `policies/autonomy.yaml` under it — the policy gate fails closed on this state, so every write in the repo is refused until the file is there |
 | `config-invalid` · `knowledge-invalid` · `policy-invalid` | error | a schema validator rejected the file, with its exact field path |
 | `config-unreadable` · `knowledge-unreadable` · `policy-unreadable` | error | the file could not be read at all (errno printed) |

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jjanczur/tyran",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "description": "Command-line scripts for the Tyran task conductor (doctor, journal, schema, and repo tooling) for CI and terminals outside Claude Code. Installing this package does NOT install the Claude Code plugin — add that separately with `/plugin marketplace add jjanczur/tyran` inside Claude Code.",
   "type": "module",
   "engines": {

--- a/scripts/doctor.mjs
+++ b/scripts/doctor.mjs
@@ -36,7 +36,7 @@
  * dead writes no state to be inconsistent with.
  */
 import { existsSync, readdirSync, realpathSync, statSync } from 'node:fs';
-import { join, dirname, resolve } from 'node:path';
+import { join, dirname, resolve, relative } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { checkHooks, DEFAULT_PLUGIN_ROOT } from './hooks-check.mjs';
 import { readJournal, validateJournal, pairSpawns, tail } from './journal.mjs';
@@ -169,6 +169,9 @@ export const SEVERITY_BY_CODE = Object.freeze(
     'projection-blocked': 'warning',
     'projection-failed': 'error',
     'projection-unreadable': 'error',
+    // the ledger in git
+    'initiative-untracked': 'warning',
+    'initiative-uncommitted': 'info',
     // configuration
     'config-missing': 'info',
     'config-invalid': 'error',
@@ -1009,6 +1012,42 @@ export function untrackedTyranDir(repoRoot, run) {
   return run(['ls-files', '--', '.tyran']).trim() === '';
 }
 
+/**
+ * Is ONE initiative's ledger in git, and is what git has current?
+ *
+ * `untrackedTyranDir` above is all-or-nothing: any tracked file under
+ * `.tyran/` and it reports healthy. That is the wrong granularity for the
+ * thing iron rule 1 actually asks for. Measured on a real install: `.tyran/`
+ * had been tracked for weeks, and inside it one initiative's directory — six
+ * files, including the plan and the gate event recording two production
+ * database migrations — had NEVER been committed, while a second was 33
+ * events behind its committed copy. The whole-directory check passed on both.
+ * `journal.mjs append` writes the working tree and nothing else, so an
+ * initiative nobody committed is one `git clean -fd` from having never
+ * happened.
+ *
+ * The two states are deliberately different findings, because only one of
+ * them is a defect:
+ *
+ *   - `untracked` — git has never seen this ledger. Wrong at any moment.
+ *   - `uncommitted` — tracked, with local changes. That is what an initiative
+ *     in flight looks like ten seconds after any append, so it reports as
+ *     `info` and never fails the check. It earns its place at the end: rule 1
+ *     says commit the ledger at every merge, and this is the one thing that
+ *     says out loud whether you did.
+ *
+ * `status --porcelain` counts untracked children too, so a half-committed
+ * directory reads as `uncommitted` rather than passing on its tracked half.
+ *
+ * Returns null when git cannot answer — same reasoning as above: "this is not
+ * a git repository" is not evidence that a file is untracked.
+ */
+export function initiativeGitState(run, relDir) {
+  if (run(['rev-parse', '--is-inside-work-tree']).trim() !== 'true') return null;
+  if (run(['ls-files', '--', relDir]).trim() === '') return 'untracked';
+  return run(['status', '--porcelain', '--', relDir]).trim() === '' ? 'committed' : 'uncommitted';
+}
+
 export function runStateChecks({ dir = '.tyran', now = null, staleHours = DEFAULT_STALE_HOURS, run = null } = {}) {
   const root = resolve(dir);
   if (!existsSync(root)) {
@@ -1038,7 +1077,8 @@ export function runStateChecks({ dir = '.tyran', now = null, staleHours = DEFAUL
     checked.push('config.yaml: absent');
   }
 
-  const untracked = untrackedTyranDir(repoRoot, run ?? gitRunner(repoRoot));
+  const git = run ?? gitRunner(repoRoot);
+  const untracked = untrackedTyranDir(repoRoot, git);
   if (untracked === true) {
     findings.push(
       finding(
@@ -1103,6 +1143,35 @@ export function runStateChecks({ dir = '.tyran', now = null, staleHours = DEFAUL
       }
       const result = checkInitiative(stateDir, name, { now, staleHours });
       findings.push(...result.findings);
+      // Only when `.tyran/` as a whole IS tracked. Under a wholly untracked
+      // `.tyran/` every initiative would repeat the directory-level finding
+      // above, and a check that says the same thing N+1 times is a check
+      // people learn to scroll past.
+      if (untracked === false) {
+        const state = initiativeGitState(git, relative(repoRoot, path));
+        if (state === 'untracked') {
+          findings.push(
+            finding(
+              'initiative-untracked',
+              show(path),
+              'this initiative’s ledger is not in git — `journal.mjs append` writes the working tree ' +
+                'and nothing else, so an initiative nobody committed is one `git clean -fd` from ' +
+                'having never happened',
+              `git add ${sq(relative(repoRoot, path))} && git commit -m ${sq(`chore(tyran): record the ${name} ledger`)}`,
+            ),
+          );
+        } else if (state === 'uncommitted') {
+          findings.push(
+            finding(
+              'initiative-uncommitted',
+              show(path),
+              'ledger has uncommitted changes — ordinary mid-initiative, a gap at a merge boundary ' +
+                '(iron rule 1: stage and commit the ledger at every merge, not once at the end)',
+              `git add ${sq(relative(repoRoot, path))} && git commit -m ${sq(`chore(tyran): ${name} ledger`)}`,
+            ),
+          );
+        }
+      }
       initiatives.push(`${show(name)} (${result.events} event(s))`);
     }
   }

--- a/site/src/content/docs/doctor.mdx
+++ b/site/src/content/docs/doctor.mdx
@@ -6,7 +6,7 @@ import Provenance from '../../components/Provenance.astro';
 import Limit from '../../components/Limit.astro';
 
 <Provenance>
-`scripts/doctor.mjs --state` · 79 unit tests
+`scripts/doctor.mjs --state` · 84 unit tests
 </Provenance>
 
 Doctor **diagnoses, it never repairs.** Every finding carries a severity, a
@@ -78,6 +78,8 @@ possible to change one and keep the suite green.
 | `projection-failed` | error | rendering the projection threw |
 | `config-missing` | info | the repo has not been set up (yet) |
 | `tyran-dir-untracked` | warning | nothing under `.tyran/` is tracked by git — worktrees get no config and no policy, so agents run there with no autonomy class at all |
+| `initiative-untracked` | warning | this initiative’s ledger is not in git — `journal.mjs append` writes the working tree only, so an initiative nobody committed is one `git clean -fd` from having never happened |
+| `initiative-uncommitted` | info | the ledger has uncommitted changes — ordinary mid-initiative, a gap at a merge boundary |
 | `policy-missing` | error | `.tyran/` exists with no `policies/autonomy.yaml` under it — the policy gate fails closed on this state, so every write in the repo is refused until the file is there |
 | `config-invalid` · `knowledge-invalid` · `policy-invalid` | error | a schema validator rejected the file, with its exact field path |
 | `config-unreadable` · `knowledge-unreadable` · `policy-unreadable` | error | the file could not be read at all (errno printed) |

--- a/skills/run/SKILL.md
+++ b/skills/run/SKILL.md
@@ -70,6 +70,13 @@ English regardless.
      server start vanish on restart, so restarts stop being deterministic;
    - probe the toolchain with `command -v` for every tool the plan names, and
      confirm your own file-writing path works before you rely on it;
+   - **probe for interactive aliases** — `alias cp mv rm 2>/dev/null` — because
+     an agent's shell is started from the user's profile, so `alias cp='cp -i'`
+     turns a copy into a question with nobody to answer it and the tool call
+     burns its whole timeout. Put `\cp` / `command cp` in the handoff when one
+     is set. Measured: three times in one session, in three different agents,
+     and none of them recognised it the first time — the symptom is a timeout,
+     which points at the machine rather than at the alias;
    - **dry-run every automaton** for one no-op iteration before you trust it
      with unattended work. Trust dialogs and missing dependencies surface
      then, not at 3am.
@@ -186,6 +193,18 @@ open one.
    premises about DATA by measuring the real thing read-only: a field being in
    the schema is not the same as the field being in the data. Correct a wrong
    premise and report the correction EXPLICITLY"; (7) when to escalate.
+   - **A `Test timed out` measured while another heavy phase was running is
+     not evidence of a defect.** Re-run it serially, report the serial result,
+     and say the first run was concurrent. The hardware ceiling in STEP 0
+     bounds AGENT count, not concurrent heavy phases, so an agent can respect
+     it and still produce a red that only the machine caused — measured twice
+     in one session, once by the conductor and once by a reviewer, five
+     failures between them, all gone on a serial re-run.
+   - **An agent that dies on a terminal API error is RESUMED, not respawned.**
+     Its context, its corrected premises and its uncommitted diff all survive
+     the death; a fresh agent on the same handoff repeats work that is already
+     on disk. Two agents died mid-story in one session here and both came back
+     with their work intact.
 3. **Quality gates.** Review is done by an agent who is NOT the author — when
    that is impossible (a limit, an outage), you spot-check AND the ledger
    carries an explicit **"NO INDEPENDENT REVIEW"** stamp; staying quiet about
@@ -282,6 +301,11 @@ open one.
      manifest and lockfile are already a SHARED ZONE nobody may edit, so the
      dependencies are guaranteed identical, and a per-worktree install is how
      a lockfile drifts. Say in the handoff which directory you linked.
+     **Gitignored environment files are missing for the same reason, and their
+     absence is QUIETER**: a missing dependency exits 127, a missing `.env`
+     makes gated specs SKIP, so the worktree reports a cleaner baseline than
+     the repo really has and the difference reads as good news. Link those
+     too, and name them in the handoff.
    - **`.tyran/state/**` lives in the main checkout only.** An agent told to
      append to `NOTES.md` from inside a worktree must use the absolute
      main-repo path, or it writes into a copy nobody reads.

--- a/tests/unit/doctor.test.mjs
+++ b/tests/unit/doctor.test.mjs
@@ -718,6 +718,83 @@ test('outside a git work tree the question has NO answer, and none is invented',
   assert.deepEqual(byCode(runStateChecks({ dir, run: fakeGit({}) }), 'tyran-dir-untracked'), []);
 });
 
+// --- the quieter one -----------------------------------------------------
+//
+// `.tyran/` tracked as a whole says nothing about ONE initiative inside it.
+// Measured: a `.tyran/` tracked for weeks with an initiative directory that
+// had never been committed — plan, notes and a gate event recording two
+// production migrations, all invisible to git while the directory-level
+// check reported healthy.
+
+const TRACKED_TYRAN = { [IN_TREE]: 'true\n', 'ls-files -- .tyran': '.tyran/config.yaml\n' };
+
+test('an initiative whose ledger git has never seen is a warning', () => {
+  const root = repo();
+  const dir = scaffold(root);
+  writeFileSync(journalPathFor(dir), '');
+  const run = fakeGit({ ...TRACKED_TYRAN, 'ls-files -- .tyran/state/demo': '' });
+  const found = byCode(runStateChecks({ dir, run }), 'initiative-untracked');
+  assert.equal(found.length, 1);
+  assert.equal(found[0].severity, 'warning');
+  assert.match(found[0].fix, /git add/);
+});
+
+test('a tracked, clean ledger produces no finding of either kind', () => {
+  const root = repo();
+  const dir = scaffold(root);
+  writeFileSync(journalPathFor(dir), '');
+  const run = fakeGit({
+    ...TRACKED_TYRAN,
+    'ls-files -- .tyran/state/demo': '.tyran/state/demo/journal.jsonl\n',
+    'status --porcelain -- .tyran/state/demo': '',
+  });
+  const result = runStateChecks({ dir, run });
+  assert.deepEqual(byCode(result, 'initiative-untracked'), []);
+  assert.deepEqual(byCode(result, 'initiative-uncommitted'), []);
+});
+
+test('uncommitted ledger changes are INFO — that is what an initiative in flight looks like', () => {
+  // `info` never fails the check, deliberately: every `journal.mjs append`
+  // produces this state within seconds, and a warning that is always on is a
+  // warning nobody reads. It earns its keep at a merge boundary, where rule 1
+  // says the ledger should already be committed.
+  const root = repo();
+  const dir = scaffold(root);
+  writeFileSync(journalPathFor(dir), '');
+  const run = fakeGit({
+    ...TRACKED_TYRAN,
+    'ls-files -- .tyran/state/demo': '.tyran/state/demo/journal.jsonl\n',
+    'status --porcelain -- .tyran/state/demo': ' M .tyran/state/demo/journal.jsonl\n',
+  });
+  const found = byCode(runStateChecks({ dir, run }), 'initiative-uncommitted');
+  assert.equal(found.length, 1);
+  assert.equal(found[0].severity, 'info');
+});
+
+test('outside a git work tree neither ledger question is answered', () => {
+  const root = repo();
+  const dir = scaffold(root);
+  writeFileSync(journalPathFor(dir), '');
+  const result = runStateChecks({ dir, run: fakeGit({}) });
+  assert.deepEqual(byCode(result, 'initiative-untracked'), []);
+  assert.deepEqual(byCode(result, 'initiative-uncommitted'), []);
+});
+
+test('a wholly untracked .tyran/ says so ONCE, not once per initiative', () => {
+  // Without the `untracked === false` guard this repo reports the same defect
+  // N+1 times — the directory finding plus one per initiative — and the
+  // per-initiative advice (`git add .tyran/state/x`) would be worse advice
+  // than the directory one it repeats.
+  const root = repo();
+  const dir = scaffold(root);
+  writeFileSync(journalPathFor(dir, 'one'), '');
+  writeFileSync(journalPathFor(dir, 'two'), '');
+  const run = fakeGit({ [IN_TREE]: 'true\n', 'ls-files -- .tyran': '' });
+  const result = runStateChecks({ dir, run });
+  assert.equal(byCode(result, 'tyran-dir-untracked').length, 1);
+  assert.deepEqual(byCode(result, 'initiative-untracked'), []);
+});
+
 test('a repo with no autonomy policy is told its writes are all refused', () => {
   // `error`, not `info`. The policy gate fails closed on this exact state, so
   // a `.tyran/` with no policy under it is a repository where every tool call
@@ -1179,6 +1256,8 @@ const EXPECTED_SEVERITY = {
   'policy-kernel-downgrade': 'error',
   'policy-rule-dead': 'warning',
   'policy-rule-overruled': 'warning',
+  'initiative-untracked': 'warning',
+  'initiative-uncommitted': 'info',
   'no-state-dir': 'info',
   'state-not-a-directory': 'error',
   'state-unreadable': 'error',


### PR DESCRIPTION
## The defect

`untrackedTyranDir` is all-or-nothing: one tracked file under `.tyran/` and the repo reports healthy.

Measured on a real install whose `.tyran/` had been tracked for weeks, while `doctor --state` reported no tracking finding at all:

- one initiative directory of **six files** — including its `PLAN.md` and the gate event recording two production database migrations — had **never been committed**;
- a second was **33 events behind** its committed copy, four merge events among them.

`journal.mjs append` writes the working tree and nothing else, so an initiative nobody committed is one `git clean -fd` from having never happened. Iron rule 1 asks for exactly the commit that nothing was measuring.

## The change

`doctor --state` now checks each initiative separately:

| code | severity | meaning |
|---|---|---|
| `initiative-untracked` | warning | git has never seen this ledger — wrong at any moment |
| `initiative-uncommitted` | info | tracked with local changes — what an initiative in flight looks like |

`uncommitted` is **info** on purpose: every `journal.mjs append` produces that state within seconds, and a warning that is always on is a warning nobody reads. It earns its keep at a merge boundary.

Under a wholly untracked `.tyran/` the directory-level finding still reports **alone** rather than once per initiative — the fifth test pins that, because without the guard the same repo reports the same defect N+1 times with worse advice each time.

## Also: four things the conductor skill was letting agents rediscover

All measured in one session, in one repo:

- **Interactive shell aliases hang an agent until the tool timeout.** An agent's shell starts from the user's profile, so `alias cp='cp -i'` asks a question nobody answers. Fired three times, in three different agents, none recognising it first time — the symptom is a timeout, which points at the machine rather than the alias. STEP 0 now probes.
- **A `Test timed out` measured under concurrency is not evidence.** The hardware ceiling bounds agent count, not concurrent heavy phases. Five such failures, all gone on a serial re-run.
- **A dead agent is resumed, not respawned** — context, corrected premises and uncommitted diff all survive the death.
- **Gitignored env files are absent from a fresh worktree too, and fail quieter than dependencies**: 127 is loud, a skipped gated spec is not, so the worktree reports a *cleaner* baseline than the repo has.

## Evidence

```
node --test "tests/**/*.test.mjs"   → 946 pass / 0 fail, exit 0
```
Before the `doctor.mjs` change, the new tests go red: **82 pass / 2 fail (84)**. Honest detail: only 2 of the 5 can go red that way — the other three assert *absence* (not-a-work-tree, clean ledger, and the no-repetition guard), which cannot fail before the feature exists. They are regression guards, not red-green proofs, and the third is the one most likely to break later.

```
node scripts/desc-budget.mjs .        → 4340/5000, exit 0
node scripts/scan-control-chars.mjs . → clean (160 files), exit 0
```

## Release

`0.1.9` bumped in all three version files in one commit, per `CLAUDE.md` — plugin.json for `claude plugin update`, marketplace.json for `claude plugin tag`, package.json for `npm-publish.yml`.

**No tag and no npm publish here.** Publishing is irreversible and a version once on npm cannot be replaced, so both tags are for the maintainer after review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)