### PR TITLE
feat(events): the journal learns progress, finding and ticket.status (14 → 17)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
     {
       "name": "tyran",
       "description": "A task conductor for Claude Code: multi-agent orchestration with an enforced evidence contract, repo-specific learning, and update-safe local evolution.",
-      "version": "0.1.10",
+      "version": "0.1.11",
       "source": "./",
       "author": {
         "name": "Jacek Janczura",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "tyran",
-  "version": "0.1.10",
+  "version": "0.1.11",
   "description": "A task conductor for Claude Code: multi-agent orchestration with an enforced evidence contract, repo-specific learning, and update-safe local evolution.",
   "author": {
     "name": "Jacek Janczura",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,9 @@
 The closed event set grows 14 → 17 — the reviewed core change the journal
 page names. `progress` is the agent's own mid-run signal (`started` ·
 `working` · `blocked` · `unblocked`, a closed list emitted at four named
-points, never part of spawn↔report pairing); `finding` is a claim plus its
-proof, queryable by other agents (`F-<n>` ids issued by `append`);
+points, never part of spawn↔report pairing); `finding` is a claim about a named
+area plus the proof for it, queryable by other agents (`F-<n>` ids issued
+by `append`);
 `ticket.status` is the conductor's lane override for exactly the three
 states no lifecycle event can derive (`blocked` · `waiting-operator` ·
 `parked`), cleared automatically by the next report, review or merge and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,28 @@
 # Changelog
 
+## 0.1.11 — 2026-08-13
+
+### The journal learns what agents are doing, finding, and waiting on
+
+The closed event set grows 14 → 17 — the reviewed core change the journal
+page names. `progress` is the agent's own mid-run signal (`started` ·
+`working` · `blocked` · `unblocked`, a closed list emitted at four named
+points, never part of spawn↔report pairing); `finding` is a claim plus its
+proof, queryable by other agents (`F-<n>` ids issued by `append`);
+`ticket.status` is the conductor's lane override for exactly the three
+states no lifecycle event can derive (`blocked` · `waiting-operator` ·
+`parked`), cleared automatically by the next report, review or merge and
+never counted as progress. Both new value sets are closed and rejected at
+append naming the whole set; the free-text keys `detail`/`claim`/`proof`
+cap at 2 000 codepoints — rejected, never truncated.
+
+STATE.md gains `Open blockages` and `Findings` sections and a per-agent
+`Last signal` column; doctor gains `spawn-blocked` (an agent whose own last
+signal says blocked, past a threshold); the agent contracts gain the
+emission points, the anti-duplication grep, and the implementer's "what you
+did NOT do" report section; operator questions and mid-run ticket intake
+now land as journal events, so the coming board can render them.
+
 ## 0.1.10 — 2026-08-13
 
 ### Overnight mode: the usage cliff becomes a wind-down

--- a/agents/implementer.md
+++ b/agents/implementer.md
@@ -21,14 +21,15 @@ commits and anything written to disk are in English.**
      was honoured) · `blocked` at the FIRST blockage, BEFORE attempting any
      workaround · `unblocked` when it clears · `working` before the final
      full validation run, the longest silent stretch you have. Shape:
-     `node <journal-script> append <abs-journal> progress <init> --actor <you>
-     --data '{"agent":"<you>","state":"blocked","ticket":"T-n","detail":"..."}'`.
+     `node ${CLAUDE_PLUGIN_ROOT}/scripts/journal.mjs append <abs-journal>
+     progress <init> --actor <you> --data
+     '{"agent":"<you>","state":"blocked","ticket":"T-n","detail":"..."}'`.
      Four emissions per story; this is a closed list, not a diary.
    - **Grep before you build.** Search for an existing implementation of the
      thing you are about to write; if it exists, report it as a corrected
      premise instead of duplicating it. Durable discoveries worth another
-     agent's time go into the journal as `finding` events — a claim plus its
-     proof — not only into prose.
+     agent's time go into the journal as `finding` events (`area` + `claim`
+     are required, plus its `proof`) — not only into prose.
    - **Verify the handoff's premises in the code.** A stale path, a wrong
      assignment, a function that no longer exists — correct it and report the
      correction EXPLICITLY instead of executing blindly. Premises about DATA

--- a/agents/implementer.md
+++ b/agents/implementer.md
@@ -15,6 +15,20 @@ commits and anything written to disk are in English.**
      lease file as the handoff describes. Another agent's unexpired lease
      means you do NOT start — you report back. Release it when you finish,
      including when you finish by failing.
+   - **Signal at four points, no more** — `progress` events appended to the
+     MAIN checkout's journal (the handoff carries its absolute path):
+     `started` right after the lease (it is also the proof the lease protocol
+     was honoured) · `blocked` at the FIRST blockage, BEFORE attempting any
+     workaround · `unblocked` when it clears · `working` before the final
+     full validation run, the longest silent stretch you have. Shape:
+     `node <journal-script> append <abs-journal> progress <init> --actor <you>
+     --data '{"agent":"<you>","state":"blocked","ticket":"T-n","detail":"..."}'`.
+     Four emissions per story; this is a closed list, not a diary.
+   - **Grep before you build.** Search for an existing implementation of the
+     thing you are about to write; if it exists, report it as a corrected
+     premise instead of duplicating it. Durable discoveries worth another
+     agent's time go into the journal as `finding` events — a claim plus its
+     proof — not only into prose.
    - **Verify the handoff's premises in the code.** A stale path, a wrong
      assignment, a function that no longer exists — correct it and report the
      correction EXPLICITLY instead of executing blindly. Premises about DATA
@@ -54,9 +68,11 @@ commits and anything written to disk are in English.**
      and showing it still fails — not by asserting it. Take that baseline
      after a `git fetch` run immediately beforehand; a stale remote once
      turned a correct proof into a false accusation.
