### PR TITLE
fix: issue ledger ids under the write lock

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
     {
       "name": "tyran",
       "description": "A task conductor for Claude Code: multi-agent orchestration with an enforced evidence contract, repo-specific learning, and update-safe local evolution.",
-      "version": "0.1.12",
+      "version": "0.1.13",
       "source": "./",
       "author": {
         "name": "Jacek Janczura",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "tyran",
-  "version": "0.1.12",
+  "version": "0.1.13",
   "description": "A task conductor for Claude Code: multi-agent orchestration with an enforced evidence contract, repo-specific learning, and update-safe local evolution.",
   "author": {
     "name": "Jacek Janczura",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,50 @@
 # Changelog
 
+## 0.1.13 — 2026-08-13
+
+### Six concurrent decisions, two ids
+
+`append` took the write lock; issuing the `D-<n>` or `F-<n>` a caller omitted
+happened before it, in the CLI. Issuing an id is read-compute-write, so every
+concurrent writer read the same journal, computed the same next number, and
+then serialized on the lock to write it. Measured on a fresh journal, seven
+runs of six simultaneous `decision` appends: **1 to 4 distinct ids for 6
+events**, and in the worst run all six carried the same id. Ids are how the
+ledger references itself — "see D-2" —
+in a file that is never rewritten, so every collision is ambiguous
+permanently: neither `validate` nor the projections can say which `D-2` a
+later event meant, and the premise of the whole design is many agents writing
+one ledger at once.
+
+The id is now issued inside the lock, from the snapshot that call has already
+read for the timestamp clamp and the spawn guard — no second read per append,
+which a long journal would pay for on every event. The contract is unchanged:
+an explicit `data.id` still wins, `"id":""` is still treated as absent, and
+only `decision` and `finding` are issued one. The same six-process race now
+measures 6 distinct ids for 6 events, and eight genuinely concurrent
+processes pin it in the suite.
+
+The exported `append()` moved with the CLI, not behind it: before this release
+a `decision` without `data.id` was rejected outright — `invalid event: data.id
+is required for ev "decision"` — so every programmatic caller had to compute an
+id first and then carry it across exactly the gap this release closes. Omitting
+`data.id` is now the safe call rather than an error.
+
+What is atomic is exactly the ids `append` ISSUES — `decision` and `finding`,
+where `data.id` was omitted or empty: two of those, concurrent, can no longer
+be handed one number. Nothing else moved. `next-id` previews a value while
+holding nothing, so an id read there and appended later still loses to any
+writer that appended in between — both journal doc surfaces say so, and a
+caller that can let `append` issue the id should. An explicit `data.id` is
+written verbatim and stays the caller's to keep unique: a journal whose three
+`decision` events all carry `D-2` validates `ok`. `ticket.created` is
+deliberately outside the issued set — a ticket id comes from the plan, which
+numbers its own stories — so there is no atomic path for a `T-` id at all, and
+`skills/run/SKILL.md` now says the conductor is the single writer for ticket
+creation. And an id at or past 2^53 saturates `max+1`: seeded with
+`D-9007199254740992`, `append` issues that same number to every decision after
+it, and a 400-digit id yields `D-Infinity` — arithmetic byte-identical to the
+previous release, named here rather than changed here.
 ## 0.1.12 — 2026-08-13
 
 ### The board: every ticket in a lane, every question in front of you

--- a/docs/journal.md
+++ b/docs/journal.md
@@ -1,6 +1,6 @@
 # Journal reference
 
-`scripts/journal.mjs` · 59 unit tests
+`scripts/journal.mjs` · 62 unit tests
 
 This page is the schema contract; extending the event set is a reviewed core
 change.
@@ -84,8 +84,11 @@ truncated; long material belongs in `NOTES.md` with a reference here.
   free the lease — it is surfaced in `tail().mismatchedReleases`.
 - **IDs never from memory:** omit `id` (or leave it empty) and `append`
   scans the file and issues `D-<max+1>` itself — duplicate or blank ledger
-  numbers after a compaction become impossible. `journal.mjs next-id <file> D`
-  previews the next value without appending.
+  numbers after a compaction become impossible. `append` issues the id under
+  the same lock as the write, so concurrent writers cannot be handed one
+  number twice; an id taken from `journal.mjs next-id <file> D` and appended
+  later still can, because another writer may append in between — prefer
+  letting `append` issue it whenever the caller does not need the value first.
 - **Resume surface:** `journal.mjs tail <file>` returns the latest
   `checkpoint` and all unreleased leases — exactly what the `SessionStart`
   hook re-injects.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jjanczur/tyran",
-  "version": "0.1.12",
+  "version": "0.1.13",
   "description": "Command-line scripts for the Tyran task conductor (doctor, journal, schema, and repo tooling) for CI and terminals outside Claude Code. Installing this package does NOT install the Claude Code plugin — add that separately with `/plugin marketplace add jjanczur/tyran` inside Claude Code.",
   "type": "module",
   "engines": {

--- a/scripts/journal.mjs
+++ b/scripts/journal.mjs
@@ -122,6 +122,14 @@ export const CAPPED_DATA_KEYS = Object.freeze({ detail: 2000, claim: 2000, proof
  */
 const q = (value) => escapeInvisible(String(value));
 
+/**
+ * A `data` payload of the shape the envelope requires. Arrays are excluded on
+ * purpose: they are objects to `typeof`, they accept string properties, and
+ * anything that ADDS a key to one would turn a rejected event into a written
+ * one of a shape the caller never wrote.
+ */
+const isDataObject = (data) => typeof data === 'object' && data !== null && !Array.isArray(data);
+
 /** Validate a single event object. Returns [] when valid, else error strings. */
 export function validateEvent(event) {
   const errors = [];
@@ -143,7 +151,7 @@ export function validateEvent(event) {
   if (typeof event.actor !== 'string' || event.actor.length === 0) {
     errors.push('actor must be a non-empty string');
   }
-  if (typeof event.data !== 'object' || event.data === null || Array.isArray(event.data)) {
+  if (!isDataObject(event.data)) {
     errors.push('data must be a JSON object (may be empty)');
   } else if (DATA_REQUIRED[event.ev]) {
     for (const key of DATA_REQUIRED[event.ev]) {
@@ -463,6 +471,31 @@ function appendUnderLock(file, event, preread = null) {
     if (lastTs && Date.parse(ts) < Date.parse(lastTs)) ts = lastTs;
   }
   const stamped = { ...event, ts };
+  // An id the caller omitted is ISSUED, not demanded — and issued HERE, from
+  // the same snapshot this write is about to extend. Issuing one is
+  // read-compute-write, so anywhere outside the lock every concurrent writer
+  // reads the same journal, computes the same "next" number, and then queues up
+  // to write it: measured over seven runs, six concurrent `decision` appends
+  // against one journal issued between 1 and 4 distinct ids for 6 events.
+  // Nothing detects that later — history is append-only, so "see D-2" stays
+  // ambiguous forever.
+  //
+  // `skills/run/SKILL.md` is emphatic that IDs never come from memory, because
+  // after a compaction memory hands out the same number twice — and `append`
+  // once REJECTED a missing `data.id`, leaving the conductor to remember a
+  // separate `next-id` call. Measured in the field: 12 decision IDs
+  // hand-assigned from memory in one initiative, which is the exact failure the
+  // rule names, with nothing objecting. A rule in prose loses to a mechanism
+  // that makes the mistake impossible.
+  //
+  // An explicit id still wins — but `"id":""` is not explicit: a conductor
+  // recovering from next-id's usage error supplied exactly that, three times,
+  // and the ledger kept three permanently blank ids nothing can reference.
+  const issuePrefix = ID_ISSUED_FOR[stamped.ev];
+  if (issuePrefix !== undefined && isDataObject(stamped.data) && (stamped.data.id === undefined || stamped.data.id === '')) {
+    // a fresh object: the `data` the caller passed in stays the caller's
+    stamped.data = { ...stamped.data, id: nextIdFrom(read().events, issuePrefix) };
+  }
   const errors = validateEvent(stamped);
   if (errors.length > 0) {
     throw new Error('invalid event: ' + errors.join('; '));
@@ -506,6 +539,9 @@ function appendUnderLock(file, event, preread = null) {
  *
  * `spawn` additionally must not duplicate an agent name that is still open
  * (ADR-18) — see `duplicateSpawnMessage` for how to get unstuck.
+ *
+ * Returns the event as written, including any `data.id` issued for it: the
+ * CLI prints that, and it is the only place the issued id is reported.
  */
 export function append(file, event) {
   mkdirSync(dirname(resolve(file)), { recursive: true });
@@ -631,14 +667,15 @@ export function validateJournal(file) {
 }
 
 /**
- * Next free ID for a prefix, derived from the journal — never from memory.
- * Scans data.id fields shaped `<PREFIX>-<number>` and returns max+1.
+ * Next free ID for a prefix, over events already read. Separate from `nextId`
+ * only so the locked append path can issue an id from the snapshot it is
+ * holding: re-reading the file there would be a second full read on every
+ * append, which a long journal pays for on every event.
  */
-export function nextId(file, prefix) {
+function nextIdFrom(events, prefix) {
   if (!/^[A-Za-z][A-Za-z0-9]*$/.test(prefix)) {
     throw new Error(`invalid id prefix "${prefix}" — use letters/digits, starting with a letter`);
   }
-  const { events } = readJournal(file);
   let max = 0;
   const re = new RegExp(`^${prefix}-(\\d+)$`);
   for (const e of events) {
@@ -646,6 +683,19 @@ export function nextId(file, prefix) {
     if (m) max = Math.max(max, Number(m[1]));
   }
   return `${prefix}-${max + 1}`;
+}
+
+/**
+ * Next free ID for a prefix, derived from the journal — never from memory.
+ * Scans data.id fields shaped `<PREFIX>-<number>` and returns max+1.
+ *
+ * A PREVIEW, not a reservation: nothing is written and no lock is held, so an
+ * id read here and appended later collides with any writer that appended in
+ * between. `append` issues ids under its own write lock; a caller that can
+ * let it do so has no window at all.
+ */
+export function nextId(file, prefix) {
+  return nextIdFrom(readJournal(file).events, prefix);
 }
 
 /** Latest checkpoint + still-open leases — the resume surface. */
@@ -744,23 +794,9 @@ function main() {
         const [file, ev, init] = rest;
         if (!file || !ev || !init) throw new UsageError();
         const data = flags.data ? JSON.parse(flags.data) : {};
-        // An id the caller omitted is ISSUED, not demanded.
-        //
-        // `skills/run/SKILL.md` is emphatic that IDs never come from memory,
-        // because after a compaction memory hands out the same number twice —
-        // and then `append` REJECTED a missing `data.id` and left the conductor
-        // to remember a separate `next-id` call. Measured in the field: 12
-        // decision IDs hand-assigned from memory in one initiative, which is
-        // the exact failure the rule names, with nothing objecting.
-        //
-        // A rule in prose loses to a mechanism that makes the mistake
-        // impossible. This is that mechanism, and an explicit id still wins —
-        // but `"id":""` is not explicit: a conductor recovering from next-id's
-        // usage error supplied exactly that, three times, and the ledger kept
-        // three permanently blank ids nothing can reference.
-        if (ID_ISSUED_FOR[ev] !== undefined && (data.id === undefined || data.id === '')) {
-          data.id = nextId(file, ID_ISSUED_FOR[ev]);
-        }
+        // An omitted id is issued by `append`, inside its write lock, and comes
+        // back on the event this prints — issuing one out here would be outside
+        // that lock, which is where concurrent writers hand out one id twice.
         const written = append(file, { ev, init, actor: flags.actor ?? 'conductor', data });
         console.log(emit(written));
         return;

--- a/site/src/content/docs/journal.mdx
+++ b/site/src/content/docs/journal.mdx
@@ -6,7 +6,7 @@ import { FileTree } from '@astrojs/starlight/components';
 import Provenance from '../../components/Provenance.astro';
 
 <Provenance>
-`scripts/journal.mjs` · 59 unit tests
+`scripts/journal.mjs` · 62 unit tests
 </Provenance>
 
 This page is the schema contract; extending the event set is a reviewed core
@@ -136,8 +136,11 @@ flowchart TB
   free the lease — it is surfaced in `tail().mismatchedReleases`.
 - **IDs never from memory:** omit `id` (or leave it empty) and `append`
   scans the file and issues `D-<max+1>` itself — duplicate or blank ledger
-  numbers after a compaction become impossible. `journal.mjs next-id <file> D`
-  previews the next value without appending.
+  numbers after a compaction become impossible. `append` issues the id under
+  the same lock as the write, so concurrent writers cannot be handed one
+  number twice; an id taken from `journal.mjs next-id <file> D` and appended
+  later still can, because another writer may append in between — prefer
+  letting `append` issue it whenever the caller does not need the value first.
 - **Resume surface:** `journal.mjs tail <file>` returns the latest
   `checkpoint` and all unreleased leases — exactly what the `SessionStart`
   hook re-injects.

--- a/skills/run/SKILL.md
+++ b/skills/run/SKILL.md
@@ -158,9 +158,14 @@ open one.
      away from having never happened.
    - **IDs never come from memory** — omit `id` from a `decision` event's
      `--data` (or leave it empty) and `append` issues the next one itself.
+     `append` issues it under the same lock it writes with, so two concurrent
+     appends can no longer be handed one number — prefer omitting `id`
+     wherever you do not need the value beforehand.
      `journal.mjs next-id <file> <prefix>` exists to preview a value ahead of
      time (prefix `D` → `D-7`); it is not a required preliminary step before
-     `append`. After a compaction, memory hands out the same number twice.
+     `append`, and it holds nothing — an id read there and appended later
+     still loses to any writer that appended in between. After a compaction,
+     memory hands out the same number twice.
    - **Authorizations and stops are `decision` events.** What you may do
      without asking, and the CLOSED list of situations where you halt, live
      in the journal with the date and the operator's own words. Outside that

--- a/tests/unit/journal.test.mjs
+++ b/tests/unit/journal.test.mjs
@@ -147,6 +147,32 @@ test('rejects missing/invalid top-level fields', () => {
   assert.ok(validateEvent(ev({ data: [] })).length > 0);
 });
 
+test('a non-object data is REFUSED by name, and refused before an id is issued', () => {
+  // MUTANT 1: drop `!Array.isArray(data)` from isDataObject — an array is an
+  // object to typeof and takes string properties, so `--data '["a"]'` would be
+  // WRITTEN, carrying a shape no reader expects.
+  // MUTANT 2: drop the isDataObject term from the issuance guard — issuing an
+  // id onto null/a string crashes with a raw TypeError instead of naming the
+  // problem, and the crash happens before validation can report it.
+  for (const data of [null, [], ['a'], 'str', 5, true]) {
+    const errs = validateEvent(ev({ data }));
+    assert.ok(
+      errs.some((e) => e.includes('data must be a JSON object')),
+      `data=${JSON.stringify(data)} must be refused by name, got ${JSON.stringify(errs)}`,
+    );
+  }
+  // Through the CLI, where issuance runs: the refusal must be the validator's
+  // sentence, never a TypeError from building an id on a non-object.
+  const file = tmp();
+  for (const raw of ['null', '"str"', '5', '["array","as","data"]']) {
+    const out = spawnSync(process.execPath, [SCRIPT, 'append', file, 'decision', 'demo', '--data', raw], { encoding: 'utf8' });
+    assert.equal(out.status, 1, `--data ${raw} must exit 1`);
+    assert.match(out.stderr, /data must be a JSON object/, `--data ${raw} must name the problem`);
+    assert.doesNotMatch(out.stderr, /Cannot (read|create)/, `--data ${raw} must not crash raw`);
+  }
+  assert.deepEqual(readJournal(file).events, [], 'nothing may be written by a refused append');
+});
+
 test('enforces per-type required data keys but allows extras', () => {
   const bad = validateEvent(ev({ ev: 'report', data: { agent: 'x' } }));
   assert.ok(bad.some((e) => e.includes('data.verdict')));
@@ -348,6 +374,54 @@ test('20 truly concurrent processes: intact lines AND monotonic timestamps', asy
   const result = validateJournal(f);
   assert.deepEqual(result.errors, []);
   assert.equal(result.ok, true); // ts monotonic BY CONSTRUCTION under the lock
+});
+
+// An issued id is the referencing mechanism of the whole ledger — "see D-2" —
+// in a file that is never rewritten, so a number handed out twice is ambiguous
+// forever. Issuing one is read-compute-write, which is only atomic under the
+// same lock as the write.
+//
+// Kills the mutant that issues the id BEFORE the lock is taken (`nextId(file,
+// …)` in the CLI, then `append`): measured on that code over seven runs, 6
+// simultaneous decision appends against one fresh journal issued between 1 and
+// 4 distinct ids for 6 events. Sequential appends cannot see it — every writer
+// must read before any of them has written.
+test('8 truly concurrent appends issue 8 DISTINCT decision ids', { timeout: 60_000 }, async () => {
+  const f = tmp();
+  const launched = [];
+  const finished = [];
+  const t0 = Date.now();
+  const procs = Array.from({ length: 8 }, (_, i) => {
+    const p = spawn(process.execPath, [
+      SCRIPT, 'append', f, 'decision', 'demo', '--actor', `p${i}`, '--data', JSON.stringify({ text: `d${i}` }),
+    ]);
+    launched.push(Date.now() - t0);
+    let err = '';
+    p.stderr.on('data', (d) => (err += d));
+    return new Promise((res, rej) => {
+      p.on('close', (code) => {
+        finished.push(Date.now() - t0);
+        code === 0 ? res() : rej(new Error(`p${i} exit ${code}: ${err}`));
+      });
+    });
+  });
+  await Promise.all(procs);
+
+  // the same overlap proof the ADR-18 race uses: without it, 8 appends that
+  // happened to serialize would pass while proving nothing
+  assert.ok(
+    Math.max(...launched) < Math.min(...finished),
+    `not concurrent: last launch ${Math.max(...launched)}ms >= first exit ${Math.min(...finished)}ms`,
+  );
+  const ids = query(f, { ev: 'decision' }).map((e) => e.data.id);
+  assert.equal(ids.length, 8, 'every writer must have appended exactly one event');
+  assert.equal(new Set(ids).size, ids.length, `ids issued twice: ${ids.join(', ')}`);
+  // contiguous, not merely distinct: max+1 under the lock can produce nothing else
+  assert.deepEqual([...ids].sort(), ['D-1', 'D-2', 'D-3', 'D-4', 'D-5', 'D-6', 'D-7', 'D-8']);
+  const { badLines, truncatedTail } = readJournal(f);
+  assert.deepEqual(badLines, []);
+  assert.equal(truncatedTail, false);
+  assert.equal(validateJournal(f).ok, true);
 });
 
 test('stamped ts is clamped to last event; explicit past ts is caller-owned', () => {
@@ -1021,6 +1095,26 @@ test('an explicit empty data.id is issued by CLI append, not stored blank', () =
   execFileSync(process.execPath, [SCRIPT, 'append', f, 'decision', 'demo', '--data', '{"id":"","text":"picked a default"}']);
   execFileSync(process.execPath, [SCRIPT, 'append', f, 'decision', 'demo', '--data', '{"id":"","text":"second"}']);
   assert.deepEqual(query(f, { ev: 'decision' }).map((e) => e.data.id), ['D-1', 'D-2']);
+});
+
+test('append itself issues the id — explicit wins, "" is absent, other types get none', () => {
+  // Every assertion goes through `append`, never the CLI: the mutant this
+  // kills is issuance moved back out to any caller (which is outside the write
+  // lock), and the CLI tests above stay green under exactly that mutant.
+  const f = tmp();
+  const decide = (data) => append(f, { ev: 'decision', init: 'demo', actor: 'c', data });
+  assert.equal(decide({ text: 'issued' }).data.id, 'D-1');
+  assert.equal(decide({ id: '', text: 'empty is not explicit' }).data.id, 'D-2');
+  assert.equal(decide({ id: 'D-99', text: 'mine' }).data.id, 'D-99');
+  assert.equal(decide({ text: 'after the explicit one' }).data.id, 'D-100');
+  const mine = { text: 'the caller keeps its own object' };
+  decide(mine);
+  assert.equal(mine.id, undefined);
+  // only the types in ID_ISSUED_FOR are issued one
+  const checkpoint = append(f, { ev: 'checkpoint', init: 'demo', actor: 'c', data: { phase: 'p', next_steps: [] } });
+  assert.equal('id' in checkpoint.data, false);
+  assert.deepEqual(query(f, { ev: 'decision' }).map((e) => e.data.id), ['D-1', 'D-2', 'D-99', 'D-100', 'D-101']);
+  assert.equal(validateJournal(f).ok, true);
 });
 
 test('a review cannot close a colliding non-reviewer spawn', () => {


### PR DESCRIPTION
A data-integrity defect in shipped code, found while designing the ask queue and reproduced before it was believed.

**Ledger id issuance ran OUTSIDE the journal write lock.** The CLI called `nextId(file, prefix)` and then `append()`, and the lock lives inside `append`. Issuing an id is read-compute-write, so every concurrent writer read the same journal, computed the same next number, and then queued up to write it.

Measured on a fresh journal with a wall-clock barrier so every process is inside `append` at the same instant: **six simultaneous `decision` appends produced ONE distinct id for six events, deterministically.** Without the barrier, 1 to 4 distinct ids across seven runs. Ids are how one event references another in a file nobody ever rewrites — so `see D-2` was permanently ambiguous, `validateJournal` reported `ok`, and nothing anywhere detected it. Tyran's premise is parallel agents writing one ledger, so this is close to a worst case for the product.

## What changed

Issuance moved into `appendUnderLock`, computed from the memoized snapshot that call already reads. No second read — measured, the end-to-end cost of an append **halved** (1k / 20k / 100k-event journals), while the lock is held ~8-11% longer for the in-memory scan.

## Verification

- 72 barriered races across 12 shapes (2/8/16 writers × `decision`/`finding` × empty and pre-seeded journals): **zero duplicates**, ids contiguous every time.
- The new 8-process concurrency test **fails on the previous code 10 runs out of 10** (3-5 distinct of 8) and passes 12/12 here — a genuine regression test, not one that passes either way.
- 19 CLI commands diffed against the previous code: journal bytes identical. Three error messages improved (a non-object `--data` now names the problem instead of crashing with a TypeError).
- Suite **1084/1084**.

## Honest scope — what is NOT atomic

Stated on both doc surfaces rather than left to be assumed: `next-id` previews without reserving, so an id read there and appended later still loses to any writer in between; an explicit `data.id` is written verbatim and stays the caller's to keep unique; `ticket.created` is deliberately outside the issued set, so there is no atomic path for a `T-` id at all — the run skill now names the conductor as the single writer for ticket creation. A pre-existing arithmetic limit at 2^53 is described, not changed.

## ADR-20 — dead mutants

| mutant | red test |
|---|---|
| issuance back outside the lock | `8 truly concurrent appends issue 8 DISTINCT decision ids` |
| the snapshot read before the lock | same test, plus the pre-existing ADR-18 race test |
| explicit id loses / `""` treated as explicit | `append itself issues the id — explicit wins, "" is absent…` |
| the array/null guard dropped from the issuance condition | `a non-object data is REFUSED by name, and refused before an id is issued` |

🤖 Generated with [Claude Code](https://claude.com/claude-code)