-7. **Final report:** what was done · test and validation output · what the
-   optimization pass changed · branch or PR · premises you corrected · a
-   verdict on every knowledge-brief entry id in your handoff (helped, wrong,
-   or unused — the retrospective folds these into the store's counters) ·
-   open doubts. The open doubts are worth more than the summary; do not tidy
-   them away.
+7. **Final report:** what was done · **what you did NOT do** (scope cut,
+   tests skipped, the input class you never exercised — name the worst case
+   for each, this section is a merge gate) · test and validation output ·
+   what the optimization pass changed · branch or PR · premises you
+   corrected · a verdict on every knowledge-brief entry id in your handoff
+   (helped, wrong, or unused — the retrospective folds these into the
+   store's counters) · open doubts. The open doubts are worth more than the
+   summary; do not tidy them away.

--- a/agents/retro.md
+++ b/agents/retro.md
@@ -17,6 +17,10 @@ to disk is in English.**
    the process itself).
 2. The agents' reports from this initiative: corrected premises, escalations,
    open doubts. This is the densest source of signal you have.
+   Alongside them, the journal's `finding` events (`journal.mjs query <file>
+   --ev finding`) — the claims agents recorded WITH proof, mid-run. Promote
+   the recurring ones into `.tyran/knowledge/` through the filter below; the
+   rest die with the initiative, which is correct.
 3. `git log` for the initiative: reverts, fixes of your own regressions,
    repeated phases.
 4. The current state of `skills/`, `agents/`, `scripts/` and the docs — **so

--- a/agents/reviewer.md
+++ b/agents/reviewer.md
@@ -25,6 +25,10 @@ that keeps you.
    author's report with no raw command output you reject on sight, without
    reading further. Run the tests yourself; for UI, drive the browser yourself
    through `browser-check`. Paste what you got, with counts.
+   - **Signal `started` after taking your lease, `blocked`/`unblocked` when a
+     blockage genuinely stops the review** — `progress` events to the main
+     checkout's journal, path from the handoff. No `working` signal: your
+     `review` event is your completion, and it closes your spawn.
    - Settle disputed measurements (font size, padding, colour) by dumping
      computed styles to JSON, never by eye. An "it looks off" audit produces
      wrong findings at roughly the rate it produces right ones.

--- a/agents/scout.md
+++ b/agents/scout.md
@@ -17,7 +17,10 @@ disk is in English.**
 2. **A finding is a claim plus its proof.** Every line you return is
    `finding -> path:line, quoted fragment, or URL`. The conductor reads dozens
    of these; there is no budget for warm-up paragraphs, and an unsourced
-   finding costs more than no finding because someone will act on it.
+   finding costs more than no finding because someone will act on it. Prefix
+   the ones that will outlive this task with `DURABLE:` — the conductor
+   journals those as `finding` events (rule 1 stands: you write nothing, not
+   even to the journal; the prefix is how a durable fact reaches it anyway).
 3. **When you did not find something, say "I did not find it"** and list
    where you looked. Never fill the gap with a guess. Anchor every grep over
    env or config files (`grep -nE '^VARIABLE='`) — an unanchored grep matches

--- a/docs/doctor.md
+++ b/docs/doctor.md
@@ -1,6 +1,6 @@
 # Doctor reference
 
-`scripts/doctor.mjs --state` · 90 unit tests
+`scripts/doctor.mjs --state` · 92 unit tests
 
 Doctor **diagnoses, it never repairs.** Every finding carries a severity, a
 location and a command you can paste.
@@ -56,7 +56,7 @@ possible to change one and keep the suite green.
 | `check-failed` | error | one check threw on this journal — the other checks still ran |
 | `spawn-open` | info | the journal still believes this agent is working |
 | `spawn-stale` | warning | ...and the initiative moved on without it (see the clock below) |
-| `spawn-blocked` | warning | the agent's own last `progress` signal says `blocked` and it has stood past the threshold — the conductor should unblock or close it |
+| `spawn-blocked` | warning | the agent's own last `progress` signal says `blocked` and it has stood past the threshold (see the clock below) — the conductor should unblock or close it |
 | `spawn-duplicate` | warning | two open spawns for one agent name — pairing is ambiguous (ADR-18) |
 | `spawn-orphan-report` | warning | a `report` that closes nothing |
 | `agent-name-unusable` | warning | an agent name that cannot act as a correlator; those events are excluded from pairing |
@@ -163,6 +163,12 @@ node scripts/doctor.mjs --state --now "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
 ```
 
 `--stale-hours` moves the threshold (default 4).
+
+`spawn-blocked` reads the same journal clock against a threshold of its own: a
+self-reported `blocked` signal that has stood for **1 hour** of journal time.
+That hour is fixed — `--stale-hours` moves staleness only. A signal counts
+only for the spawn it was emitted during, so a re-spawned agent name does not
+inherit the blockage its previous incarnation's report already cleared.
 
 ## Dead policy rules
 

--- a/docs/doctor.md
+++ b/docs/doctor.md
@@ -1,6 +1,6 @@
 # Doctor reference
 
-`scripts/doctor.mjs --state` · 89 unit tests
+`scripts/doctor.mjs --state` · 90 unit tests
 
 Doctor **diagnoses, it never repairs.** Every finding carries a severity, a
 location and a command you can paste.
@@ -56,6 +56,7 @@ possible to change one and keep the suite green.
 | `check-failed` | error | one check threw on this journal — the other checks still ran |
 | `spawn-open` | info | the journal still believes this agent is working |
 | `spawn-stale` | warning | ...and the initiative moved on without it (see the clock below) |
+| `spawn-blocked` | warning | the agent's own last `progress` signal says `blocked` and it has stood past the threshold — the conductor should unblock or close it |
 | `spawn-duplicate` | warning | two open spawns for one agent name — pairing is ambiguous (ADR-18) |
 | `spawn-orphan-report` | warning | a `report` that closes nothing |
 | `agent-name-unusable` | warning | an agent name that cannot act as a correlator; those events are excluded from pairing |

--- a/docs/journal.md
+++ b/docs/journal.md
@@ -1,6 +1,6 @@
 # Journal reference
 
-`scripts/journal.mjs` · 54 unit tests
+`scripts/journal.mjs` · 59 unit tests
 
 This page is the schema contract; extending the event set is a reviewed core
 change.
@@ -29,24 +29,35 @@ contents are moved, one initiative directory at a time, under `state/`.
 | `actor` | string | who wrote the event (agent name or `conductor`) |
 | `data` | object | free-form, but each type's required keys are enforced |
 
-## Closed event set (14)
+## Closed event set (17)
 
 | `ev` | Required `data` keys | Meaning |
 |---|---|---|
 | `init.created` | — | initiative opened |
 | `plan.accepted` | — | plan gate passed; routing snapshot frozen |
 | `ticket.created` | `id` | unit of work (+ `deps[]`, `files_predicted[]`) |
+| `ticket.status` | `ticket`, `column` | conductor-only lane override; `column` ∈ `blocked` · `waiting-operator` · `parked` — only the lanes no lifecycle event can derive. Cleared by the next `report`/`review`/`merge` |
 | `spawn` | `agent`, `role` | agent started (+ `model`, `ticket`, `worktree`); `agent` must have no open spawn — see below |
 | `report` | `agent`, `verdict` | agent finished (+ `evidence[]: {cmd, exit, counts}`); closes that agent's open spawn |
+| `progress` | `agent`, `state` | the agent's own mid-run signal; `state` ∈ `started` · `working` · `blocked` · `unblocked` (+ `ticket`, `detail`, `next`). Never part of spawn↔report pairing |
 | `gate` | `kind`, `result` | quality gate outcome (+ `evidence_ref`) |
 | `review` | `ticket`, `verdict`, `by` | independent review verdict (closes the reviewer’s open spawn — role `reviewer` only) |
 | `merge` | `ticket`, `sha` | merged (+ `mode`) |
 | `decision` | `id`, `text` | ledger entry (`append` issues the id when omitted or empty) |
+| `finding` | `area`, `claim` | a claim plus its proof, queryable by other agents (+ `proof`, `ticket`, `confidence`; `append` issues `F-<n>` ids) |
 | `lease.acquired` | `resource`, `holder` | worktree / heavy-slot lease taken |
 | `lease.released` | `resource`, `holder` | lease returned |
 | `checkpoint` | `phase`, `next_steps` | resume surface (re-injected after compaction) |
 | `retro.entry` | `kind`, `target` | self-improvement ledger (+ `confidence`) |
 | `error` | `class` | failure record (+ `detail`) |
+
+Two value rules ride the schema, enforced at append time: the `progress.state`
+and `ticket.status.column` sets are CLOSED (an unknown value is rejected
+naming the whole set, exactly like an unknown `ev`), and the free-text keys
+`detail`, `claim` and `proof` are capped at 2 000 codepoints — rejected, never
+truncated; long material belongs in `NOTES.md` with a reference here.
+`validateJournal` reports historical oversizes as warnings only.
+
 
 ## Guarantees
 

--- a/docs/journal.md
+++ b/docs/journal.md
@@ -44,7 +44,7 @@ contents are moved, one initiative directory at a time, under `state/`.
 | `review` | `ticket`, `verdict`, `by` | independent review verdict (closes the reviewer’s open spawn — role `reviewer` only) |
 | `merge` | `ticket`, `sha` | merged (+ `mode`) |
 | `decision` | `id`, `text` | ledger entry (`append` issues the id when omitted or empty) |
-| `finding` | `area`, `claim` | a claim plus its proof, queryable by other agents (+ `proof`, `ticket`, `confidence`; `append` issues `F-<n>` ids) |
+| `finding` | `area`, `claim` | a claim about one `area`, with its proof, queryable by other agents (+ `proof`, `ticket`, `confidence`; `append` issues `F-<n>` ids) |
 | `lease.acquired` | `resource`, `holder` | worktree / heavy-slot lease taken |
 | `lease.released` | `resource`, `holder` | lease returned |
 | `checkpoint` | `phase`, `next_steps` | resume surface (re-injected after compaction) |

--- a/docs/projections.md
+++ b/docs/projections.md
@@ -1,6 +1,6 @@
 # Projections reference
 
-`scripts/project.mjs` · 51 unit tests, including byte-exact
+`scripts/project.mjs` · 58 unit tests, including byte-exact
 golden files
 
 The journal stays the only source of truth; everything on this page is a
@@ -105,7 +105,7 @@ catch.
 | Agents | `spawn`, closed by the next `report` for the same agent name; the Last signal column is the agent's latest `progress` event, shown on running rows only |
 | Open blockages | `progress` with `state: blocked` — cleared by the same agent's next movement signal and by `report`/`review`/`merge` |
 | Findings | `finding` events, in journal order |
-| Ledger | `ticket.created`, `ticket.status` (a lane override that never moves the percent), `spawn`, `report`, `review`, `merge` |
+| Ledger | `ticket.created`, `ticket.status` (a lane override that never moves the percent, and never invents a ticket — one naming an id no other event created is ignored, loudly), `spawn`, `report`, `review`, `merge` |
 | Gates | `gate` — the latest event per `kind` |
 | Leases | `lease.acquired` / `lease.released` |
 | Decisions · Retro · Errors | `decision` · `retro.entry` · `error` |

--- a/docs/projections.md
+++ b/docs/projections.md
@@ -1,6 +1,6 @@
 # Projections reference
 
-`scripts/project.mjs` · 48 unit tests, including byte-exact
+`scripts/project.mjs` · 51 unit tests, including byte-exact
 golden files
 
 The journal stays the only source of truth; everything on this page is a
@@ -102,8 +102,10 @@ catch.
 | Section | Built from |
 |---|---|
 | Checkpoint | the last `checkpoint` event (+ `plan.accepted`, and the last event of any type) |
-| Agents | `spawn`, closed by the next `report` for the same agent name |
-| Ledger | `ticket.created`, `spawn`, `report`, `review`, `merge` |
+| Agents | `spawn`, closed by the next `report` for the same agent name; the Last signal column is the agent's latest `progress` event, shown on running rows only |
+| Open blockages | `progress` with `state: blocked` — cleared by the same agent's next movement signal and by `report`/`review`/`merge` |
+| Findings | `finding` events, in journal order |
+| Ledger | `ticket.created`, `ticket.status` (a lane override that never moves the percent), `spawn`, `report`, `review`, `merge` |
 | Gates | `gate` — the latest event per `kind` |
 | Leases | `lease.acquired` / `lease.released` |
 | Decisions · Retro · Errors | `decision` · `retro.entry` · `error` |

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jjanczur/tyran",
-  "version": "0.1.10",
+  "version": "0.1.11",
   "description": "Command-line scripts for the Tyran task conductor (doctor, journal, schema, and repo tooling) for CI and terminals outside Claude Code. Installing this package does NOT install the Claude Code plugin — add that separately with `/plugin marketplace add jjanczur/tyran` inside Claude Code.",
   "type": "module",
   "engines": {

--- a/scripts/doctor.mjs
+++ b/scripts/doctor.mjs
@@ -697,7 +697,15 @@ function spawnFindings(journalPath, at, dirName, events, reference, staleHours) 
     for (const spawn of open.get(agent)) {
       const age = reference === null ? null : hoursBetween(spawn.ts, reference);
       const where = `${show(spawn.data.ticket ?? 'no ticket')}, role ${show(spawn.data.role)}`;
-      const signal = signals.get(agent) ?? null;
+      // `lastSignals` is keyed by agent NAME, and ADR-18 permits a name to be
+      // re-spawned once its previous spawn is closed — so the latest signal
+      // under this name may belong to an incarnation that has already
+      // reported, whose blockage the report cleared. Only a signal emitted
+      // during THIS spawn describes the agent running now; a pair that cannot
+      // be ordered (a hand-edited timestamp) is not evidence either.
+      const latest = signals.get(agent) ?? null;
+      const sinceSpawn = latest === null ? null : hoursBetween(spawn.ts, latest.ts);
+      const signal = sinceSpawn !== null && sinceSpawn >= 0 ? latest : null;
       const blockedHours =
         signal?.state === 'blocked' && reference !== null ? hoursBetween(signal.ts, reference) : null;
       if (blockedHours !== null && blockedHours >= DEFAULT_BLOCKED_HOURS) {

--- a/scripts/doctor.mjs
+++ b/scripts/doctor.mjs
@@ -154,6 +154,7 @@ export const SEVERITY_BY_CODE = Object.freeze(
     // spawns
     'spawn-open': 'info',
     'spawn-stale': 'warning',
+    'spawn-blocked': 'warning',
     'spawn-duplicate': 'warning',
     'spawn-orphan-report': 'warning',
     'agent-name-unusable': 'warning',
@@ -674,14 +675,42 @@ function closeSpawnHint(journalPath, init, agent) {
     : `node scripts/journal.mjs close-spawn ${sq(journalPath)} ${sq(slug)} ${sq(agent)} --reason "<why>"`;
 }
 
+/** How long a self-reported `blocked` may stand before it is a finding. */
+export const DEFAULT_BLOCKED_HOURS = 1;
+
+/** The latest `progress` signal per agent, from the raw events. */
+function lastSignals(events) {
+  const signals = new Map();
+  for (const e of events) {
+    if (e?.ev === 'progress' && typeof e?.data?.agent === 'string') {
+      signals.set(e.data.agent, { state: e.data.state ?? null, detail: e.data.detail ?? null, ts: e.ts ?? null });
+    }
+  }
+  return signals;
+}
+
 function spawnFindings(journalPath, at, dirName, events, reference, staleHours) {
   const findings = [];
   const { open } = pairSpawns(events);
+  const signals = lastSignals(events);
   for (const agent of sortedNames(open.keys())) {
     for (const spawn of open.get(agent)) {
       const age = reference === null ? null : hoursBetween(spawn.ts, reference);
       const where = `${show(spawn.data.ticket ?? 'no ticket')}, role ${show(spawn.data.role)}`;
-      if (age !== null && age >= staleHours) {
+      const signal = signals.get(agent) ?? null;
+      const blockedHours =
+        signal?.state === 'blocked' && reference !== null ? hoursBetween(signal.ts, reference) : null;
+      if (blockedHours !== null && blockedHours >= DEFAULT_BLOCKED_HOURS) {
+        findings.push(
+          finding(
+            'spawn-blocked',
+            at,
+            `agent "${show(agent)}" reported itself BLOCKED ${blockedHours.toFixed(1)} h of journal time ago ` +
+              `(${show(signal.detail ?? 'no detail')}) and nothing has cleared it. ${where}`,
+            closeSpawnHint(journalPath, spawn.init ?? dirName, agent),
+          ),
+        );
+      } else if (age !== null && age >= staleHours) {
         findings.push(
           finding(
             'spawn-stale',
@@ -697,7 +726,9 @@ function spawnFindings(journalPath, at, dirName, events, reference, staleHours) 
           finding(
             'spawn-open',
             at,
-            `agent "${show(agent)}" is still working (spawned ${show(spawn.ts)}). ${where}`,
+            `agent "${show(agent)}" is still working (spawned ${show(spawn.ts)})` +
+              (signal ? ` — last signal ${show(signal.state)} at ${show(signal.ts)}` : '') +
+              `. ${where}`,
           ),
         );
       }

--- a/scripts/journal.mjs
+++ b/scripts/journal.mjs
@@ -40,12 +40,15 @@ export const EVENT_TYPES = Object.freeze([
   'init.created',
   'plan.accepted',
   'ticket.created',
+  'ticket.status',
   'spawn',
   'report',
+  'progress',
   'gate',
   'review',
   'merge',
   'decision',
+  'finding',
   'lease.acquired',
   'lease.released',
   'checkpoint',
@@ -58,23 +61,50 @@ export const EVENT_TYPES = Object.freeze([
  * prefix to issue it under. `ticket.created` is deliberately absent: a ticket
  * id comes from the plan, which numbers its own stories.
  */
-export const ID_ISSUED_FOR = Object.freeze(Object.assign(Object.create(null), { decision: 'D' }));
+export const ID_ISSUED_FOR = Object.freeze(Object.assign(Object.create(null), { decision: 'D', finding: 'F' }));
 
 /** Per-type required keys inside `data` (data may always carry extra keys). */
 export const DATA_REQUIRED = Object.freeze({
   'ticket.created': ['id'],
+  'ticket.status': ['ticket', 'column'],
   spawn: ['agent', 'role'],
   report: ['agent', 'verdict'],
+  progress: ['agent', 'state'],
   gate: ['kind', 'result'],
   review: ['ticket', 'verdict', 'by'],
   merge: ['ticket', 'sha'],
   decision: ['id', 'text'],
+  finding: ['area', 'claim'],
   'lease.acquired': ['resource', 'holder'],
   'lease.released': ['resource', 'holder'],
   checkpoint: ['phase', 'next_steps'],
   'retro.entry': ['kind', 'target'],
   error: ['class'],
 });
+
+/**
+ * Closed VALUE sets inside `data`, for the same reason the event set is
+ * closed: an unknown value must be a loud rejection at append time, not a
+ * surprise in a projection. Hard errors are safe here because both types are
+ * new — no legacy journal can retroactively fail `validate`.
+ *
+ * `ticket.status.column` is deliberately NARROW: only the lanes no lifecycle
+ * event can ever derive. Anything broader would be a second source of truth
+ * against the derived board (`done` is what `merge` means; an override saying
+ * so would let the two disagree).
+ */
+export const DATA_ENUMS = Object.freeze({
+  progress: Object.freeze({ state: Object.freeze(['started', 'working', 'blocked', 'unblocked']) }),
+  'ticket.status': Object.freeze({ column: Object.freeze(['blocked', 'waiting-operator', 'parked']) }),
+});
+
+/**
+ * Free-text keys with a size ceiling, in codepoints. REJECTED at append,
+ * never truncated — the journal does not silently shorten anything. Long
+ * material belongs in NOTES.md with a reference here. `validateJournal`
+ * reports historical oversizes as warnings only (no retroactive errors).
+ */
+export const CAPPED_DATA_KEYS = Object.freeze({ detail: 2000, claim: 2000, proof: 2000 });
 
 /**
  * A journal-derived value on its way into a HUMAN-READABLE MESSAGE.
@@ -130,8 +160,35 @@ export function validateEvent(event) {
         errors.push(`data.id must be a string for ev "${q(event.ev)}" (got ${typeof event.data.id})`);
       }
     }
+    const enums = DATA_ENUMS[event.ev];
+    if (enums) {
+      for (const [key, allowed] of Object.entries(enums)) {
+        if (key in event.data && !allowed.includes(event.data[key])) {
+          // Name the whole set, same as the closed event set above: the agent
+          // recovering from this error has no other source of truth.
+          errors.push(
+            `data.${q(key)} "${q(event.data[key])}" is not valid for ev "${q(event.ev)}" — valid: ${allowed.join(', ')}`,
+          );
+        }
+      }
+    }
   }
   return errors;
+}
+
+/**
+ * The oversize problem of one capped data key, or null. Codepoints, not
+ * UTF-16 units, same as every other length rule in this repo.
+ */
+export function cappedKeyProblem(data) {
+  if (data === null || typeof data !== 'object') return null;
+  for (const [key, cap] of Object.entries(CAPPED_DATA_KEYS)) {
+    const value = data[key];
+    if (typeof value === 'string' && Array.from(value).length > cap) {
+      return `data.${key} is ${Array.from(value).length} codepoints (cap ${cap}) — put the full text in NOTES.md and reference it here`;
+    }
+  }
+  return null;
 }
 
 // -------------------------------------------------- spawn ↔ report pairing
@@ -410,7 +467,10 @@ function appendUnderLock(file, event, preread = null) {
   if (errors.length > 0) {
     throw new Error('invalid event: ' + errors.join('; '));
   }
-  if (stamped.ev === 'spawn' || stamped.ev === 'report') {
+  if (stamped.ev === 'spawn' || stamped.ev === 'report' || stamped.ev === 'progress') {
+    // `progress` joins the guard because data.agent is how a signal attaches
+    // to the agent row in the fold — a non-canonical name would silently
+    // fail to attach rather than error anywhere.
     const problem = agentNameProblem(stamped.data.agent);
     if (problem) {
       throw new Error(
@@ -418,6 +478,10 @@ function appendUnderLock(file, event, preread = null) {
           `between spawn and report (got ${JSON.stringify(stamped.data.agent)})`,
       );
     }
+  }
+  {
+    const oversize = cappedKeyProblem(stamped.data);
+    if (oversize) throw new Error(`invalid event: ${oversize}`);
   }
   if (stamped.ev === 'spawn') {
     // ADR-18: refuse a second OPEN spawn for one agent name. Same lock as the
@@ -556,6 +620,13 @@ export function validateJournal(file) {
   for (const [raw, problem] of badNames) {
     warnings.push(`unusable data.agent ${q(raw)}: ${problem} — excluded from spawn↔report pairing`);
   }
+  // Historical oversizes are warnings, never errors: the cap is enforced at
+  // append time, and a hand-edited file must stay visible without turning a
+  // whole journal's `validate` red retroactively.
+  events.forEach((e, i) => {
+    const oversize = cappedKeyProblem(e?.data);
+    if (oversize) warnings.push(`event ${i + 1}: ${oversize}`);
+  });
   return { ok: errors.length === 0, errors, warnings, count: events.length, truncatedTail };
 }
 

--- a/scripts/project.mjs
+++ b/scripts/project.mjs
@@ -178,19 +178,43 @@ function list(items) {
 
 // ------------------------------------------------------------------ fold
 
+/** The open blockage this agent reported clears when the agent moves on. */
+function clearBlockageBy(state, agent) {
+  state.blockages.delete(String(agent));
+}
+
+/** A `review`/`merge` settles the ticket for EVERY agent blocked on it. */
+function clearBlockagesOn(state, ticketId) {
+  for (const [key, blockage] of state.blockages) {
+    // A ticketless blockage is keyed to its agent and belongs to no ticket —
+    // the `(no ticket)` pseudo-ticket of a review/merge without `data.ticket`
+    // is a different thing and must not sweep it up.
+    if (blockage.ticket != null && String(blockage.ticket) === ticketId) state.blockages.delete(key);
+  }
+}
+
+/**
+ * A `report` — and a `review`, which is the reviewer's completion event —
+ * ENDS that agent's stint, so everything still keyed by its name goes with it.
+ *
+ * ADR-18 permits a later `spawn` to reuse the name once the prior one is
+ * closed, and that is the standard close-spawn recovery path, not an exotic
+ * journal. Kept, these records render against the NEXT incarnation: a fresh
+ * agent that has emitted nothing showed as `blocked at <old ts>` while
+ * `## Open blockages` said _none_ — one document contradicting itself. Cleared
+ * here, at fold time, so no reader has to compare timestamps of its own.
+ */
+function closeAgent(state, agent) {
+  clearBlockageBy(state, agent);
+  state.progressByAgent.delete(String(agent));
+}
+
 /**
  * Fold a journal read into the projection state. Pure: no clock, no I/O.
  * Every closed-set event type must hit a branch here; anything else is
  * counted in `unknownTypes` so a newer Tyran's events stay visible to an
  * older projector instead of vanishing.
  */
-/** Every open blockage this agent reported clears when the agent moves on. */
-function clearBlockagesBy(state, agent) {
-  for (const [key, blockage] of state.blockages) {
-    if (blockage.agent === agent) state.blockages.delete(key);
-  }
-}
-
 export function fold({ events = [], truncatedTail = false, badLines = [] } = {}) {
   const state = {
     initiatives: [],
@@ -219,12 +243,23 @@ export function fold({ events = [], truncatedTail = false, badLines = [] } = {})
     ambiguousAgents: [],
     // agent name -> latest self-reported signal (last one wins)
     progressByAgent: new Map(),
-    // ticket id (or "(agent) name" for ticketless blockage) -> open blockage;
-    // cleared by `unblocked`/`started`/`working` from the same agent and by
-    // the stronger lifecycle events, AT FOLD TIME — no reader needs temporal
-    // reasoning of its own.
+    // agent name -> that agent's open blockage, the ticket inside the value.
+    //
+    // Keyed by AGENT and not by ticket, because one agent has at most one live
+    // blockage (last-blocked-wins, exactly like its last signal) while one
+    // ticket can block SEVERAL agents. Under ticket keys the second agent's
+    // record replaced the first's, and the second agent's next movement signal
+    // then deleted a blockage its owner had never cleared — so an agent stayed
+    // stuck with nothing anywhere saying so. The ticket survives as rendered
+    // context and as what `review`/`merge` match against.
+    //
+    // Cleared by `unblocked`/`started`/`working` from the SAME agent, by that
+    // agent's report/review, and by a `review`/`merge` on the ticket — AT FOLD
+    // TIME, so no reader needs temporal reasoning of its own.
     blockages: new Map(),
     findings: [],
+    // `ticket.status` events naming a ticket no other event mentions
+    unknownOverrides: [],
   };
 
   /**
@@ -377,7 +412,7 @@ export function fold({ events = [], truncatedTail = false, badLines = [] } = {})
           t.report = { verdict: data.verdict ?? null, ts, by: data.agent ?? actor };
           t.override = null; // a lifecycle event outranks a hand-set lane
         }
-        if (data.agent != null) clearBlockagesBy(state, data.agent);
+        if (data.agent != null) closeAgent(state, data.agent);
         break;
       }
       case 'progress': {
@@ -390,12 +425,11 @@ export function fold({ events = [], truncatedTail = false, badLines = [] } = {})
           ts,
         });
         if (data.state === 'blocked') {
-          const key = data.ticket != null ? String(data.ticket) : `(agent) ${agent}`;
-          state.blockages.set(key, { ticket: data.ticket ?? null, agent, detail: data.detail ?? null, ts });
+          state.blockages.set(agent, { ticket: data.ticket ?? null, agent, detail: data.detail ?? null, ts });
         } else {
           // started / working / unblocked all say "this agent is moving";
           // whatever it reported itself blocked on is no longer blocking.
-          clearBlockagesBy(state, agent);
+          clearBlockageBy(state, agent);
         }
         break;
       }
@@ -412,7 +446,20 @@ export function fold({ events = [], truncatedTail = false, badLines = [] } = {})
         });
         break;
       case 'ticket.status': {
-        const t = ticketOf(data.ticket ?? '(no ticket)', ts);
+        // An override is a LANE, not progress: it must never move the percent.
+        // Minting a ledger ticket for an id no other event mentions did exactly
+        // that — one mistyped id (`T-1O` for `T-10`) enlarged the denominator
+        // and dropped the headline percent, while the ticket the operator meant
+        // to park stayed unparked. So the override lands only on a ticket the
+        // journal already knows; an unknown one is refused OUT LOUD (see
+        // `warnings()`) rather than inventing the ticket it names, because a
+        // silent exclusion is the failure ADR-19 correction 1 forbids.
+        const key = String(data.ticket ?? '(no ticket)');
+        if (!state.tickets.has(key)) {
+          state.unknownOverrides.push({ ticket: key, ts });
+          break;
+        }
+        const t = ticketOf(key, ts);
         t.override = { column: data.column ?? null, reason: data.reason ?? null, until: data.until ?? null, ts };
         break;
       }
@@ -435,14 +482,20 @@ export function fold({ events = [], truncatedTail = false, badLines = [] } = {})
         const t = ticketOf(data.ticket ?? '(no ticket)', ts);
         t.review = { verdict: data.verdict ?? null, by: data.by ?? actor, ts };
         t.override = null;
-        state.blockages.delete(t.id);
+        clearBlockagesOn(state, t.id);
+        // The review is the REVIEWER's completion event, as a report is the
+        // implementer's: pairSpawns closes the reviewer's spawn on `data.by`,
+        // and the same correlator closes what that spawn left behind. Without
+        // it a reviewer's ticketless blockage outlived its own review with no
+        // later event that could ever clear it.
+        if (data.by != null) closeAgent(state, data.by);
         break;
       }
       case 'merge': {
         const t = ticketOf(data.ticket ?? '(no ticket)', ts);
         t.merge = { sha: data.sha ?? null, mode: data.mode ?? null, ts };
         t.override = null;
-        state.blockages.delete(t.id);
+        clearBlockagesOn(state, t.id);
         break;
       }
       case 'decision':
@@ -536,6 +589,11 @@ export function warnings(state) {
   for (const [ev, n] of sortByKey([...state.unknownTypes.entries()], (e) => e[0])) {
     out.push(`unknown event type "${inlinePlain(ev)}" x${n} — counted but not folded (newer Tyran?)`);
   }
+  // The lane the operator meant to set is NOT set, and the id they typed is the
+  // only thing that can tell them why.
+  for (const { ticket } of state.unknownOverrides) {
+    out.push(`ticket.status for unknown ticket "${inlinePlain(ticket)}" — ignored (an override never invents a ticket)`);
+  }
   if (state.initiatives.length > 1) {
     out.push(
       `journal mixes ${state.initiatives.length} initiatives: ${state.initiatives.map((i) => inlinePlain(i)).join(', ')}`,
@@ -590,8 +648,10 @@ function renderState(state) {
     table(
       ['Agent', 'Role', 'Model', 'Ticket', 'Worktree', 'Status', 'Spawned', 'Last signal'],
       sortByKey(state.agents, (a) => `${a.agent} ${a.spawnTs ?? ''}`).map((a) => {
-        // A signal that outlived the report is stale by definition — only
-        // running rows carry one.
+        // A signal that outlived its report is stale by definition, and cannot
+        // be read here: the report deleted it at fold time (see `closeAgent`),
+        // and only running rows carry a signal at all. The filter alone was not
+        // enough — a re-spawned name is running again.
         const signal = a.status === 'running' ? state.progressByAgent.get(a.agent) : null;
         return [
           inline(a.agent),

--- a/scripts/project.mjs
+++ b/scripts/project.mjs
@@ -184,6 +184,13 @@ function list(items) {
  * counted in `unknownTypes` so a newer Tyran's events stay visible to an
  * older projector instead of vanishing.
  */
+/** Every open blockage this agent reported clears when the agent moves on. */
+function clearBlockagesBy(state, agent) {
+  for (const [key, blockage] of state.blockages) {
+    if (blockage.agent === agent) state.blockages.delete(key);
+  }
+}
+
 export function fold({ events = [], truncatedTail = false, badLines = [] } = {}) {
   const state = {
     initiatives: [],
@@ -210,6 +217,14 @@ export function fold({ events = [], truncatedTail = false, badLines = [] } = {})
     milestones: [],
     unusableAgentNames: [],
     ambiguousAgents: [],
+    // agent name -> latest self-reported signal (last one wins)
+    progressByAgent: new Map(),
+    // ticket id (or "(agent) name" for ticketless blockage) -> open blockage;
+    // cleared by `unblocked`/`started`/`working` from the same agent and by
+    // the stronger lifecycle events, AT FOLD TIME — no reader needs temporal
+    // reasoning of its own.
+    blockages: new Map(),
+    findings: [],
   };
 
   /**
@@ -259,6 +274,7 @@ export function fold({ events = [], truncatedTail = false, badLines = [] } = {})
         report: null,
         review: null,
         merge: null,
+        override: null,
         lastTs: seenTs ?? null,
       });
     }
@@ -357,8 +373,47 @@ export function fold({ events = [], truncatedTail = false, badLines = [] } = {})
           });
         }
         if (data.ticket != null) {
-          ticketOf(data.ticket, ts).report = { verdict: data.verdict ?? null, ts, by: data.agent ?? actor };
+          const t = ticketOf(data.ticket, ts);
+          t.report = { verdict: data.verdict ?? null, ts, by: data.agent ?? actor };
+          t.override = null; // a lifecycle event outranks a hand-set lane
         }
+        if (data.agent != null) clearBlockagesBy(state, data.agent);
+        break;
+      }
+      case 'progress': {
+        const agent = String(data.agent ?? '(no agent)');
+        state.progressByAgent.set(agent, {
+          state: data.state ?? null,
+          ticket: data.ticket ?? null,
+          detail: data.detail ?? null,
+          next: data.next ?? null,
+          ts,
+        });
+        if (data.state === 'blocked') {
+          const key = data.ticket != null ? String(data.ticket) : `(agent) ${agent}`;
+          state.blockages.set(key, { ticket: data.ticket ?? null, agent, detail: data.detail ?? null, ts });
+        } else {
+          // started / working / unblocked all say "this agent is moving";
+          // whatever it reported itself blocked on is no longer blocking.
+          clearBlockagesBy(state, agent);
+        }
+        break;
+      }
+      case 'finding':
+        state.findings.push({
+          id: data.id ?? null,
+          area: data.area ?? null,
+          claim: data.claim ?? null,
+          proof: data.proof ?? null,
+          ticket: data.ticket ?? null,
+          confidence: data.confidence ?? null,
+          ts,
+          actor,
+        });
+        break;
+      case 'ticket.status': {
+        const t = ticketOf(data.ticket ?? '(no ticket)', ts);
+        t.override = { column: data.column ?? null, reason: data.reason ?? null, until: data.until ?? null, ts };
         break;
       }
       case 'gate': {
@@ -376,20 +431,20 @@ export function fold({ events = [], truncatedTail = false, badLines = [] } = {})
       // `review`/`merge` require data.ticket, but a hand-written or older
       // journal may omit it — bucket those under a visible pseudo-ticket
       // instead of dropping the event (silent loss is the worse failure).
-      case 'review':
-        ticketOf(data.ticket ?? '(no ticket)', ts).review = {
-          verdict: data.verdict ?? null,
-          by: data.by ?? actor,
-          ts,
-        };
+      case 'review': {
+        const t = ticketOf(data.ticket ?? '(no ticket)', ts);
+        t.review = { verdict: data.verdict ?? null, by: data.by ?? actor, ts };
+        t.override = null;
+        state.blockages.delete(t.id);
         break;
-      case 'merge':
-        ticketOf(data.ticket ?? '(no ticket)', ts).merge = {
-          sha: data.sha ?? null,
-          mode: data.mode ?? null,
-          ts,
-        };
+      }
+      case 'merge': {
+        const t = ticketOf(data.ticket ?? '(no ticket)', ts);
+        t.merge = { sha: data.sha ?? null, mode: data.mode ?? null, ts };
+        t.override = null;
+        state.blockages.delete(t.id);
         break;
+      }
       case 'decision':
         state.decisions.push({ id: data.id ?? '(no id)', text: data.text ?? null, ts, actor });
         break;
@@ -433,6 +488,10 @@ export function fold({ events = [], truncatedTail = false, badLines = [] } = {})
 
 /** Human-readable status of one ticket, derived from the strongest signal. */
 export function ticketStatus(t) {
+  // A hand-set lane outranks derivation — but only until the next stronger
+  // lifecycle event, which clears it AT FOLD TIME. It never touches the
+  // merged count or the percent: an override is a lane, not progress.
+  if (t.override) return `${t.override.column ?? '(no column)'} (set by ticket.status)`;
   if (t.merge) return `merged (${t.merge.sha ?? 'no sha'})`;
   if (t.review) return `review: ${t.review.verdict ?? 'no verdict'}`;
   if (t.report) return `reported: ${t.report.verdict ?? 'no verdict'}`;
@@ -529,17 +588,52 @@ function renderState(state) {
   parts.push('\n## Agents\n\n');
   parts.push(
     table(
-      ['Agent', 'Role', 'Model', 'Ticket', 'Worktree', 'Status', 'Spawned'],
-      sortByKey(state.agents, (a) => `${a.agent} ${a.spawnTs ?? ''}`).map((a) => [
-        inline(a.agent),
-        inline(a.role),
-        inline(a.model),
-        inline(a.ticket),
-        inline(a.worktree),
-        a.status === 'running'
-          ? '**running (no report yet)**'
-          : `${inline(a.status)}${a.verdict == null ? '' : `: ${inline(a.verdict)}`}`,
-        inline(a.spawnTs),
+      ['Agent', 'Role', 'Model', 'Ticket', 'Worktree', 'Status', 'Spawned', 'Last signal'],
+      sortByKey(state.agents, (a) => `${a.agent} ${a.spawnTs ?? ''}`).map((a) => {
+        // A signal that outlived the report is stale by definition — only
+        // running rows carry one.
+        const signal = a.status === 'running' ? state.progressByAgent.get(a.agent) : null;
+        return [
+          inline(a.agent),
+          inline(a.role),
+          inline(a.model),
+          inline(a.ticket),
+          inline(a.worktree),
+          a.status === 'running'
+            ? '**running (no report yet)**'
+            : `${inline(a.status)}${a.verdict == null ? '' : `: ${inline(a.verdict)}`}`,
+          inline(a.spawnTs),
+          signal ? `${inline(signal.state)} at ${inline(signal.ts)}` : inline(null),
+        ];
+      }),
+    ),
+  );
+
+  parts.push('\n## Open blockages\n\n');
+  parts.push(
+    table(
+      ['Ticket', 'Agent', 'Detail', 'Since'],
+      sortByKey([...state.blockages.values()], (b) => `${b.ticket ?? ''} ${b.agent}`).map((b) => [
+        inline(b.ticket),
+        inline(b.agent),
+        inline(b.detail),
+        inline(b.ts),
+      ]),
+    ),
+  );
+
+  parts.push('\n## Findings\n\n');
+  parts.push(
+    table(
+      ['Id', 'Area', 'Claim', 'Proof', 'Ticket', 'By', 'At'],
+      state.findings.map((f) => [
+        inline(f.id),
+        inline(f.area),
+        inline(f.claim),
+        inline(f.proof),
+        inline(f.ticket),
+        inline(f.actor),
+        inline(f.ts),
       ]),
     ),
   );

--- a/site/src/content/docs/doctor.mdx
+++ b/site/src/content/docs/doctor.mdx
@@ -6,7 +6,7 @@ import Provenance from '../../components/Provenance.astro';
 import Limit from '../../components/Limit.astro';
 
 <Provenance>
-`scripts/doctor.mjs --state` · 90 unit tests
+`scripts/doctor.mjs --state` · 92 unit tests
 </Provenance>
 
 Doctor **diagnoses, it never repairs.** Every finding carries a severity, a
@@ -63,7 +63,7 @@ possible to change one and keep the suite green.
 | `check-failed` | error | one check threw on this journal — the other checks still ran |
 | `spawn-open` | info | the journal still believes this agent is working |
 | `spawn-stale` | warning | ...and the initiative moved on without it (see the clock below) |
-| `spawn-blocked` | warning | the agent's own last `progress` signal says `blocked` and it has stood past the threshold — the conductor should unblock or close it |
+| `spawn-blocked` | warning | the agent's own last `progress` signal says `blocked` and it has stood past the threshold (see the clock below) — the conductor should unblock or close it |
 | `spawn-duplicate` | warning | two open spawns for one agent name — pairing is ambiguous (ADR-18) |
 | `spawn-orphan-report` | warning | a `report` that closes nothing |
 | `agent-name-unusable` | warning | an agent name that cannot act as a correlator; those events are excluded from pairing |
@@ -170,6 +170,12 @@ node scripts/doctor.mjs --state --now "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
 ```
 
 `--stale-hours` moves the threshold (default 4).
+
+`spawn-blocked` reads the same journal clock against a threshold of its own: a
+self-reported `blocked` signal that has stood for **1 hour** of journal time.
+That hour is fixed — `--stale-hours` moves staleness only. A signal counts
+only for the spawn it was emitted during, so a re-spawned agent name does not
+inherit the blockage its previous incarnation's report already cleared.
 
 ## Dead policy rules
 

--- a/site/src/content/docs/doctor.mdx
+++ b/site/src/content/docs/doctor.mdx
@@ -6,7 +6,7 @@ import Provenance from '../../components/Provenance.astro';
 import Limit from '../../components/Limit.astro';
 
 <Provenance>
-`scripts/doctor.mjs --state` · 89 unit tests
+`scripts/doctor.mjs --state` · 90 unit tests
 </Provenance>
 
 Doctor **diagnoses, it never repairs.** Every finding carries a severity, a
@@ -63,6 +63,7 @@ possible to change one and keep the suite green.
 | `check-failed` | error | one check threw on this journal — the other checks still ran |
 | `spawn-open` | info | the journal still believes this agent is working |
 | `spawn-stale` | warning | ...and the initiative moved on without it (see the clock below) |
+| `spawn-blocked` | warning | the agent's own last `progress` signal says `blocked` and it has stood past the threshold — the conductor should unblock or close it |
 | `spawn-duplicate` | warning | two open spawns for one agent name — pairing is ambiguous (ADR-18) |
 | `spawn-orphan-report` | warning | a `report` that closes nothing |
 | `agent-name-unusable` | warning | an agent name that cannot act as a correlator; those events are excluded from pairing |

--- a/site/src/content/docs/journal.mdx
+++ b/site/src/content/docs/journal.mdx
@@ -67,7 +67,7 @@ contents are moved, one initiative directory at a time, under `state/`.
 | `review` | `ticket`, `verdict`, `by` | independent review verdict (closes the reviewer’s open spawn — role `reviewer` only) |
 | `merge` | `ticket`, `sha` | merged (+ `mode`) |
 | `decision` | `id`, `text` | ledger entry (`append` issues the id when omitted or empty) |
-| `finding` | `area`, `claim` | a claim plus its proof, queryable by other agents (+ `proof`, `ticket`, `confidence`; `append` issues `F-<n>` ids) |
+| `finding` | `area`, `claim` | a claim about one `area`, with its proof, queryable by other agents (+ `proof`, `ticket`, `confidence`; `append` issues `F-<n>` ids) |
 | `lease.acquired` | `resource`, `holder` | worktree / heavy-slot lease taken |
 | `lease.released` | `resource`, `holder` | lease returned |
 | `checkpoint` | `phase`, `next_steps` | resume surface (re-injected after compaction) |
@@ -97,9 +97,14 @@ flowchart TB
   G --> H(["merge"])
   H --> I(["retro.entry"])
 
+  C -. "conductor lane override, cleared by the next report / review / merge" .-> S(["ticket.status"])
+  D -. "the agent's own mid-run signal, never part of the pairing" .-> P(["progress"])
+  P -.-> E
+
   subgraph ANY["Recorded at any point"]
     direction LR
     J(["decision"])
+    N(["finding"])
     K(["lease.acquired / lease.released"])
     L(["checkpoint"])
     M(["error"])

--- a/site/src/content/docs/journal.mdx
+++ b/site/src/content/docs/journal.mdx
@@ -1,12 +1,12 @@
 ---
 title: 'Journal reference'
-description: 'The append-only JSONL event schema: the envelope, the closed set of 14 event types, the one-open-spawn-per-agent rule and its measured gaps.'
+description: 'The append-only JSONL event schema: the envelope, the closed set of 17 event types, the one-open-spawn-per-agent rule and its measured gaps.'
 ---
 import { FileTree } from '@astrojs/starlight/components';
 import Provenance from '../../components/Provenance.astro';
 
 <Provenance>
-`scripts/journal.mjs` · 54 unit tests
+`scripts/journal.mjs` · 59 unit tests
 </Provenance>
 
 This page is the schema contract; extending the event set is a reviewed core
@@ -52,24 +52,35 @@ contents are moved, one initiative directory at a time, under `state/`.
 | `actor` | string | who wrote the event (agent name or `conductor`) |
 | `data` | object | free-form, but each type's required keys are enforced |
 
-## Closed event set (14)
+## Closed event set (17)
 
 | `ev` | Required `data` keys | Meaning |
 |---|---|---|
 | `init.created` | — | initiative opened |
 | `plan.accepted` | — | plan gate passed; routing snapshot frozen |
 | `ticket.created` | `id` | unit of work (+ `deps[]`, `files_predicted[]`) |
+| `ticket.status` | `ticket`, `column` | conductor-only lane override; `column` ∈ `blocked` · `waiting-operator` · `parked` — only the lanes no lifecycle event can derive. Cleared by the next `report`/`review`/`merge` |
 | `spawn` | `agent`, `role` | agent started (+ `model`, `ticket`, `worktree`); `agent` must have no open spawn — see below |
 | `report` | `agent`, `verdict` | agent finished (+ `evidence[]: {cmd, exit, counts}`); closes that agent's open spawn |
+| `progress` | `agent`, `state` | the agent's own mid-run signal; `state` ∈ `started` · `working` · `blocked` · `unblocked` (+ `ticket`, `detail`, `next`). Never part of spawn↔report pairing |
 | `gate` | `kind`, `result` | quality gate outcome (+ `evidence_ref`) |
 | `review` | `ticket`, `verdict`, `by` | independent review verdict (closes the reviewer’s open spawn — role `reviewer` only) |
 | `merge` | `ticket`, `sha` | merged (+ `mode`) |
 | `decision` | `id`, `text` | ledger entry (`append` issues the id when omitted or empty) |
+| `finding` | `area`, `claim` | a claim plus its proof, queryable by other agents (+ `proof`, `ticket`, `confidence`; `append` issues `F-<n>` ids) |
 | `lease.acquired` | `resource`, `holder` | worktree / heavy-slot lease taken |
 | `lease.released` | `resource`, `holder` | lease returned |
 | `checkpoint` | `phase`, `next_steps` | resume surface (re-injected after compaction) |
 | `retro.entry` | `kind`, `target` | self-improvement ledger (+ `confidence`) |
 | `error` | `class` | failure record (+ `detail`) |
+
+Two value rules ride the schema, enforced at append time: the `progress.state`
+and `ticket.status.column` sets are CLOSED (an unknown value is rejected
+naming the whole set, exactly like an unknown `ev`), and the free-text keys
+`detail`, `claim` and `proof` are capped at 2 000 codepoints — rejected, never
+truncated; long material belongs in `NOTES.md` with a reference here.
+`validateJournal` reports historical oversizes as warnings only.
+
 
 The order those types arrive in over one initiative, as the table above
 defines them:

--- a/site/src/content/docs/projections.mdx
+++ b/site/src/content/docs/projections.mdx
@@ -5,7 +5,7 @@ description: 'How STATE.md and PROGRESS.md are generated from the journal, the d
 import Provenance from '../../components/Provenance.astro';
 
 <Provenance>
-`scripts/project.mjs` · 48 unit tests, including byte-exact golden files
+`scripts/project.mjs` · 51 unit tests, including byte-exact golden files
 </Provenance>
 
 The journal stays the only source of truth; everything on this page is a
@@ -107,8 +107,10 @@ catch.
 | Section | Built from |
 |---|---|
 | Checkpoint | the last `checkpoint` event (+ `plan.accepted`, and the last event of any type) |
-| Agents | `spawn`, closed by the next `report` for the same agent name |
-| Ledger | `ticket.created`, `spawn`, `report`, `review`, `merge` |
+| Agents | `spawn`, closed by the next `report` for the same agent name; the Last signal column is the agent's latest `progress` event, shown on running rows only |
+| Open blockages | `progress` with `state: blocked` — cleared by the same agent's next movement signal and by `report`/`review`/`merge` |
+| Findings | `finding` events, in journal order |
+| Ledger | `ticket.created`, `ticket.status` (a lane override that never moves the percent), `spawn`, `report`, `review`, `merge` |
 | Gates | `gate` — the latest event per `kind` |
 | Leases | `lease.acquired` / `lease.released` |
 | Decisions · Retro · Errors | `decision` · `retro.entry` · `error` |

--- a/site/src/content/docs/projections.mdx
+++ b/site/src/content/docs/projections.mdx
@@ -5,7 +5,7 @@ description: 'How STATE.md and PROGRESS.md are generated from the journal, the d
 import Provenance from '../../components/Provenance.astro';
 
 <Provenance>
-`scripts/project.mjs` · 51 unit tests, including byte-exact golden files
+`scripts/project.mjs` · 58 unit tests, including byte-exact golden files
 </Provenance>
 
 The journal stays the only source of truth; everything on this page is a
@@ -110,7 +110,7 @@ catch.
 | Agents | `spawn`, closed by the next `report` for the same agent name; the Last signal column is the agent's latest `progress` event, shown on running rows only |
 | Open blockages | `progress` with `state: blocked` — cleared by the same agent's next movement signal and by `report`/`review`/`merge` |
 | Findings | `finding` events, in journal order |
-| Ledger | `ticket.created`, `ticket.status` (a lane override that never moves the percent), `spawn`, `report`, `review`, `merge` |
+| Ledger | `ticket.created`, `ticket.status` (a lane override that never moves the percent, and never invents a ticket — one naming an id no other event created is ignored, loudly), `spawn`, `report`, `review`, `merge` |
 | Gates | `gate` — the latest event per `kind` |
 | Leases | `lease.acquired` / `lease.released` |
 | Decisions · Retro · Errors | `decision` · `retro.entry` · `error` |

--- a/skills/run/SKILL.md
+++ b/skills/run/SKILL.md
@@ -166,16 +166,19 @@ open one.
      chasing you instead of reading reports.
    - **Operator messages mid-run queue; none is dropped silently.** Triage
      each at the next natural pause: which initiative (or a new one), what
-     size, then a `ticket.created` with `title`, `deps` and `files_predicted`
-     (numbered from the plan), or a `decision` when it changes course rather
-     than adds work. Confirm in one line — "queued as T-9". A thought that
-     never reached the journal does not exist. `ticket.status` is your lane
-     override for the three states no lifecycle event can derive (`blocked`,
-     `waiting-operator`, `parked`); the next report, review or merge clears
-     it.
-   - **Scout `DURABLE:` findings, you journal** as `finding` events (a claim
-     plus its proof) — scouts write nothing themselves. Implementers and
-     reviewers append their own.
+     size, then a `ticket.created` carrying `id` — the one key `append` does
+     NOT issue for you, so read it from the journal and never from memory:
+     `journal.mjs next-id <abs-journal> T` returns the next one, continuing
+     the plan's numbering — plus `title`, `deps` and `files_predicted`; or a
+     `decision` when it changes course rather than adds work. Confirm in one
+     line — "queued as T-9". A thought that never reached the journal does
+     not exist. `ticket.status` is your lane override for the three states no
+     lifecycle event can derive (`blocked`, `waiting-operator`, `parked`);
+     the next report, review or merge clears it.
+   - **Scout `DURABLE:` findings, you journal** as `finding` events — the
+     required keys are `area` + `claim` (the area is the path or subsystem the
+     scout's proof points at), plus that `proof` — scouts write nothing
+     themselves. Implementers and reviewers append their own.
 2. **Fresh context per task.** Handoffs are SELF-CONTAINED; the agent
    disappears afterwards. Never ask the operator to compact. **Every handoff
    carries eight things:** (1) the role and one story, one goal; (2) paths to

--- a/skills/run/SKILL.md
+++ b/skills/run/SKILL.md
@@ -164,10 +164,25 @@ open one.
      list: decide and record. Without this you ask a second time for consent
      you already have, which is the most common reason an operator ends up
      chasing you instead of reading reports.
+   - **Operator messages mid-run queue; none is dropped silently.** Triage
+     each at the next natural pause: which initiative (or a new one), what
+     size, then a `ticket.created` with `title`, `deps` and `files_predicted`
+     (numbered from the plan), or a `decision` when it changes course rather
+     than adds work. Confirm in one line — "queued as T-9". A thought that
+     never reached the journal does not exist. `ticket.status` is your lane
+     override for the three states no lifecycle event can derive (`blocked`,
+     `waiting-operator`, `parked`); the next report, review or merge clears
+     it.
+   - **Scout `DURABLE:` findings, you journal** as `finding` events (a claim
+     plus its proof) — scouts write nothing themselves. Implementers and
+     reviewers append their own.
 2. **Fresh context per task.** Handoffs are SELF-CONTAINED; the agent
    disappears afterwards. Never ask the operator to compact. **Every handoff
    carries eight things:** (1) the role and one story, one goal; (2) paths to
-   the files of record; (3) the iron rules copied VERBATIM, not linked;
+   the files of record — including the ABSOLUTE path of the initiative
+   journal in the MAIN checkout and the initiative slug, because worktree
+   agents append their `progress` and `finding` events there;
+   (3) the iron rules copied VERBATIM, not linked;
    (4) the lease protocol (rule 7); (5) the **evidence contract** — the report
    must contain raw command output (exit codes, `X passed / Y failed`); a
    paraphrase like "tests are green" with no log is a REJECTED report. Final
@@ -252,6 +267,12 @@ open one.
    (XL); product, visual and irreversible decisions, put in plain language
    with your recommendation; anything hard to undo or visible outside the
    repo. **"Shall I continue?" is forbidden.**
+   **Every question to the operator lands in the journal before (or as) you
+   ask it**: a `gate` event, `result: WAITING_ON_OPERATOR`, `data` carrying
+   `question`, `recommendation`, `default` and `ticket` when it has one — a
+   question that lives only in chat has to be re-litigated after every
+   compaction. When answered, append the same `kind` with `result: answered`
+   plus a `decision` recording the answer in the operator's words.
    **Check the brake before every spawn and every merge:**
    `node ${CLAUDE_PLUGIN_ROOT}/scripts/stop-check.mjs` — exit 1 means the
    operator created `.tyran/STOP`. Halt, report where you got to, and do not

--- a/tests/fixtures/golden/PROGRESS.md
+++ b/tests/fixtures/golden/PROGRESS.md
@@ -9,7 +9,7 @@ Initiative: **demo** · see `STATE.md` for the full state.
 
 - [x] `T-1` — merged (88ea8cb) — journal module
 - [ ] `T-2` — in progress — schemas &#124; with a pipe and &#96;backticks&#96;
-- [ ] `T-10` — open — projections
+- [ ] `T-10` — parked (set by ticket.status) — projections
 
 ## Open gates
 

--- a/tests/fixtures/golden/STATE.md
+++ b/tests/fixtures/golden/STATE.md
@@ -13,10 +13,22 @@
 
 ## Agents
 
-| Agent | Role | Model | Ticket | Worktree | Status | Spawned |
+| Agent | Role | Model | Ticket | Worktree | Status | Spawned | Last signal |
+|---|---|---|---|---|---|---|---|
+| impl-1 | implementer | work | T-1 | tyran-s1 | reported: done | 2026-07-26T09:04:01.000Z | &mdash; |
+| impl-2 | implementer | work | T-2 | tyran-s2 | **running (no report yet)** | 2026-07-26T09:36:01.000Z | blocked at 2026-07-26T09:41:40.000Z |
+
+## Open blockages
+
+| Ticket | Agent | Detail | Since |
+|---|---|---|---|
+| T-2 | impl-2 | waiting on the worktree lease | 2026-07-26T09:41:40.000Z |
+
+## Findings
+
+| Id | Area | Claim | Proof | Ticket | By | At |
 |---|---|---|---|---|---|---|
-| impl-1 | implementer | work | T-1 | tyran-s1 | reported: done | 2026-07-26T09:04:01.000Z |
-| impl-2 | implementer | work | T-2 | tyran-s2 | **running (no report yet)** | 2026-07-26T09:36:01.000Z |
+| F-1 | scripts/** | the suite needs the quoted glob | MODULE_NOT_FOUND without it | &mdash; | impl-2 | 2026-07-26T09:41:45.000Z |
 
 ## Ledger
 
@@ -24,7 +36,7 @@
 |---|---|---|---|---|---|
 | `T-1` | journal module | merged (88ea8cb) | &mdash; | impl-1 | 2026-07-26T09:32:00.000Z |
 | `T-2` | schemas &#124; with a pipe and &#96;backticks&#96; | in progress | T-1 | impl-2 | 2026-07-26T09:36:01.000Z |
-| `T-10` | projections | open | T-1 | &mdash; | 2026-07-26T09:02:02.000Z |
+| `T-10` | projections | parked (set by ticket.status) | T-1 | &mdash; | 2026-07-26T09:41:50.000Z |
 
 ## Open gates
 
@@ -77,10 +89,10 @@
 
 ## Journal integrity
 
-- **Events folded:** 20
+- **Events folded:** 23
 - **Unknown event types:** 0
 - **Non-object lines skipped:** 0
 - **Corrupt lines skipped:** 0
 - **Truncated final line:** no
 - **Timespan:** 2026-07-26T09:00:00.000Z → 2026-07-26T09:42:00.000Z
-- **Events by type:** `checkpoint` 1 · `decision` 1 · `error` 1 · `gate` 2 · `init.created` 1 · `lease.acquired` 2 · `lease.released` 2 · `merge` 1 · `plan.accepted` 1 · `report` 1 · `retro.entry` 1 · `review` 1 · `spawn` 2 · `ticket.created` 3
+- **Events by type:** `checkpoint` 1 · `decision` 1 · `error` 1 · `finding` 1 · `gate` 2 · `init.created` 1 · `lease.acquired` 2 · `lease.released` 2 · `merge` 1 · `plan.accepted` 1 · `progress` 1 · `report` 1 · `retro.entry` 1 · `review` 1 · `spawn` 2 · `ticket.created` 3 · `ticket.status` 1

--- a/tests/fixtures/journal-demo.jsonl
+++ b/tests/fixtures/journal-demo.jsonl
@@ -17,4 +17,7 @@
 {"ts":"2026-07-26T09:40:00.000Z","ev":"error","init":"demo","actor":"impl-2","data":{"class":"flaky-test","detail":"race in withLock under 20 concurrent processes"}}
 {"ts":"2026-07-26T09:41:00.000Z","ev":"retro.entry","init":"demo","actor":"tyran-retro","data":{"kind":"skill","target":"skills/tyran/SKILL.md","confidence":"medium"}}
 {"ts":"2026-07-26T09:41:30.000Z","ev":"lease.released","init":"demo","actor":"intruder","data":{"resource":"worktree:tyran-s2","holder":"intruder"}}
+{"ts":"2026-07-26T09:41:40.000Z","ev":"progress","init":"demo","actor":"impl-2","data":{"agent":"impl-2","state":"blocked","ticket":"T-2","detail":"waiting on the worktree lease"}}
+{"ts":"2026-07-26T09:41:45.000Z","ev":"finding","init":"demo","actor":"impl-2","data":{"id":"F-1","area":"scripts/**","claim":"the suite needs the quoted glob","proof":"MODULE_NOT_FOUND without it"}}
+{"ts":"2026-07-26T09:41:50.000Z","ev":"ticket.status","init":"demo","actor":"conductor","data":{"ticket":"T-10","column":"parked","reason":"pricing question open"}}
 {"ts":"2026-07-26T09:42:00.000Z","ev":"checkpoint","init":"demo","actor":"conductor","data":{"phase":"E2","next_steps":["re-read STATE.md","finish the T-2 review","then start T-10"]}}

--- a/tests/unit/doctor.test.mjs
+++ b/tests/unit/doctor.test.mjs
@@ -513,6 +513,47 @@ test('an agent blocked past the threshold is a warning; a moving agent is not', 
   assert.match(byCode(moving, 'spawn-open')[0].message, /last signal/);
 });
 
+test('a blocked agent that is ALSO stale reports blocked, not stale', () => {
+  const root = repo();
+  const dir = scaffold(root);
+  const journal = journalPathFor(dir);
+  writeJournal(journal, [
+    ev('2026-07-26T09:00:00.000Z', 'spawn', { agent: 'impl-1', role: 'implementer' }),
+    ev('2026-07-26T09:02:00.000Z', 'progress', { agent: 'impl-1', state: 'blocked', detail: 'registry 503' }),
+  ]);
+  regenerate(journal);
+  // The operationally important case — blocked all night — trips BOTH clocks:
+  // 15 h open (threshold 4) and 15 h blocked (threshold 1). Only one row may
+  // survive, and it must be the one carrying the reason the agent is stuck.
+  const overnight = runStateChecks({ dir, now: '2026-07-27T00:00:00.000Z' });
+  assert.equal(byCode(overnight, 'spawn-blocked').length, 1);
+  assert.match(byCode(overnight, 'spawn-blocked')[0].message, /registry 503/);
+  assert.deepEqual(byCode(overnight, 'spawn-stale'), [], 'blocked outranks stale, not only the plain open row');
+});
+
+test('a signal from a closed incarnation does not follow the name onto the next spawn', () => {
+  const root = repo();
+  const dir = scaffold(root);
+  const journal = journalPathFor(dir);
+  // ADR-18 permits a name to be re-spawned once its previous spawn is closed,
+  // and `close-spawn` recovery writes exactly this report. The report cleared
+  // the blockage — the fold says so — so the fresh spawn is a plain open row.
+  writeJournal(journal, [
+    ev('2026-07-26T00:10:00.000Z', 'spawn', { agent: 'impl-1', role: 'implementer', ticket: 'T-1' }),
+    ev('2026-07-26T00:20:00.000Z', 'progress', { agent: 'impl-1', state: 'blocked', detail: 'waiting on lease' }),
+    ev('2026-07-26T00:30:00.000Z', 'report', { agent: 'impl-1', verdict: 'done' }),
+    ev('2026-07-26T02:00:00.000Z', 'spawn', { agent: 'impl-1', role: 'implementer', ticket: 'T-2' }),
+    ev('2026-07-26T02:05:00.000Z', 'checkpoint', { phase: 'build', next_steps: [] }),
+  ]);
+  regenerate(journal);
+  const result = runStateChecks({ dir });
+  assert.deepEqual(byCode(result, 'spawn-blocked'), [], 'the blockage died with the incarnation that reported it');
+  const open = byCode(result, 'spawn-open');
+  assert.equal(open.length, 1);
+  assert.match(open[0].message, /T-2/);
+  assert.doesNotMatch(open[0].message, /last signal/, 'this spawn has signalled nothing yet');
+});
+
 // ---------------------------------------------------------- overnight mode
 
 const PAUSE_MARKER = (over = {}) => ({

--- a/tests/unit/doctor.test.mjs
+++ b/tests/unit/doctor.test.mjs
@@ -481,6 +481,38 @@ test('a custom-named state dir keeps both git checks asking about THAT name', ()
   }
 });
 
+// ------------------------------------------------------- progress signals
+
+test('an agent blocked past the threshold is a warning; a moving agent is not', () => {
+  const root = repo();
+  const dir = scaffold(root);
+  const journal = journalPathFor(dir);
+  writeJournal(journal, [
+    ev('2026-07-26T09:00:00.000Z', 'init.created', {}),
+    ev('2026-07-26T09:01:00.000Z', 'spawn', { agent: 'impl-1', role: 'implementer' }),
+    ev('2026-07-26T09:02:00.000Z', 'progress', { agent: 'impl-1', state: 'blocked', detail: 'lease held' }),
+  ]);
+  regenerate(journal);
+  const blocked = runStateChecks({ dir, now: '2026-07-26T10:30:00.000Z' });
+  const found = byCode(blocked, 'spawn-blocked');
+  assert.equal(found.length, 1);
+  assert.match(found[0].message, /lease held/);
+  assert.deepEqual(byCode(blocked, 'spawn-open'), [], 'blocked outranks the plain open row');
+
+  // an unblocked signal clears it back to spawn-open
+  writeJournal(journal, [
+    ev('2026-07-26T09:00:00.000Z', 'init.created', {}),
+    ev('2026-07-26T09:01:00.000Z', 'spawn', { agent: 'impl-1', role: 'implementer' }),
+    ev('2026-07-26T09:02:00.000Z', 'progress', { agent: 'impl-1', state: 'blocked', detail: 'lease held' }),
+    ev('2026-07-26T09:40:00.000Z', 'progress', { agent: 'impl-1', state: 'unblocked' }),
+  ]);
+  regenerate(journal);
+  const moving = runStateChecks({ dir, now: '2026-07-26T10:30:00.000Z' });
+  assert.deepEqual(byCode(moving, 'spawn-blocked'), []);
+  assert.equal(byCode(moving, 'spawn-open').length, 1);
+  assert.match(byCode(moving, 'spawn-open')[0].message, /last signal/);
+});
+
 // ---------------------------------------------------------- overnight mode
 
 const PAUSE_MARKER = (over = {}) => ({
@@ -1355,6 +1387,7 @@ const EXPECTED_SEVERITY = {
   'check-failed': 'error',
   'spawn-open': 'info',
   'spawn-stale': 'warning',
+  'spawn-blocked': 'warning',
   'spawn-duplicate': 'warning',
   'spawn-orphan-report': 'warning',
   'agent-name-unusable': 'warning',

--- a/tests/unit/journal.test.mjs
+++ b/tests/unit/journal.test.mjs
@@ -57,14 +57,43 @@ test('progress and ticket.status enums reject out-of-set values, naming the whol
   assert.ok(Object.isFrozen(DATA_ENUMS) && Object.isFrozen(DATA_ENUMS.progress.state));
 });
 
-test('an oversized capped key is REJECTED at append and only WARNED about in history', () => {
+/**
+ * The capped set is closed, and the table below spells it out INSTEAD OF
+ * iterating `CAPPED_DATA_KEYS`: a loop over the map under test silently skips
+ * whatever was deleted from it. Measured — with `detail` and `proof` dropped
+ * from `CAPPED_DATA_KEYS` the whole suite stayed green while both doc surfaces
+ * kept claiming all three keys are capped.
+ *
+ * Each key is carried by an event that legitimately holds it, so the rejection
+ * is the cap and not some other missing requirement.
+ */
+const OVERSIZED_EVENT_BY_KEY = [
+  ['detail', (big) => ({ ev: 'progress', data: { agent: 'impl-1', state: 'blocked', detail: big } })],
+  ['claim', (big) => ({ ev: 'finding', data: { id: 'F-1', area: 'a', claim: big } })],
+  ['proof', (big) => ({ ev: 'finding', data: { id: 'F-1', area: 'a', claim: 'c', proof: big } })],
+];
+
+test('EVERY capped key is REJECTED at append and only WARNED about in history', () => {
+  assert.deepEqual(
+    Object.keys(CAPPED_DATA_KEYS).sort(),
+    OVERSIZED_EVENT_BY_KEY.map(([key]) => key).sort(),
+    'the capped key set changed — docs/journal.md and its site mirror name these three',
+  );
+  for (const [key, build] of OVERSIZED_EVENT_BY_KEY) {
+    const cap = CAPPED_DATA_KEYS[key];
+    assert.equal(cap, 2000, `both doc surfaces claim a 2 000-codepoint cap for data.${key}`);
+    const file = tmp();
+    const big = 'x'.repeat(cap + 1);
+    assert.throws(
+      () => append(file, ev({ ...build(big), ts: undefined })),
+      new RegExp(`data\\.${key} is ${cap + 1} codepoints \\(cap ${cap}\\)`),
+      `an oversized data.${key} must be rejected at append, naming the key and the cap`,
+    );
+    assert.deepEqual(readJournal(file).events, [], `a rejected append must write nothing (data.${key})`);
+  }
+  // the same event hand-written into the file: validate stays ok, warns loudly
   const file = tmp();
   const big = 'x'.repeat(CAPPED_DATA_KEYS.claim + 1);
-  assert.throws(
-    () => append(file, ev({ ev: 'finding', ts: undefined, data: { id: 'F-1', area: 'a', claim: big } })),
-    /codepoints \(cap 2000\)/,
-  );
-  // the same event hand-written into the file: validate stays ok, warns loudly
   writeFileSync(file, JSON.stringify(ev({ ev: 'finding', data: { id: 'F-1', area: 'a', claim: big } })) + '\n');
   const result = validateJournal(file);
   assert.equal(result.ok, true, 'no retroactive errors');

--- a/tests/unit/journal.test.mjs
+++ b/tests/unit/journal.test.mjs
@@ -26,6 +26,9 @@ import {
   closeSpawn,
   pairSpawns,
   agentNameProblem,
+  DATA_ENUMS,
+  CAPPED_DATA_KEYS,
+  cappedKeyProblem,
 } from '../../scripts/journal.mjs';
 
 const SCRIPT = new URL('../../scripts/journal.mjs', import.meta.url).pathname;
@@ -40,6 +43,64 @@ const ev = (over = {}) => ({
 });
 
 // --- validateEvent -----------------------------------------------------
+
+// --- the 17-event additions --------------------------------------------
+
+test('progress and ticket.status enums reject out-of-set values, naming the whole set', () => {
+  const bad = validateEvent(ev({ ev: 'progress', data: { agent: 'a', state: 'flying' } }));
+  assert.ok(bad.some((e) => e.includes('started, working, blocked, unblocked')), bad.join('; '));
+  const badColumn = validateEvent(ev({ ev: 'ticket.status', data: { ticket: 'T-1', column: 'done' } }));
+  assert.ok(badColumn.some((e) => e.includes('blocked, waiting-operator, parked')), badColumn.join('; '));
+  // done is what merge means — the override set is deliberately narrow
+  assert.deepEqual(validateEvent(ev({ ev: 'ticket.status', data: { ticket: 'T-1', column: 'parked' } })), []);
+  assert.deepEqual(validateEvent(ev({ ev: 'progress', data: { agent: 'a', state: 'blocked' } })), []);
+  assert.ok(Object.isFrozen(DATA_ENUMS) && Object.isFrozen(DATA_ENUMS.progress.state));
+});
+
+test('an oversized capped key is REJECTED at append and only WARNED about in history', () => {
+  const file = tmp();
+  const big = 'x'.repeat(CAPPED_DATA_KEYS.claim + 1);
+  assert.throws(
+    () => append(file, ev({ ev: 'finding', ts: undefined, data: { id: 'F-1', area: 'a', claim: big } })),
+    /codepoints \(cap 2000\)/,
+  );
+  // the same event hand-written into the file: validate stays ok, warns loudly
+  writeFileSync(file, JSON.stringify(ev({ ev: 'finding', data: { id: 'F-1', area: 'a', claim: big } })) + '\n');
+  const result = validateJournal(file);
+  assert.equal(result.ok, true, 'no retroactive errors');
+  assert.ok(result.warnings.some((w) => w.includes('data.claim')), result.warnings.join('; '));
+  // codepoints, not UTF-16 units
+  assert.equal(cappedKeyProblem({ claim: '\u{1D400}'.repeat(CAPPED_DATA_KEYS.claim) }), null);
+});
+
+test('progress events never disturb spawn-report pairing (ADR-18)', () => {
+  const spawnEv = ev({ ev: 'spawn', ts: '2026-07-26T10:00:01.000Z', data: { agent: 'impl-1', role: 'implementer' } });
+  const progressEv = ev({ ev: 'progress', ts: '2026-07-26T10:00:02.000Z', data: { agent: 'impl-1', state: 'working' } });
+  const reportEv = ev({ ev: 'report', ts: '2026-07-26T10:00:03.000Z', data: { agent: 'impl-1', verdict: 'done' } });
+  const withProgress = pairSpawns([spawnEv, progressEv, reportEv]);
+  const without = pairSpawns([spawnEv, reportEv]);
+  assert.equal(withProgress.open.size, without.open.size);
+  assert.equal(withProgress.pairs.length, without.pairs.length);
+  assert.equal(withProgress.orphanReports.length, 0);
+});
+
+test('progress rejects an unusable agent name at append — it is a fold correlator', () => {
+  const file = tmp();
+  assert.throws(
+    () => append(file, ev({ ev: 'progress', ts: undefined, data: { agent: ' padded ', state: 'working' } })),
+    /data\.agent/,
+  );
+});
+
+test('finding gets F-ids issued by the CLI when omitted', () => {
+  const file = tmp();
+  const run = (args) => execFileSync(process.execPath, [SCRIPT, ...args], { encoding: 'utf8' });
+  run(['append', file, 'finding', 'demo', '--actor', 'scout-1', '--data', '{"area":"src/**","claim":"c"}']);
+  run(['append', file, 'finding', 'demo', '--actor', 'scout-1', '--data', '{"area":"src/**","claim":"d"}']);
+  const ids = readJournal(file).events.map((e) => e.data.id);
+  assert.deepEqual(ids, ['F-1', 'F-2']);
+});
+
 
 test('accepts a fully valid event', () => {
   assert.deepEqual(validateEvent(ev()), []);
@@ -355,7 +416,7 @@ test('the self-run guard survives an argv[1] that cannot be canonicalized', () =
 
 test('EVENT_TYPES is frozen and matches the documented closed set size', () => {
   assert.ok(Object.isFrozen(EVENT_TYPES));
-  assert.equal(EVENT_TYPES.length, 14);
+  assert.equal(EVENT_TYPES.length, 17);
 });
 
 // --- ADR-18: one open spawn per agent name -----------------------------

--- a/tests/unit/project.test.mjs
+++ b/tests/unit/project.test.mjs
@@ -29,6 +29,7 @@ import {
   checkFile,
   writeAtomic,
   writeAllAtomic,
+  ticketStatus,
 } from '../../scripts/project.mjs';
 
 /** First line of every projection — used to spot a half-written document. */
@@ -363,17 +364,76 @@ test('a lease released by a non-holder stays open and is reported', () => {
   assert.equal(state.mismatchedReleases.length, 1);
 });
 
+test('a blockage opens on blocked, clears on movement and on stronger lifecycle events', () => {
+  const base = [
+    ev({ ev: 'ticket.created', ts: '2026-07-26T09:00:00.000Z', data: { id: 'T-1' } }),
+    ev({ ev: 'progress', ts: '2026-07-26T09:01:00.000Z', data: { agent: 'impl-1', state: 'blocked', ticket: 'T-1', detail: 'lease held' } }),
+  ];
+  const open = fold({ events: base });
+  assert.equal(open.blockages.size, 1);
+  assert.equal(open.blockages.get('T-1').detail, 'lease held');
+
+  const unblocked = fold({ events: [...base, ev({ ev: 'progress', ts: '2026-07-26T09:02:00.000Z', data: { agent: 'impl-1', state: 'unblocked' } })] });
+  assert.equal(unblocked.blockages.size, 0, 'unblocked clears');
+
+  const reported = fold({ events: [...base, ev({ ev: 'report', ts: '2026-07-26T09:02:00.000Z', data: { agent: 'impl-1', verdict: 'done', ticket: 'T-1' } })] });
+  assert.equal(reported.blockages.size, 0, 'a report by the same agent clears');
+
+  const merged = fold({ events: [...base, ev({ ev: 'merge', ts: '2026-07-26T09:02:00.000Z', data: { ticket: 'T-1', sha: 'abc' } })] });
+  assert.equal(merged.blockages.size, 0, 'a merge on the ticket clears');
+
+  // a ticketless blockage keys on the agent and still clears on movement
+  const agentOnly = fold({ events: [ev({ ev: 'progress', ts: '2026-07-26T09:01:00.000Z', data: { agent: 'impl-2', state: 'blocked' } })] });
+  assert.equal(agentOnly.blockages.size, 1);
+});
+
+test('a ticket.status override wins the status line, clears on lifecycle, and NEVER moves the percent', () => {
+  const base = [
+    ev({ ev: 'ticket.created', ts: '2026-07-26T09:00:00.000Z', data: { id: 'T-1' } }),
+    ev({ ev: 'ticket.created', ts: '2026-07-26T09:00:01.000Z', data: { id: 'T-2' } }),
+    ev({ ev: 'ticket.status', ts: '2026-07-26T09:01:00.000Z', data: { ticket: 'T-1', column: 'parked', reason: 'pricing open' } }),
+  ];
+  const parked = fold({ events: base });
+  const t1 = parked.ticketList.find((t) => t.id === 'T-1');
+  assert.match(ticketStatus(t1), /^parked \(set by ticket\.status\)$/);
+  assert.equal(parked.percent, 0, 'an override is a lane, not progress');
+
+  const merged = fold({ events: [...base, ev({ ev: 'merge', ts: '2026-07-26T09:02:00.000Z', data: { ticket: 'T-1', sha: 'abc' } })] });
+  const t1m = merged.ticketList.find((t) => t.id === 'T-1');
+  assert.match(ticketStatus(t1m), /^merged /, 'merge clears the override');
+  assert.equal(merged.percent, 50);
+});
+
+test('the Agents table shows the last signal only on running rows', () => {
+  const events = [
+    ev({ ev: 'spawn', ts: '2026-07-26T09:00:00.000Z', data: { agent: 'impl-1', role: 'implementer' } }),
+    ev({ ev: 'progress', ts: '2026-07-26T09:01:00.000Z', data: { agent: 'impl-1', state: 'working' } }),
+    ev({ ev: 'spawn', ts: '2026-07-26T09:02:00.000Z', data: { agent: 'impl-2', role: 'implementer' } }),
+    ev({ ev: 'progress', ts: '2026-07-26T09:03:00.000Z', data: { agent: 'impl-2', state: 'working' } }),
+    ev({ ev: 'report', ts: '2026-07-26T09:04:00.000Z', data: { agent: 'impl-2', verdict: 'done' } }),
+  ];
+  const text = renderProjections({ events }).files[STATE_FILE];
+  const rows = text.split('\n').filter((l) => l.startsWith('| impl-'));
+  const running = rows.find((l) => l.startsWith('| impl-1'));
+  const done = rows.find((l) => l.startsWith('| impl-2'));
+  assert.match(running, /working at 2026-07-26T09:01:00\.000Z/);
+  assert.ok(!/working at/.test(done), 'a signal that outlived the report is stale and must not render');
+});
+
 test('every event type of the closed set is folded into a section (no silent loss)', () => {
   const sample = {
     'init.created': {},
     'plan.accepted': {},
     'ticket.created': { id: 'T-1' },
+    'ticket.status': { ticket: 'T-1', column: 'parked' },
     spawn: { agent: 'a', role: 'implementer' },
     report: { agent: 'a', verdict: 'done' },
+    progress: { agent: 'a', state: 'blocked', ticket: 'T-1', detail: 'waiting on a lease' },
     gate: { kind: 'tests', result: 'pass' },
     review: { ticket: 'T-1', verdict: 'APPROVE', by: 'r' },
     merge: { ticket: 'T-1', sha: 'abc' },
     decision: { id: 'D-1', text: 't' },
+    finding: { area: 'src/**', claim: 'c', proof: 'p' },
     'lease.acquired': { resource: 'r', holder: 'h' },
     'lease.released': { resource: 'r', holder: 'h' },
     checkpoint: { phase: 'F1', next_steps: ['s'] },

--- a/tests/unit/project.test.mjs
+++ b/tests/unit/project.test.mjs
@@ -364,30 +364,165 @@ test('a lease released by a non-holder stays open and is reported', () => {
   assert.equal(state.mismatchedReleases.length, 1);
 });
 
-test('a blockage opens on blocked, clears on movement and on stronger lifecycle events', () => {
+/**
+ * ONE CLEARING RULE PER TEST.
+ *
+ * These were two tests that named more rules than they exercised: blockages
+ * were only ever cleared by `report` and `merge`, the override only by `merge`,
+ * and the ticketless blockage was asserted to OPEN and never to clear. A single
+ * mutant could therefore delete three clauses at once — the override-clear on
+ * `report`, both clears on `review`, and the ticketless case in
+ * `clearBlockageBy` — and stay green. Each clause now has a test that dies
+ * alone, and each names the mutant that must kill it.
+ */
+const blocked = (agent, over = {}) =>
+  ev({ ev: 'progress', ts: '2026-07-26T09:01:00.000Z', data: { agent, state: 'blocked', detail: 'lease held', ...over } });
+
+test('a blockage opens on blocked and clears on the same agent next movement signal', () => {
+  // MUTANT: drop the `else` arm of the progress branch — the blockage then
+  // survives every signal short of a report.
   const base = [
     ev({ ev: 'ticket.created', ts: '2026-07-26T09:00:00.000Z', data: { id: 'T-1' } }),
-    ev({ ev: 'progress', ts: '2026-07-26T09:01:00.000Z', data: { agent: 'impl-1', state: 'blocked', ticket: 'T-1', detail: 'lease held' } }),
+    blocked('impl-1', { ticket: 'T-1' }),
   ];
   const open = fold({ events: base });
   assert.equal(open.blockages.size, 1);
-  assert.equal(open.blockages.get('T-1').detail, 'lease held');
+  assert.equal(open.blockages.get('impl-1').detail, 'lease held');
+  assert.equal(open.blockages.get('impl-1').ticket, 'T-1');
 
-  const unblocked = fold({ events: [...base, ev({ ev: 'progress', ts: '2026-07-26T09:02:00.000Z', data: { agent: 'impl-1', state: 'unblocked' } })] });
-  assert.equal(unblocked.blockages.size, 0, 'unblocked clears');
-
-  const reported = fold({ events: [...base, ev({ ev: 'report', ts: '2026-07-26T09:02:00.000Z', data: { agent: 'impl-1', verdict: 'done', ticket: 'T-1' } })] });
-  assert.equal(reported.blockages.size, 0, 'a report by the same agent clears');
-
-  const merged = fold({ events: [...base, ev({ ev: 'merge', ts: '2026-07-26T09:02:00.000Z', data: { ticket: 'T-1', sha: 'abc' } })] });
-  assert.equal(merged.blockages.size, 0, 'a merge on the ticket clears');
-
-  // a ticketless blockage keys on the agent and still clears on movement
-  const agentOnly = fold({ events: [ev({ ev: 'progress', ts: '2026-07-26T09:01:00.000Z', data: { agent: 'impl-2', state: 'blocked' } })] });
-  assert.equal(agentOnly.blockages.size, 1);
+  for (const state of ['unblocked', 'working', 'started']) {
+    const moved = fold({
+      events: [...base, ev({ ev: 'progress', ts: '2026-07-26T09:02:00.000Z', data: { agent: 'impl-1', state } })],
+    });
+    assert.equal(moved.blockages.size, 0, `${state} must clear the blockage`);
+  }
 });
 
-test('a ticket.status override wins the status line, clears on lifecycle, and NEVER moves the percent', () => {
+test('a TICKETLESS blockage clears on movement too, not only a ticketed one', () => {
+  // MUTANT: restrict the clear to blockages that carry a ticket. A reviewer or
+  // a scout blocked on something with no ticket then stays blocked forever,
+  // because nothing else will ever key on it.
+  const base = [blocked('impl-2')];
+  const open = fold({ events: base });
+  assert.equal(open.blockages.size, 1);
+  assert.equal(open.blockages.get('impl-2').ticket, null);
+
+  const moved = fold({
+    events: [...base, ev({ ev: 'progress', ts: '2026-07-26T09:02:00.000Z', data: { agent: 'impl-2', state: 'working' } })],
+  });
+  assert.equal(moved.blockages.size, 0);
+});
+
+test('a report clears its own agent blockage — ticketed or not', () => {
+  // MUTANT: remove `closeAgent`/`clearBlockageBy` from the report branch.
+  for (const over of [{ ticket: 'T-1' }, {}]) {
+    const state = fold({
+      events: [
+        blocked('impl-1', over),
+        ev({ ev: 'report', ts: '2026-07-26T09:02:00.000Z', data: { agent: 'impl-1', verdict: 'done', ticket: 'T-1' } }),
+      ],
+    });
+    assert.equal(state.blockages.size, 0, `a report left a ${over.ticket ? 'ticketed' : 'ticketless'} blockage open`);
+  }
+});
+
+test('a report clears the lane override on the ticket it reports', () => {
+  // MUTANT: remove `t.override = null` from the report branch — a parked lane
+  // then outranks the report that finished the work.
+  const state = fold({
+    events: [
+      ev({ ev: 'ticket.created', ts: '2026-07-26T09:00:00.000Z', data: { id: 'T-1' } }),
+      ev({ ev: 'ticket.status', ts: '2026-07-26T09:01:00.000Z', data: { ticket: 'T-1', column: 'parked' } }),
+      ev({ ev: 'report', ts: '2026-07-26T09:02:00.000Z', data: { agent: 'impl-1', verdict: 'done', ticket: 'T-1' } }),
+    ],
+  });
+  assert.match(ticketStatus(state.ticketList.find((t) => t.id === 'T-1')), /^reported: done$/);
+});
+
+test('a review clears the reviewer own blockage, the blockage on its ticket, and the lane override', () => {
+  // MUTANTS, three of them, and each assertion here kills exactly one:
+  //  - drop `closeAgent(state, data.by)`: the reviewer's TICKETLESS blockage
+  //    survives its own review, and no later event can ever clear it (the
+  //    review IS the reviewer's last event);
+  //  - drop `clearBlockagesOn`: the implementer stays blocked on a ticket that
+  //    has been reviewed;
+  //  - drop `t.override = null`: a parked lane outranks the verdict.
+  const review = ev({
+    ev: 'review',
+    ts: '2026-07-26T09:03:00.000Z',
+    data: { ticket: 'T-1', verdict: 'APPROVE', by: 'rev-1' },
+  });
+  const state = fold({
+    events: [
+      ev({ ev: 'ticket.created', ts: '2026-07-26T09:00:00.000Z', data: { id: 'T-1' } }),
+      ev({ ev: 'spawn', ts: '2026-07-26T09:00:30.000Z', data: { agent: 'rev-1', role: 'reviewer', ticket: 'T-1' } }),
+      blocked('rev-1', { detail: 'waiting for CI' }), // no ticket: keyed to the agent
+      blocked('impl-1', { ticket: 'T-1' }),
+      ev({ ev: 'ticket.status', ts: '2026-07-26T09:02:00.000Z', data: { ticket: 'T-1', column: 'parked' } }),
+      review,
+    ],
+  });
+  assert.deepEqual([...state.blockages.keys()], [], 'a review left a blockage open');
+  assert.match(ticketStatus(state.ticketList.find((t) => t.id === 'T-1')), /^review: APPROVE$/);
+  // and the review closed the reviewer's spawn, so its signal is gone with it
+  assert.equal(state.progressByAgent.has('rev-1'), false);
+  assert.equal(state.agents.find((a) => a.agent === 'rev-1').status, 'reported');
+});
+
+test('two agents blocked on one ticket are two blockages, and only their owner clears one', () => {
+  // MUTANT: key blockages by ticket id. B's record then REPLACES A's, and B's
+  // next movement signal deletes a blockage A never cleared — A is stuck with
+  // `## Open blockages` reading _none_.
+  const base = [
+    ev({ ev: 'ticket.created', ts: '2026-07-26T09:00:00.000Z', data: { id: 'T-1' } }),
+    blocked('impl-a', { ticket: 'T-1', detail: 'A stuck' }),
+    blocked('impl-b', { ticket: 'T-1', detail: 'B stuck' }),
+  ];
+  const both = fold({ events: base });
+  assert.equal(both.blockages.size, 2);
+  assert.deepEqual([...both.blockages.values()].map((b) => b.detail).sort(), ['A stuck', 'B stuck']);
+
+  const bMoved = fold({
+    events: [...base, ev({ ev: 'progress', ts: '2026-07-26T09:02:00.000Z', data: { agent: 'impl-b', state: 'working' } })],
+  });
+  assert.deepEqual(
+    [...bMoved.blockages.values()].map((b) => `${b.agent}:${b.detail}`),
+    ['impl-a:A stuck'],
+    "B's movement erased A's blockage",
+  );
+  // both rows are visible in the document, not just in the state
+  const rows = renderProjections({ events: base }).files[STATE_FILE]
+    .split('## Open blockages\n')[1]
+    .split('\n## ')[0]
+    .split('\n')
+    .filter((l) => l.startsWith('| T-1 '));
+  assert.equal(rows.length, 2, 'two agents blocked on one ticket rendered as one row');
+});
+
+test('a re-spawned agent name inherits nothing from the incarnation that already closed', () => {
+  // MUTANT: leave `progressByAgent`/`blockages` keyed by the name after the
+  // report. The new running row then reads `blocked at <old ts>` while
+  // `## Open blockages` reads _none_ — the document contradicting itself about
+  // an agent that has emitted no signal at all. ADR-18 permits the reuse, and
+  // close-spawn recovery produces exactly this journal.
+  const events = [
+    ev({ ev: 'spawn', ts: '2026-07-26T09:00:00.000Z', data: { agent: 'impl-1', role: 'implementer', ticket: 'T-1' } }),
+    blocked('impl-1', { ticket: 'T-1' }),
+    ev({ ev: 'report', ts: '2026-07-26T09:02:00.000Z', data: { agent: 'impl-1', verdict: 'done', ticket: 'T-1' } }),
+    ev({ ev: 'spawn', ts: '2026-07-26T09:03:00.000Z', data: { agent: 'impl-1', role: 'implementer', ticket: 'T-2' } }),
+  ];
+  const state = fold({ events });
+  assert.equal(state.blockages.size, 0);
+  assert.equal(state.progressByAgent.has('impl-1'), false, 'the closed incarnation kept its signal');
+
+  const text = renderProjections({ events }).files[STATE_FILE];
+  const running = text.split('\n').find((l) => l.startsWith('| impl-1') && l.includes('running'));
+  assert.match(running, /&mdash; \|$/, 'the fresh spawn rendered a signal it never emitted');
+  assert.ok(!/blocked at/.test(text));
+  assert.ok(text.split('## Open blockages\n')[1].startsWith('\n_none_'));
+});
+
+test('a ticket.status override wins the status line, a merge clears it, and it NEVER moves the percent', () => {
   const base = [
     ev({ ev: 'ticket.created', ts: '2026-07-26T09:00:00.000Z', data: { id: 'T-1' } }),
     ev({ ev: 'ticket.created', ts: '2026-07-26T09:00:01.000Z', data: { id: 'T-2' } }),
@@ -402,6 +537,33 @@ test('a ticket.status override wins the status line, clears on lifecycle, and NE
   const t1m = merged.ticketList.find((t) => t.id === 'T-1');
   assert.match(ticketStatus(t1m), /^merged /, 'merge clears the override');
   assert.equal(merged.percent, 50);
+});
+
+test('a ticket.status for an unknown ticket is refused out loud and moves NOTHING', () => {
+  // MUTANT: mint the ticket with `ticketOf()`. One mistyped id then enlarges
+  // the denominator — 100% becomes 50% — and the operator's primary signal
+  // moved because of a lane override, which is the one thing an override is
+  // documented never to do.
+  const base = [
+    ev({ ev: 'ticket.created', ts: '2026-07-26T09:00:00.000Z', data: { id: 'T-10' } }),
+    ev({ ev: 'merge', ts: '2026-07-26T09:01:00.000Z', data: { ticket: 'T-10', sha: 'abc' } }),
+  ];
+  const before = fold({ events: base });
+  assert.equal(before.percent, 100);
+
+  const typo = fold({
+    events: [...base, ev({ ev: 'ticket.status', ts: '2026-07-26T09:02:00.000Z', data: { ticket: 'T-1O', column: 'parked' } })],
+  });
+  assert.equal(typo.percent, 100, 'a lane override moved the percent');
+  assert.deepEqual(typo.ticketList.map((t) => t.id), ['T-10'], 'a lane override invented a ticket');
+  assert.equal(typo.merged, 1);
+  // refused, never silently (ADR-19 correction 1)
+  assert.ok(
+    warnings(typo).some((w) => /ticket\.status for unknown ticket "T-1O"/.test(w)),
+    `no warning named the ignored override: ${warnings(typo)}`,
+  );
+  // the events folded, and the type census still counts them
+  assert.equal(typo.byType.get('ticket.status'), 1);
 });
 
 test('the Agents table shows the last signal only on running rows', () => {

--- a/tests/unit/projection-fuzz.test.mjs
+++ b/tests/unit/projection-fuzz.test.mjs
@@ -102,19 +102,74 @@ const DATA_KEYS = [
   'id', 'title', 'text', 'agent', 'role', 'model', 'ticket', 'worktree', 'verdict',
   'kind', 'result', 'evidence', 'evidence_ref', 'resource', 'holder', 'phase',
   'next_steps', 'deps', 'by', 'sha', 'mode', 'target', 'confidence', 'class', 'detail',
-  // the 17-event set's additions — hostile payloads must reach their branches
+  // the 17-event set's additions
   'state', 'column', 'area', 'claim', 'proof', 'next',
 ];
 
-function hostileEvent(rand) {
+/**
+ * Two of those keys are CORRELATORS rather than free text, and a hostile string
+ * never matches a correlator: an Open-blockages row opens only on the exact
+ * value `blocked`, and a Last-signal cell needs a `spawn` and a `progress`
+ * naming ONE agent with no report in between. Drawn from `hostileValue` alone,
+ * both tables were rendered only in their EMPTY shape — measured at 0 rows in
+ * all 300 cases — so an unescaped `b.detail` or `signal.state` would have gone
+ * unnoticed by the very fuzz that claims to cover them.
+ *
+ * The pools restore the reach without softening the payload: every agent name
+ * here is itself a hostile fragment that `journal.agentNameProblem` accepts as
+ * a correlator. One name is drawn PER CASE, not per event — a case is one
+ * journal, one journal is one initiative, and drawing per event left the reach
+ * to chance (measured: a spawn and a progress agreed on a name in 0 of 300
+ * cases, the mulberry32 counter sampled at a near-constant stride). The
+ * coverage counters below fail if the reach is ever lost again.
+ */
+const PROGRESS_STATES = ['blocked', 'working', 'started', 'unblocked'];
+const AGENT_NAMES = [
+  '| injected | columns |',
+  '<script>alert(1)</script>',
+  '![beacon](https://evil.example/leak.png)',
+];
+
+const pick = (rand, pool) => pool[Math.floor(rand() * pool.length)];
+
+/**
+ * The four types that correlate with EACH OTHER by agent name. Drawn uniformly
+ * from all 17, a `spawn` and a `progress` land in one case (1-6 events) about
+ * twice in 300 — so one event in five comes from here instead. The 12.5% below
+ * keeps the unknown-event-type rate at the 10% overall it has always been.
+ */
+const LIFECYCLE_TYPES = ['spawn', 'progress', 'report', 'review'];
+
+function hostileType(rand) {
+  if (rand() < 0.2) return pick(rand, LIFECYCLE_TYPES);
+  return rand() < 0.875 ? pick(rand, EVENT_TYPES) : hostileString(rand);
+}
+
+function hostileEvent(rand, agent = AGENT_NAMES[0]) {
+  const ev = hostileType(rand);
   const data = {};
   const keys = 1 + Math.floor(rand() * 5);
-  for (let i = 0; i < keys; i++) {
-    data[DATA_KEYS[Math.floor(rand() * DATA_KEYS.length)]] = hostileValue(rand);
+  for (let i = 0; i < keys; i++) data[DATA_KEYS[Math.floor(rand() * DATA_KEYS.length)]] = hostileValue(rand);
+  // The events that OPEN state get the case's agent four times in five, on the
+  // key they correlate by (`data.by` for a review, `data.agent` for the rest);
+  // the events that CLOSE it get it half as often, because a closed spawn
+  // renders no Last-signal cell at all and a closed blockage no row. The
+  // remaining draws keep the fully hostile shape, where those keys hold
+  // arbitrary JSON.
+  const opens = ev === 'spawn' || ev === 'progress';
+  const closes = ev === 'report' || ev === 'review';
+  if ((opens && rand() < 0.8) || (closes && rand() < 0.4)) {
+    if (ev === 'review') data.by = agent;
+    else data.agent = agent;
+  }
+  // `blocked` gets half the draws on its own: it is the only value that OPENS
+  // an Open-blockages row, and the other three exist to close one.
+  if (ev === 'progress' && rand() < 0.8) {
+    data.state = rand() < 0.5 ? 'blocked' : pick(rand, PROGRESS_STATES);
   }
   return {
     ts: rand() < 0.9 ? '2026-01-01T00:00:0' + Math.floor(rand() * 10) + '.000Z' : hostileString(rand),
-    ev: rand() < 0.9 ? EVENT_TYPES[Math.floor(rand() * EVENT_TYPES.length)] : hostileString(rand),
+    ev,
     init: rand() < 0.5 ? 'demo' : hostileString(rand),
     actor: hostileString(rand),
     data,
@@ -148,6 +203,15 @@ function tableColumnProblems(markdown) {
   return problems;
 }
 
+/** The data rows of one `## <heading>` table — no header, no separator. */
+function tableRows(markdown, heading) {
+  const section = (markdown.split(`\n## ${heading}\n`)[1] ?? '').split('\n## ')[0];
+  return section
+    .split('\n')
+    .filter((l) => l.startsWith('|') && !/^\|[-|]+\|$/.test(l))
+    .slice(1);
+}
+
 function checkDocument(name, markdown, caseNo, events) {
   const context = () => `case ${caseNo} (seed ${SEED}) ${name}\nevents: ${JSON.stringify(events)}`;
 
@@ -176,12 +240,65 @@ function checkDocument(name, markdown, caseNo, events) {
 
 test(`fuzz: hostile journal data cannot break the projections (seed ${SEED}, ${CASES} cases)`, () => {
   const rand = rng(SEED);
+  const reached = { blockageRow: 0, signalCell: 0, findingRow: 0, overrideStatus: 0 };
   for (let caseNo = 0; caseNo < CASES; caseNo++) {
-    const events = Array.from({ length: 1 + Math.floor(rand() * 6) }, () => hostileEvent(rand));
+    // one case is one journal, so one agent name (see AGENT_NAMES)
+    const agent = pick(rand, AGENT_NAMES);
+    const events = Array.from({ length: 1 + Math.floor(rand() * 6) }, () => hostileEvent(rand, agent));
     const { files, warnings } = renderProjections({ events });
     checkDocument(STATE_FILE, files[STATE_FILE], caseNo, events);
     checkDocument(PROGRESS_FILE, files[PROGRESS_FILE], caseNo, events);
     checkWarnings(warnings, caseNo, events);
+
+    const state = files[STATE_FILE];
+    reached.blockageRow += tableRows(state, 'Open blockages').length;
+    reached.findingRow += tableRows(state, 'Findings').length;
+    // the Last signal cell is the last column of the Agents table
+    reached.signalCell += tableRows(state, 'Agents').filter((r) => r.split('|').at(-2).trim() !== '&mdash;').length;
+    reached.overrideStatus += tableRows(state, 'Ledger').filter((r) => r.includes('(set by ticket.status)')).length;
+  }
+  // COVERAGE, not decoration: a fuzz is worth exactly the branches it reaches,
+  // and each of these four was rendered zero times until the generator learned
+  // to produce correlators. A future edit that loses one fails HERE, loudly,
+  // instead of quietly reducing this file to a test of empty tables.
+  for (const [branch, hits] of Object.entries(reached)) {
+    assert.ok(hits > 0, `no case rendered ${branch} — the hostile payload never reached that branch`);
+  }
+});
+
+/**
+ * The two cells whose content the random corpus cannot make hostile.
+ *
+ * A blockage row exists only while `data.state` is exactly `blocked`, and the
+ * Last-signal cell renders the state of the LAST progress event — so the fuzz
+ * reaches both branches (the counters above prove it) but fills the state cell
+ * with a correlator every time. Rendering `signal.state` raw therefore survived
+ * all 300 cases. Directed and deterministic, like the malformed-lines case:
+ * one agent blocked with a hostile detail, one agent whose latest signal IS a
+ * hostile payload, and every field around them hostile too.
+ */
+test('directed: hostile payloads inside a blockage row and a Last-signal cell', () => {
+  const [blockedAgent, movingAgent] = AGENT_NAMES;
+  for (const payload of HOSTILE) {
+    const label = `directed ${JSON.stringify(payload)}`;
+    const events = [
+      { ts: '2026-01-01T00:00:00.000Z', ev: 'spawn', init: payload, actor: payload,
+        data: { agent: blockedAgent, role: payload, model: payload, ticket: payload, worktree: payload } },
+      { ts: '2026-01-01T00:00:01.000Z', ev: 'spawn', init: 'demo', actor: payload,
+        data: { agent: movingAgent, role: payload } },
+      { ts: '2026-01-01T00:00:02.000Z', ev: 'progress', init: 'demo', actor: payload,
+        data: { agent: blockedAgent, state: 'blocked', ticket: payload, detail: payload, next: payload } },
+      { ts: payload, ev: 'progress', init: 'demo', actor: payload,
+        data: { agent: movingAgent, state: payload, detail: payload } },
+    ];
+    const { files, warnings } = renderProjections({ events });
+    const state = files[STATE_FILE];
+    assert.equal(tableRows(state, 'Open blockages').length, 1, `no blockage row — ${label}`);
+    const signals = tableRows(state, 'Agents').map((r) => r.split('|').at(-2).trim());
+    assert.equal(signals.filter((s) => s !== '&mdash;').length, 2, `no Last-signal cell — ${label}`);
+    checkDocument(STATE_FILE, state, label, events);
+    checkDocument(PROGRESS_FILE, files[PROGRESS_FILE], label, events);
+    checkWarnings(warnings, label, events);
   }
 });
 
@@ -213,7 +330,7 @@ test(`fuzz: the same seed renders the same bytes twice (determinism)`, () => {
     const rand = rng(SEED);
     const out = [];
     for (let i = 0; i < 50; i++) {
-      const events = Array.from({ length: 1 + Math.floor(rand() * 6) }, () => hostileEvent(rand));
+      const events = Array.from({ length: 1 + Math.floor(rand() * 6) }, () => hostileEvent(rand, pick(rand, AGENT_NAMES)));
       const { files } = renderProjections({ events });
       out.push(files[STATE_FILE], files[PROGRESS_FILE]);
     }

--- a/tests/unit/projection-fuzz.test.mjs
+++ b/tests/unit/projection-fuzz.test.mjs
@@ -102,6 +102,8 @@ const DATA_KEYS = [
   'id', 'title', 'text', 'agent', 'role', 'model', 'ticket', 'worktree', 'verdict',
   'kind', 'result', 'evidence', 'evidence_ref', 'resource', 'holder', 'phase',
   'next_steps', 'deps', 'by', 'sha', 'mode', 'target', 'confidence', 'class', 'detail',
+  // the 17-event set's additions — hostile payloads must reach their branches
+  'state', 'column', 'area', 'claim', 'proof', 'next',
 ];
 
 function hostileEvent(rand) {


### PR DESCRIPTION
Phase 3: the journal learns what agents are doing, finding, and waiting on. **This is the reviewed core change `docs/journal.md` names** — the closed event set grows 14 → 17, in one change. Ships as 0.1.11.

## What ships

- **`progress`** — the agent's own mid-run signal: `state` ∈ `started · working · blocked · unblocked` (a closed set, rejected at append naming the whole set), emitted at four named points in the agent contracts (after the lease · at the FIRST blockage, before any workaround · when it clears · before final validation). Never part of ADR-18 spawn↔report pairing — pinned by a test that fails if `progress` ever joins the pairing filter. `data.agent` joins the append-time agent-name guard (it is the fold correlator).
- **`finding`** — a claim plus its proof, queryable by other agents (`journal.mjs query --ev finding`); `F-<n>` ids issued by `append`. Implementers and reviewers write their own; scouts stay write-free and flag `DURABLE:` findings the conductor journals.
- **`ticket.status`** — the conductor's lane override, deliberately narrow: `column` ∈ `blocked · waiting-operator · parked` — only the lanes no lifecycle event can derive (`done` is what `merge` means; a broader set would be a second source of truth). Cleared at fold time by the next `report`/`review`/`merge`, and it **never moves the percent** (pinned).
- **String caps**: `detail`/`claim`/`proof` cap at 2 000 codepoints — rejected at append, never truncated; `validateJournal` reports historical oversizes as warnings only (no retroactive errors).
- **Projections**: STATE.md gains `Open blockages` and `Findings` sections and a per-agent `Last signal` column (running rows only — a signal that outlived its report is stale). Blockages clear on the same agent's movement signal and on stronger lifecycle events, at fold time.
- **Doctor**: `spawn-blocked` (warning) — an agent whose own last signal says `blocked` past a threshold, outranking the plain open row; `spawn-open` now shows the last signal.
- **Prose contracts**: the emission points (implementer/reviewer), the anti-duplication grep, the implementer's "what you did NOT do" report section, mid-run operator-message intake as `ticket.created`/`decision` events ("a thought that never reached the journal does not exist"), and operator questions as `gate {WAITING_ON_OPERATOR, question, recommendation, default}` events — the substrate the Phase 4 board renders.

## Verification

Full suite on the rebased branch: **1052 tests, 1052 pass, 0 skipped**; desc-budget 4340/5000; control-char scan clean (170 files); plugin validation passes. Fixture extended before its final checkpoint line (three consumer tests share it); goldens regenerated by hand; fuzz corpus reaches the new branches via six new data keys (a reshuffled seed is a real finding, not flake); docs on both surfaces with re-measured counts (doctor 89 → 90).

## ADR-20 — dead mutants

| mutant | red test |
|---|---|
| a fold branch deleted | `every event type of the closed set is folded into a section (no silent loss)` |
| `DATA_ENUMS` enforcement neutered | `progress and ticket.status enums reject out-of-set values, naming the whole set` |
| `progress` added to the pairSpawns filter | `progress events never disturb spawn-report pairing (ADR-18)` |

## Release

0.1.11 in all three files; after merge: `claude plugin tag .` + `v0.1.11`, both pushed; npm verified on the tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
