### PR TITLE
fix(policy-gate): a read the Read tool already allows is not a boundary

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
     {
       "name": "tyran",
       "description": "A task conductor for Claude Code: multi-agent orchestration with an enforced evidence contract, repo-specific learning, and update-safe local evolution.",
-      "version": "0.1.15",
+      "version": "0.1.16",
       "source": "./",
       "author": {
         "name": "Jacek Janczura",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "tyran",
-  "version": "0.1.15",
+  "version": "0.1.16",
   "description": "A task conductor for Claude Code: multi-agent orchestration with an enforced evidence contract, repo-specific learning, and update-safe local evolution.",
   "author": {
     "name": "Jacek Janczura",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,12 +42,36 @@ shell in every mode, which is a deliberate narrowing rather than a consequence �
 and it is the one file from which every gate is switched off at once. One line
 naming a readable path *and* a secret is still refused for the secret.
 
+That last sentence needed a second check to stay true, and review found it out.
+The exemption was decided on the **finding list**, which is computed from a
+*stripped* copy of the command: `stripMessageArguments` removes a message-bearing
+flag together with its argument, and non-literal tokens are dropped after that.
+`-t` is `git commit --template` *and* a legal flag of `diff` and `cat`, so
+`diff -t .env hooks/scripts/policy-gate.mjs` left a finding list naming only the
+readable path, read as "read-only command on a readable path", and was exempted —
+really publishing the file. Four shapes were measured deny-on-0.1.15 →
+pass-before-the-fix: `diff -t SECRET FILE`, `grep --file=SECRET FILE`,
+`grep -m SECRET FILE`, and `diff ~/SECRET FILE`, the last because a leading `~`
+makes the token non-literal and it is dropped entirely. The exemption is now
+refused when any word of the **raw** command is credential-shaped, tested with
+the same `SECRET_READ_RULES` the findings use, and the refusal names that word
+rather than offering a rewrite that cannot help. This is the invariant being
+repaired, not a new capability: `diff -t .env src/app.js` publishes the same
+bytes and always did, because it names no protected path at all. One false
+refusal comes with it, in the safe direction — `git log --grep=.env -- FILE`
+loses the exemption over a word in a search pattern.
+
 The residual floor is stated in the refusal text and in `docs/policy-gate.md`
 rather than implied: matching flags bounds what a command *says*, not what the
 program *does*. An allowed reader can still be pointed at another program by
 configuration this gate never reads — a `diff.external` driver or a pager in git
 config, a `NODE_OPTIONS` carrying `--require`, a shell function shadowing `cat`.
-It is now the fifth entry in `SHELL_DECLARED_MISSES`.
+That is the fifth entry in `SHELL_DECLARED_MISSES`. The sixth is one step
+earlier: the program table is keyed on the **basename**, which is what makes
+`/bin/cat` and `cat` one entry and also makes a repo-writable `src/cat` an
+allowed reader. It is declared rather than closed, because closing it would
+close nothing — a script with the path already inside it needs no allowed name
+at all, which is the third entry.
 
 ## 0.1.15 — 2026-08-14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,54 @@
 # Changelog
 
+## 0.1.16 — 2026-08-14
+
+### `cat hooks/…` was refused while `Read` handed you the same bytes
+
+Measured on the shipped 0.1.15 gate, on one file under `hooks/**`: `Read` passes,
+and `cat`, `grep -n`, `wc -l` and `node --check` on that same file all **deny**.
+The bytes were one tool call away in every case, so the refusal protected
+nothing — and it was not consistent with itself either: `git log --oneline --
+hooks/` passed all along, because a bare directory token names no file to
+classify, while `wc -l` on a file inside it did not. The cost was four
+interrupted tool calls in one session for the author, every one of them while
+reading the gate being worked on.
+
+The rule this release encodes instead: **the shell must not become a second
+route to something the `Read` tool already refuses.** For `.env` that symmetry
+is load-bearing and is untouched — `Read` denies *and* `grep` denies, because
+the measured incident behind that rule is a refused `Read .env` followed by
+`Bash: grep` in the very next tool call. Where `Read` is allowed, refusing the
+shell buys nothing.
+
+So on `hooks/**` and `.tyran/policies/**` — and only there — a read-only shell
+command now passes. "Read-only" is matched on the **program and its flags**,
+never on the program alone, because read-shaped programs have write-shaped
+modes: `node --check FILE` passes and `node FILE` denies; `git log` passes and
+`git log --output=FILE` denies, which was a real hole found in an earlier review
+of this gate; `tail -n 5` passes and `tail -f` does not. An unrecognised flag
+refuses, so the enumeration's incompleteness costs a false refusal and never a
+pass. `sed` and `awk` are not on the list at all: their script argument is a
+program with its own write commands, and reading it would need a second parser.
+The raw command may contain none of ``< > $ ` ( ) { } &``, which is every
+redirection spelling, command substitution, subshell and `&&` at once — checked
+on the raw text, because the shared lexer *consumes* those characters as
+separators and by the time a token exists the `>` is gone. `|` and `;` are fine,
+since each composed segment still has to be an allowed reader.
+
+What did not change: every credential shape denies for reads and writes alike;
+`.claude/settings.json` and `.claude/settings.local.json` stay refused from a
+shell in every mode, which is a deliberate narrowing rather than a consequence —
+`Read` passes on the registry too, so the principle alone would have admitted it,
+and it is the one file from which every gate is switched off at once. One line
+naming a readable path *and* a secret is still refused for the secret.
+
+The residual floor is stated in the refusal text and in `docs/policy-gate.md`
+rather than implied: matching flags bounds what a command *says*, not what the
+program *does*. An allowed reader can still be pointed at another program by
+configuration this gate never reads — a `diff.external` driver or a pager in git
+config, a `NODE_OPTIONS` carrying `--require`, a shell function shadowing `cat`.
+It is now the fifth entry in `SHELL_DECLARED_MISSES`.
+
 ## 0.1.15 — 2026-08-14
 
 ### Fifteen questions, ten minutes, and the swarm moves

--- a/docs/policy-gate.md
+++ b/docs/policy-gate.md
@@ -176,8 +176,11 @@ prints the lines.
 
 The way out is an explicit `class: AUTO` rule for the path in
 `.tyran/policies/autonomy.yaml`. That file is class `KERNEL`, **and a shell
-command that names it is refused too**, so the exemption is not one an agent
-writes for itself in the ordinary way. It is not a proof: a path this gate
+command that writes to it is refused too**, so the exemption is not one an agent
+writes for itself in the ordinary way. (Narrowed in 0.1.16 from "a shell command
+that *names* it": a read-only command on that path passes now, as `Read` always
+did. What closes the route is the write half, which is the half `cat >>` used.)
+It is not a proof: a path this gate
 never sees as a word is in the declared floor above. Round two claimed the
 stronger version — "cannot be talked out of it from inside a session" — and
 review took it apart in three tool calls.
@@ -195,12 +198,15 @@ Stated here rather than left to be discovered, because a boundary an agent
 finds by itself is a boundary it learns to prefer.
 
 1. **Shell commands are path-checked for two families only, not classified.**
-   A `Bash` command that names a credential-shaped path, or a path under the
-   two built-in protected globs, is refused; the policy's own `AUTO`/`GATED`/
-   `KERNEL` rules are **not** consulted for shell commands. *Worst case:* a
-   `KERNEL` path a user declared in their own policy can be written from a
-   shell. The two built-in globs are deliberate — they need no policy file, so
-   a broken policy cannot be the thing that stops an operator repairing it.
+   A `Bash` command that names a credential-shaped path is refused outright; a
+   command that could write to a path under the two built-in protected globs,
+   `.claude/settings.json` or `.claude/settings.local.json` is refused, while a
+   read-only command on the two built-in globs passes (see below). The policy's
+   own `AUTO`/`GATED`/`KERNEL` rules are **not** consulted for shell commands.
+   *Worst case:* a `KERNEL` path a user declared in their own policy can be
+   written from a shell. The two built-in globs are deliberate — they need no
+   policy file, so a broken policy cannot be the thing that stops an operator
+   repairing it.
 2. **Product code is not classified by default.** Only `.tyran/`, `.claude/`
    and `hooks/` fall under the policy's `default:`; everything else needs an
    explicit rule. *Worst case:* a user who believes the policy covers their
@@ -264,14 +270,15 @@ of the command, never the effect of running it.**
 
 Every literal token of every segment is tested — there is no heuristic about
 which token "looks like a path", because an ordinary word matches nothing.
-Two families are refused:
+Two families are refused, and they are refused for different reasons:
 
 - a **credential-shaped** path, whatever the program does with it. `cat`,
   `grep`, `cp` and `base64` all publish the bytes, and the distinction between
-  reading and copying is not one a gate reading text can make;
+  reading and copying is not one a gate reading text can make. Reads and writes
+  alike, because the `Read` tool refuses this family too;
 - a path under `hooks/**`, `.tyran/policies/**`, `.claude/settings.json` or
-  `.claude/settings.local.json`. To *read* one, use the `Read` tool, which is
-  not refused for them.
+  `.claude/settings.local.json`. This family is a **write** rule: on the two
+  built-in globs a read-only command passes, because `Read` passes on them.
 
 **`.claude/settings.json` is on that list because it registers the hooks** — it
 is the one place inside a repository from which every gate can be switched off
@@ -301,6 +308,82 @@ same move `stripHeredocBodies` makes in the shared lexer, for the same
 measured reason: a commit message is data, and lexing data as a program was
 the largest single source of false alarms there.
 
+### Reading `hooks/**` and `.tyran/policies/**` from a shell
+
+Measured on 0.1.15, for one file under `hooks/**`:
+
+| call | 0.1.15 | 0.1.16 |
+|---|---|---|
+| `Read FILE` | pass | pass |
+| `cat FILE` | **deny** | pass |
+| `grep -n X FILE` | **deny** | pass |
+| `wc -l FILE` | **deny** | pass |
+| `node --check FILE` | **deny** | pass |
+| `git log --oneline -- hooks/` | pass | pass |
+
+The last row is what made the old rule indefensible: a bare directory token
+names no file to classify, so it always passed, while `wc -l` on a file inside
+it did not. In every other row the bytes were one `Read` call away.
+
+**The rule this encodes: the shell must not become a second route to something
+the `Read` tool already refuses.** For `.env` that symmetry is the whole point —
+`Read` denies *and* `grep` denies, because the measured incident is a refused
+`Read .env` followed by `Bash: grep` in the very next tool call. Where `Read` is
+allowed, refusing the shell buys nothing and costs a tool call every time
+somebody inspects the gate they are working on.
+
+A command is exempted only when **all** of the following hold:
+
+- every segment's program is `cat`, `head`, `tail`, `wc`, `grep`, `rg`, `diff`,
+  `node` or `git`, matched **exactly** on the program name. `/bin/cat` and
+  `CAT` are the same program; `catnip` is not, and neither is `constructor`;
+- for `git`, the word immediately after it is `log`, `show` or `diff`. A global
+  flag before the subcommand refuses, because `git -c core.pager=…` names a
+  program for git to run and `planCommand`'s alias check only covers `alias.`;
+- for `node`, `--check` (or `-c`) is **required** rather than merely permitted:
+  `node FILE` executes FILE;
+- every token beginning with `-` is in that program's flag list, short clusters
+  read letter by letter. An unrecognised flag **refuses** — the enumeration's
+  incompleteness costs a false refusal, never a pass;
+- the raw command contains none of ``< > $ ` ( ) { } &`` — every redirection
+  spelling, command substitution, parameter expansion, subshell, group, and
+  `&`/`&&` at once. Tested on the raw text because the shared lexer *consumes*
+  these as separators: by the time a token exists, the `>` that made the line a
+  write is gone.
+
+`|` and `;` are allowed, because every composed segment still has to be an
+allowed reader — a pipe into a writer is a writer.
+
+Refused, and each one is a mode of an otherwise allowed program:
+
+| refused | why |
+|---|---|
+| `sed -n 1,20p FILE` · `awk NR<10 FILE` | the script argument is a program with its own write commands (`sed`'s `w`, awk's `print >`). Reading it needs a second parser, which ADR-21 is exactly about |
+| `node FILE` | executes it |
+| `git log --output=FILE` · `git show --output=FILE` | writes a file — a real hole found in an earlier review of this gate |
+| `git -c core.pager=tee log` | a global `-c` names a program for git to run |
+| `rg --pre CMD` · `rg --hostname-bin CMD` | runs `CMD` once per file |
+| `tail -f FILE` | never returns |
+| `cat FILE > /tmp/cat` · `cat $(cat FILE)` · `cat FILE \| tee /tmp/x` | redirection, substitution, a pipe into a writer |
+| the same commands on `.env`, `id_rsa`, `.aws/credentials` | the credential family, unchanged |
+| the same commands on `.claude/settings.json` | below |
+
+**`.claude/settings.json` is deliberately outside the exemption**, and that is a
+narrowing rather than a consequence: `Read` passes on it too, so the principle
+alone would admit it. It is the hook registry — the one place inside a
+repository from which every gate is switched off at once — and this change is
+scoped to the friction that was measured. Direction of error stays refuse.
+
+**The residual floor, plainly.** Matching flags bounds what a command *says*,
+not what the program *does*. An allowed reader can still be pointed at another
+program by configuration this gate never reads: a `diff.external` driver or a
+pager in git config, a `NODE_OPTIONS` carrying `--require`, a shell function
+shadowing `cat`. The claim is exact and narrow — **these two globs are no harder
+to read from a shell than with the `Read` tool, which already passes on them**
+— and it is not a claim that an allowed program can only ever read. One false
+refusal is declared with it: quoting is not honoured, so `grep ">" FILE` is
+refused for a character inside a string.
+
 ### The declared floor for the shell rules
 
 Not a ceiling. `SHELL_DECLARED_MISSES` in the source is the same list:
@@ -313,7 +396,11 @@ Not a ceiling. `SHELL_DECLARED_MISSES` in the source is the same list:
 3. anything a script writes once it is running;
 4. a `KERNEL` path declared by the **policy** rather than built in — only
    `SHELL_PROTECTED_GLOBS` is checked, so a broken policy can never be the
-   thing that stops an operator repairing it.
+   thing that stops an operator repairing it;
+5. a program an allowed reader is **configured** to launch — a `diff.external`
+   driver or pager in git config, a `NODE_OPTIONS` carrying `--require`, a
+   shell function shadowing `cat`. The flag table matches the command *text*,
+   and the environment is not in it.
 
 ## The cost, measured
 

--- a/docs/policy-gate.md
+++ b/docs/policy-gate.md
@@ -349,7 +349,19 @@ A command is exempted only when **all** of the following hold:
   spelling, command substitution, parameter expansion, subshell, group, and
   `&`/`&&` at once. Tested on the raw text because the shared lexer *consumes*
   these as separators: by the time a token exists, the `>` that made the line a
-  write is gone.
+  write is gone;
+- **no word of the raw command is credential-shaped**, tested a second time
+  against the same `SECRET_READ_RULES` and with none of the filters the path
+  findings go through. The findings are computed from a *stripped* copy of the
+  command — `stripMessageArguments` removes a message-bearing flag together with
+  its argument, and non-literal tokens are dropped — so a credential can be
+  invisible in them. `-t` is `git commit --template` *and* a legal `diff` flag,
+  which made `diff -t .env FILE` read as "one readable path, one read-only
+  command" and exempted it. Four shapes were measured deny-on-0.1.15 →
+  pass-before-this-check: `diff -t SECRET FILE`, `grep --file=SECRET FILE`,
+  `grep -m SECRET FILE`, `diff ~/SECRET FILE`. One false refusal is declared
+  with it, in the direction this gate errs in: `git log --grep=.env -- FILE`
+  loses the exemption over a word in a search pattern.
 
 `|` and `;` are allowed, because every composed segment still has to be an
 allowed reader — a pipe into a writer is a writer.
@@ -366,6 +378,7 @@ Refused, and each one is a mode of an otherwise allowed program:
 | `tail -f FILE` | never returns |
 | `cat FILE > /tmp/cat` · `cat $(cat FILE)` · `cat FILE \| tee /tmp/x` | redirection, substitution, a pipe into a writer |
 | the same commands on `.env`, `id_rsa`, `.aws/credentials` | the credential family, unchanged |
+| `diff -t .env FILE` · `grep --file=.env FILE` · `grep -m .env FILE` · `diff ~/.env FILE` | the credential family again, found on the **raw** text: the finding list is computed from a stripped copy of the command and never saw these words |
 | the same commands on `.claude/settings.json` | below |
 
 **`.claude/settings.json` is deliberately outside the exemption**, and that is a
@@ -378,7 +391,9 @@ scoped to the friction that was measured. Direction of error stays refuse.
 not what the program *does*. An allowed reader can still be pointed at another
 program by configuration this gate never reads: a `diff.external` driver or a
 pager in git config, a `NODE_OPTIONS` carrying `--require`, a shell function
-shadowing `cat`. The claim is exact and narrow — **these two globs are no harder
+shadowing `cat`. The name in the command may not even be the program it looks
+like — the table is keyed on the basename, item 6 below. The claim is exact and
+narrow — **these two globs are no harder
 to read from a shell than with the `Read` tool, which already passes on them**
 — and it is not a claim that an allowed program can only ever read. One false
 refusal is declared with it: quoting is not honoured, so `grep ">" FILE` is
@@ -400,7 +415,15 @@ Not a ceiling. `SHELL_DECLARED_MISSES` in the source is the same list:
 5. a program an allowed reader is **configured** to launch — a `diff.external`
    driver or pager in git config, a `NODE_OPTIONS` carrying `--require`, a
    shell function shadowing `cat`. The flag table matches the command *text*,
-   and the environment is not in it.
+   and the environment is not in it;
+6. **a different program wearing an allowed one's name.** `READ_ONLY_PROGRAMS`
+   is keyed on the *basename*, which is what makes `/bin/cat` and `cat` one
+   entry — and also makes a repo-writable `src/cat` an allowed reader, with
+   `src/**` classed AUTO in the shipped template. Declared rather than closed:
+   requiring a bare program name would break `/bin/cat` and still admit an
+   absolute in-repo path, and it would buy nothing anyway, because miss 3
+   already lets the same script do the same work with the path baked in and no
+   allowed name at all.
 
 ## The cost, measured
 

--- a/hooks/scripts/policy-gate.mjs
+++ b/hooks/scripts/policy-gate.mjs
@@ -1025,8 +1025,11 @@ const READ_REMEDY =
   // calls: `cat >> .tyran/policies/autonomy.yaml`, then the same read, allowed.
   // The shell route is closed now, so the claim is nearly true — and "nearly"
   // is exactly the word a guarantee may not leave out.
-  'That file is class KERNEL, and a shell command that NAMES it is refused too, so the exemption ' +
-  'is not one an agent can write for itself in the ordinary way. It is not a proof: a path this ' +
+  // Narrowed in 0.1.16 from "a shell command that NAMES it": a read-only shell
+  // command on that path passes now, exactly as `Read` always did. What closes
+  // the route is the WRITE half, which is the half `cat >>` used.
+  'That file is class KERNEL, and a shell command that WRITES to it is refused too, so the ' +
+  'exemption is not one an agent can write for itself in the ordinary way. It is not a proof: a path this ' +
   'gate never sees as a word — assembled from a variable, or from a program it launches — is in ' +
   'the declared floor in docs/policy-gate.md. Writing that exemption yourself is working around ' +
   'the gate, which is the one move that makes a boundary worse than no boundary.';
@@ -1225,8 +1228,8 @@ function escapeRoute(cls, unsupervised) {
       'edit in the main session, where the permission prompt is the approval. Do not look for a ' +
       'path around this gate: writing the same bytes through `Bash` is outside what this gate ' +
       'checks for CLASSES — though it does refuse a shell command that names a credential file or ' +
-      'a built-in protected path — and doing it deliberately is the one thing that turns a ' +
-      'boundary into a decoration.'
+      'writes to a built-in protected path — and doing it deliberately is the one thing that ' +
+      'turns a boundary into a decoration.'
     );
   }
   return (
@@ -1318,6 +1321,13 @@ export function stripMessageArguments(command) {
  *    the thing that stops an operator running the validator. The two built-in
  *    globs need no configuration and cannot be edited away.
  *
+ * The second family is a WRITE rule, and since 0.1.16 it says so: a command
+ * that can only read passes on `SHELL_READABLE_GLOBS`, because the `Read` tool
+ * passes on those paths and a shell refusal on top of an allowed `Read`
+ * protects nothing. See `SHELL_READABLE_GLOBS` for the measurement. The first
+ * family is untouched — for a credential the `Read` tool refuses too, and that
+ * symmetry is the entire rule.
+ *
  * ## The declared floor
  *
  * `SHELL_DECLARED_MISSES` names what still gets through. A path assembled at
@@ -1362,6 +1372,250 @@ export function shellProtectedGlobFor(normalized) {
   return null;
 }
 
+// ------------------------------------------- the read-only shell exemption
+
+/**
+ * The protected globs on which a READ-ONLY shell command is allowed.
+ *
+ * ## The measurement
+ *
+ * On 0.1.15, for any path under `hooks/**` or `.tyran/policies/**`: the `Read`
+ * tool PASSES, and every read-shaped shell command on the SAME file is
+ * refused — `cat FILE`, `grep -n X FILE`, `wc -l FILE`, `node --check FILE`,
+ * all deny. The bytes are one `Read` call away, so the refusal protected
+ * nothing and cost a tool call every time somebody inspected the gate they
+ * were working on. The rule was not even consistent with itself:
+ * `git log --oneline -- hooks/` passes, because a bare directory token names
+ * no file to classify, while `wc -l` on a file inside it does not.
+ *
+ * ## The distinction this encodes
+ *
+ * **The shell must not become a second route to something the `Read` tool
+ * already refuses.** For a secret that symmetry is load-bearing and stays
+ * exactly as it was: `Read .env` denies AND `grep .env` denies, because the
+ * measured incident is a refused `Read` followed by `Bash: grep` in the very
+ * next tool call. Where `Read` is allowed, refusing the shell buys nothing —
+ * it only teaches the reader that the gate is an obstacle rather than a
+ * boundary, which is the failure mode ADR-19 is about.
+ *
+ * ## Why this list is not `SHELL_PROTECTED_GLOBS`
+ *
+ * `.claude/settings.json` and `.claude/settings.local.json` are deliberately
+ * NOT here, and that is a narrowing beyond what the argument above strictly
+ * requires — `Read` passes on them too, so by the principle alone they would
+ * qualify. They are the hook registry, the one place inside a repository from
+ * which every gate is switched off at once, and this change is scoped to the
+ * friction that was actually measured. Direction of error stays REFUSE.
+ */
+export const SHELL_READABLE_GLOBS = Object.freeze([...MANDATORY_KERNEL_PATHS]);
+
+/**
+ * Characters that put a WRITE — or a program this gate cannot see — into a
+ * command line. One of them anywhere in the raw text disqualifies the whole
+ * line from the exemption, whatever the programs are.
+ *
+ * `>` and `<` are every redirection spelling at once (`>`, `>>`, `2>`, `&>`,
+ * `<`, `<<`, `<<<`, `<(…)`); `` ` `` and `$` are command substitution and
+ * parameter expansion, whose result this gate never sees; `(`, `)`, `{`, `}`
+ * are subshells and groups; `&` is both background and `&&`, and telling those
+ * apart needs a parser this repository is not getting a second of (ADR-21).
+ *
+ * Tested on the RAW command rather than on the lexer's tokens, and that is
+ * forced rather than chosen: `splitSegments` CONSUMES these as separators
+ * (`SEPARATORS` in secrets-gate.mjs), so by the time a token exists the `>`
+ * that made the line a write is already gone. Quoting is not honoured, so
+ * `grep ">" FILE` is a false refusal — the direction this gate errs in.
+ *
+ * `|`, `;` and newline are absent on purpose: they compose commands without
+ * writing, and every composed segment still has to be an allowed read-only
+ * program, so a pipe into a writer is refused by the program check.
+ */
+export const SHELL_READ_DISQUALIFIERS = '<>$`(){}&';
+
+/**
+ * Programs that read, and the flags under which they only read.
+ *
+ * ## Program AND flags, because read-shaped programs have write-shaped modes
+ *
+ * This is the honest risk of the whole exemption, so it is matched rather than
+ * asserted: `sed -n` versus `sed -i`, `node --check FILE` versus
+ * `node FILE`, and `git log` versus `git log --output=FILE` — the last a real
+ * hole found in an earlier review of this gate. Every token beginning with `-`
+ * must appear in the entry for its program; an unrecognised flag REFUSES, so
+ * the enumeration's incompleteness costs a false refusal and never a pass.
+ *
+ * Fields, all optional except `short`/`long`:
+ *  - `short` — the single letters a short cluster may contain (`-rn` is `r`
+ *    and `n`, checked one letter at a time);
+ *  - `long`  — the long options, matched on the name before any `=`, so
+ *    `--output=/tmp/x` is tested as `--output` and refused;
+ *  - `numeric` — the program takes a bare count (`head -20`, `git log -5`)
+ *    and an attached one (`head -n20`);
+ *  - `subcommands` — the word that MUST follow the program immediately. `git`
+ *    is the only entry with one, and requiring it in the very next slot is
+ *    what refuses `git -c core.pager=… log`: a global `-c` can name a program
+ *    for git to run, and `planCommand`'s alias check only covers `alias.`;
+ *  - `require` — at least one of these must be present. `node` alone RUNS a
+ *    file, so `--check` is not merely permitted, it is mandatory.
+ *
+ * Null-prototype on purpose: a plain object literal answers `constructor`
+ * with a function, which would make `constructor FILE` an allowed program.
+ */
+export const READ_ONLY_PROGRAMS = Object.freeze(Object.assign(Object.create(null), {
+  cat: {
+    short: 'AbeEnstTuv',
+    long: ['--show-all', '--number-nonblank', '--show-ends', '--number', '--squeeze-blank',
+      '--show-tabs', '--show-nonprinting'],
+  },
+  head: {
+    short: 'cnqvz',
+    numeric: true,
+    long: ['--bytes', '--lines', '--quiet', '--silent', '--verbose', '--zero-terminated'],
+  },
+  // Identical to `head` minus `-f`/`-F`/`--follow`/`--retry`/`--pid`, which do
+  // not write but never return either: a gate that hands the session a command
+  // it can only recover from by killing the tool call has not helped anyone.
+  tail: {
+    short: 'cnqvz',
+    numeric: true,
+    long: ['--bytes', '--lines', '--quiet', '--silent', '--verbose', '--zero-terminated'],
+  },
+  wc: {
+    short: 'clLmw',
+    long: ['--bytes', '--chars', '--lines', '--max-line-length', '--words'],
+  },
+  grep: {
+    short: 'ABCDEFGHILPRTUVZabcdefhilmnoqrsuvwxyz',
+    long: ['--extended-regexp', '--fixed-strings', '--basic-regexp', '--perl-regexp', '--regexp',
+      '--file', '--ignore-case', '--no-ignore-case', '--invert-match', '--word-regexp',
+      '--line-regexp', '--count', '--files-without-match', '--files-with-matches', '--max-count',
+      '--only-matching', '--quiet', '--silent', '--no-messages', '--byte-offset', '--with-filename',
+      '--no-filename', '--label', '--line-number', '--initial-tab', '--null', '--null-data',
+      '--after-context', '--before-context', '--context', '--group-separator',
+      '--no-group-separator', '--color', '--colour', '--binary-files', '--text', '--directories',
+      '--devices', '--recursive', '--dereference-recursive', '--include', '--exclude',
+      '--exclude-from', '--exclude-dir', '--line-buffered', '--binary', '--version', '--help'],
+  },
+  // ripgrep is the entry that most needs its flags read rather than its name:
+  // `--pre` and `--hostname-bin` name a program for rg to execute per file,
+  // which is arbitrary code from a command line that otherwise looks like a
+  // search. Neither is listed, so both refuse.
+  rg: {
+    short: 'ABCFHILMNPSTUVcefghijlmnopqrstuvwxz0',
+    long: ['--after-context', '--before-context', '--context', '--count', '--count-matches',
+      '--regexp', '--fixed-strings', '--file', '--glob', '--iglob', '--with-filename',
+      '--no-filename', '--ignore-case', '--smart-case', '--case-sensitive', '--follow',
+      '--files-with-matches', '--files-without-match', '--files', '--max-columns', '--max-count',
+      '--max-depth', '--max-filesize', '--no-line-number', '--line-number', '--column',
+      '--only-matching', '--pcre2', '--pretty', '--quiet', '--replace', '--type', '--type-not',
+      '--multiline', '--multiline-dotall', '--unrestricted', '--version', '--invert-match',
+      '--word-regexp', '--line-regexp', '--search-zip', '--threads', '--null', '--heading',
+      '--no-heading', '--hidden', '--no-ignore', '--no-config', '--color', '--colors', '--json',
+      '--vimgrep', '--sort', '--sortr', '--stats', '--trim', '--text', '--binary', '--engine',
+      '--help'],
+  },
+  diff: {
+    short: 'BCEHNSTUWZabcdinpqrstuwxy',
+    long: ['--unified', '--context', '--side-by-side', '--brief', '--report-identical-files',
+      '--recursive', '--new-file', '--ignore-space-change', '--ignore-all-space',
+      '--ignore-blank-lines', '--ignore-case', '--ignore-tab-expansion', '--ignore-trailing-space',
+      '--ignore-matching-lines', '--text', '--expand-tabs', '--initial-tab', '--minimal',
+      '--speed-large-files', '--color', '--width', '--suppress-common-lines',
+      '--strip-trailing-cr', '--show-c-function', '--label', '--exclude', '--exclude-from',
+      '--starting-file', '--no-dereference', '--version', '--help'],
+  },
+  // `node FILE` executes FILE. `--check` only parses it, and is REQUIRED here
+  // rather than merely allowed, which is what separates the two.
+  node: {
+    short: 'c',
+    long: ['--check'],
+    require: { short: 'c', long: ['--check'] },
+  },
+  git: {
+    subcommands: ['log', 'show', 'diff'],
+    short: 'MSUbnpsuw',
+    numeric: true,
+    long: ['--oneline', '--graph', '--decorate', '--no-decorate', '--abbrev-commit',
+      '--no-abbrev-commit', '--pretty', '--format', '--date', '--stat', '--numstat',
+      '--shortstat', '--dirstat', '--name-only', '--name-status', '--raw', '--patch',
+      '--no-patch', '--unified', '--word-diff', '--color', '--no-color', '--reverse', '--all',
+      '--branches', '--tags', '--remotes', '--author', '--committer', '--grep', '--since',
+      '--until', '--before', '--after', '--max-count', '--skip', '--follow', '--first-parent',
+      '--merges', '--no-merges', '--cached', '--staged', '--summary', '--find-renames',
+      '--find-copies', '--full-history', '--topo-order', '--date-order', '--author-date-order',
+      '--relative', '--no-prefix', '--src-prefix', '--dst-prefix', '--diff-filter', '--text',
+      '--binary', '--numbered', '--no-renames'],
+  },
+}));
+
+/** True when one `-…` token is a flag its program only reads under. */
+export function readOnlyFlag(spec, token) {
+  if (token.startsWith('--')) return (spec.long ?? []).includes(token.split('=')[0]);
+  const body = token.slice(1);
+  // `head -20`, `git log -5`: the whole body is the count.
+  if (/^[0-9]+$/.test(body)) return spec.numeric === true;
+  // `head -n20`: an attached count on the last letter of the cluster.
+  const letters = spec.numeric === true ? body.replace(/[0-9]+$/, '') : body;
+  if (letters === '') return false;
+  for (const ch of letters) if (!(spec.short ?? '').includes(ch)) return false;
+  return true;
+}
+
+/** True when one segment is a read-only program used in a read-only way. */
+export function readOnlySegment(tokens) {
+  if (tokens.length === 0) return false;
+  // `basename` for the same reason the lexer uses it: `/usr/bin/cat` and `cat`
+  // are one program. Case-folded because a case-insensitive filesystem will
+  // launch `CAT` from the same inode.
+  const spec = READ_ONLY_PROGRAMS[basename(tokens[0]).toLowerCase()];
+  if (spec === undefined) return false;
+  let rest = tokens.slice(1);
+  if (spec.subcommands !== undefined) {
+    if (rest.length === 0 || !spec.subcommands.includes(rest[0])) return false;
+    rest = rest.slice(1);
+  }
+  // `-` is stdin and `--` ends the options; neither is a flag.
+  const flags = rest.filter((t) => t.startsWith('-') && t !== '-' && t !== '--');
+  for (const flag of flags) if (!readOnlyFlag(spec, flag)) return false;
+  if (spec.require === undefined) return true;
+  return flags.some((t) =>
+    t.startsWith('--')
+      ? spec.require.long.includes(t.split('=')[0])
+      : [...t.slice(1)].some((ch) => spec.require.short.includes(ch)));
+}
+
+/**
+ * True when this whole command line can only read.
+ *
+ * Two gates, and both have to hold: no character that can redirect, substitute
+ * or group (checked on the raw text, see `SHELL_READ_DISQUALIFIERS`), and
+ * every segment the shared lexer produces is an allowed program under allowed
+ * flags. Segmentation comes from `splitSegments` — this repository has one
+ * lexer and is not getting a second (ADR-21).
+ */
+export function isReadOnlyCommand(command) {
+  const text = String(command);
+  for (const ch of SHELL_READ_DISQUALIFIERS) if (text.includes(ch)) return false;
+  const segments = splitSegments(text);
+  if (segments.length === 0) return false;
+  for (const segment of segments) if (!readOnlySegment(tokensOf(segment))) return false;
+  return true;
+}
+
+/**
+ * True when the path refusal may be lifted for this command.
+ *
+ * Every finding must be in the readable class — one credential-shaped path, or
+ * one `.claude/settings.json`, and the whole line is refused however read-only
+ * the rest of it is. That ordering is the point: the exemption widens what may
+ * be done to paths the `Read` tool already hands over, and nothing else.
+ */
+export function shellReadExempt(findings, command) {
+  if (findings.length === 0) return false;
+  if (!findings.every((f) => f.kind === 'kernel' && SHELL_READABLE_GLOBS.includes(f.detail))) return false;
+  return isReadOnlyCommand(command);
+}
+
 export const SHELL_DECLARED_MISSES = Object.freeze([
   'a path assembled at runtime — from a variable, a command substitution, a glob, or a file ' +
     'already on disk. The gate never expands anything, so it never sees the result',
@@ -1371,6 +1625,12 @@ export const SHELL_DECLARED_MISSES = Object.freeze([
   'anything a script writes once it is running — this reads the COMMAND, never its effect',
   'a KERNEL path declared by the POLICY rather than built in; only SHELL_PROTECTED_GLOBS is ' +
     'checked here, so that a broken policy cannot stop the operator repairing it',
+  // The floor of the read-only exemption, stated in the same list rather than
+  // in a second one: what an allowed program does is decided partly OUTSIDE
+  // the command text this gate reads, and no flag table can see that half.
+  'a program an allowed reader is CONFIGURED to launch — a `diff.external` driver or a pager ' +
+    'in git config, a `NODE_OPTIONS` carrying `--require`, a shell function shadowing `cat`. ' +
+    'READ_ONLY_PROGRAMS matches the command TEXT, and the environment is not in it',
 ]);
 
 /** Every literal token of a command, with message-flag arguments skipped. */
@@ -1407,6 +1667,12 @@ export function shellPathFindings(command, startDir, root) {
 function refuseShellPaths(findings) {
   const credentials = findings.filter((f) => f.kind === 'credential');
   const kernel = findings.filter((f) => f.kind === 'kernel');
+  // True when the PATHS were all in the readable class, so the command itself
+  // is the only reason this is a refusal. Worth saying: the reader is one
+  // rewrite away from an allowed call, and a refusal with no reachable way
+  // forward produces an agent that looks for a way around (ADR-19).
+  const commandWasTheProblem =
+    credentials.length === 0 && kernel.every((f) => SHELL_READABLE_GLOBS.includes(f.detail));
   const lines = [
     'tyran policy-gate: refused. This command names a path this gate protects.',
     ...credentials.map(
@@ -1431,6 +1697,23 @@ function refuseShellPaths(findings) {
       'A protected path is edited by a human, by hand, outside an agent session — these are the ' +
         'files that enforce every other boundary. To READ one, use the Read tool, which is not ' +
         'refused for them.',
+    );
+  }
+  if (commandWasTheProblem) {
+    lines.push(
+      '',
+      `These paths are READABLE from a shell — ${SHELL_READABLE_GLOBS.join(' and ')} both are — ` +
+        'so what was refused is this COMMAND, not the file. A read-only line passes: the allowed ' +
+        'programs are cat, head, tail, wc, grep, rg, diff, `node --check` and `git log`/`show`/' +
+        '`diff`, each only under flags that cannot write, and the line may contain no redirection ' +
+        '(`>`, `>>`, `2>`, `<`), no command substitution (`$(…)`, backticks), no `&`, and no ' +
+        'segment whose program is not on that list — a pipe into a writer is a writer.',
+      'Residual floor, stated because a flag table cannot see past the command text: an allowed ' +
+        'reader can still be made to run something else by configuration this gate never reads — ' +
+        'a `diff.external` driver or pager in git config, a NODE_OPTIONS carrying `--require`, a ' +
+        'shell function shadowing `cat`. The exemption is that these paths are no harder to READ ' +
+        'from a shell than with the Read tool, which already passes on them; it is not a claim ' +
+        'that an allowed program can only ever read.',
     );
   }
   lines.push(
@@ -1468,7 +1751,10 @@ async function decideBash({ input, toolInput, root, runner, budget }) {
   // check that only runs once a policy loads is a check an unconfigured repo
   // does not have.
   const findings = shellPathFindings(command, startDir, root);
-  if (findings.length > 0) return refuseShellPaths(findings);
+  // The exemption SKIPS this refusal; it does not return PASS. A `git log` that
+  // names a protected path still travels the deployment class and every other
+  // check below, exactly as `git log` on any other path does.
+  if (findings.length > 0 && !shellReadExempt(findings, command)) return refuseShellPaths(findings);
 
   const plan = planCommand(command, startDir);
   const pushes = plan.targets.filter((t) => t.scanPush === true && Array.isArray(t.pushArgv));

--- a/hooks/scripts/policy-gate.mjs
+++ b/hooks/scripts/policy-gate.mjs
@@ -1566,7 +1566,10 @@ export function readOnlySegment(tokens) {
   if (tokens.length === 0) return false;
   // `basename` for the same reason the lexer uses it: `/usr/bin/cat` and `cat`
   // are one program. Case-folded because a case-insensitive filesystem will
-  // launch `CAT` from the same inode.
+  // launch `CAT` from the same inode. What that costs is the last entry of
+  // SHELL_DECLARED_MISSES: a repo-writable `src/cat` is an allowed reader by
+  // name. Stated there rather than narrowed here — see the entry for why a
+  // narrowing would close nothing.
   const spec = READ_ONLY_PROGRAMS[basename(tokens[0]).toLowerCase()];
   if (spec === undefined) return false;
   let rest = tokens.slice(1);
@@ -1603,16 +1606,76 @@ export function isReadOnlyCommand(command) {
 }
 
 /**
+ * Credential-shaped words of the RAW command text, as `{token, detail}`.
+ *
+ * ## Why the finding list is not enough to decide the exemption
+ *
+ * `shellPathFindings` reads `commandTokens`, and `commandTokens` runs
+ * `stripMessageArguments` FIRST — which removes a message-bearing flag together
+ * with its argument. `-t` is in `MESSAGE_FLAGS` (git's `--template`) and is also
+ * a legal flag of `diff` and `cat`, so `diff -t SECRET READABLE` produced a
+ * finding list naming only the readable path, `isReadOnlyCommand` agreed on the
+ * raw text, and the line was EXEMPTED. Measured deny-on-0.1.15 -> pass, in four
+ * shapes: `diff -t S R`, `grep --file=S R`, `grep -m S R`, and `diff ~/S R` —
+ * the last for a second reason, that `~` makes the token fail `isLiteralPath`
+ * and `commandTokens` drops it entirely.
+ *
+ * That is a broken INVARIANT rather than a new capability: `diff -t S src/app.js`
+ * publishes the same bytes and always did, because it names no protected path
+ * at all. But the exemption's stated claim is that it widens what may be done
+ * to paths `Read` already hands over and NOTHING else, and a line that dumps a
+ * credential is not that.
+ *
+ * ## What this reads
+ *
+ * The raw text, with none of the three filters that lost the word: no message
+ * stripping, no `isLiteralPath`, and the right-hand side of an attached `=`
+ * tested as well as the whole word, so `--file=.env` cannot hide behind its own
+ * flag. The RULES are `secretReadRules` — the same matcher the credential
+ * findings use, asked a second question rather than spelled a second time
+ * (ADR-21).
+ *
+ * One false refusal is declared with it, and it is the direction this gate errs
+ * in: a credential-SHAPED word that is not a path loses the exemption, so
+ * `git log --grep=.env -- hooks/x.mjs` is refused for a word in a search
+ * pattern and costs one `Read` call. A commit message cannot reach here at all
+ * — `git commit -m "fix .env loading"` names no protected path, so there is no
+ * finding to exempt and this function is never called.
+ */
+export function rawCredentialWords(command) {
+  const out = [];
+  for (const segment of splitSegments(String(command))) {
+    for (const token of tokensOf(segment)) {
+      const at = token.indexOf('=');
+      for (const word of at === -1 ? [token] : [token, token.slice(at + 1)]) {
+        if (word === '') continue;
+        const ids = secretReadRules(word);
+        if (ids.length > 0) {
+          out.push({ token, detail: ids.join(', ') });
+          break;
+        }
+      }
+    }
+  }
+  return out;
+}
+
+/**
  * True when the path refusal may be lifted for this command.
  *
  * Every finding must be in the readable class — one credential-shaped path, or
  * one `.claude/settings.json`, and the whole line is refused however read-only
  * the rest of it is. That ordering is the point: the exemption widens what may
  * be done to paths the `Read` tool already hands over, and nothing else.
+ *
+ * The last clause is checked on the RAW text and not only on the findings,
+ * because the findings are computed from a STRIPPED copy of the command and a
+ * credential can be invisible in it. See `rawCredentialWords`.
  */
 export function shellReadExempt(findings, command) {
   if (findings.length === 0) return false;
   if (!findings.every((f) => f.kind === 'kernel' && SHELL_READABLE_GLOBS.includes(f.detail))) return false;
+  if (rawCredentialWords(command).length > 0) return false;
   return isReadOnlyCommand(command);
 }
 
@@ -1631,6 +1694,14 @@ export const SHELL_DECLARED_MISSES = Object.freeze([
   'a program an allowed reader is CONFIGURED to launch — a `diff.external` driver or a pager ' +
     'in git config, a `NODE_OPTIONS` carrying `--require`, a shell function shadowing `cat`. ' +
     'READ_ONLY_PROGRAMS matches the command TEXT, and the environment is not in it',
+  // The same miss one step earlier: not what the reader launches, but which
+  // reader the name picks out. Split from the entry above because that one ends
+  // "the environment is not in it" and this program IS in the command text —
+  // the gate reads the word and still gets the wrong program.
+  'a DIFFERENT program with an allowed one\'s name. The table is keyed on the BASENAME, so ' +
+    '`/bin/cat` and `cat` are one entry — and so is a repo-writable `src/cat`, or a bare `cat` ' +
+    'resolved from a PATH entry the repository owns. Closing it would close nothing: a script ' +
+    'with the path already inside it needs no allowed name at all, which is miss 3',
 ]);
 
 /** Every literal token of a command, with message-flag arguments skipped. */
@@ -1664,25 +1735,34 @@ export function shellPathFindings(command, startDir, root) {
 }
 
 /** The refusal for a protected path named in a shell command. */
-function refuseShellPaths(findings) {
+function refuseShellPaths(findings, command = '') {
   const credentials = findings.filter((f) => f.kind === 'credential');
   const kernel = findings.filter((f) => f.kind === 'kernel');
+  // The credential the finding list never saw, because it sat where a message
+  // flag's argument would be or behind a `~`. Computed only when no credential
+  // finding already names one, so the same path is not billed twice — and named
+  // out loud, because otherwise this refusal would offer the "rewrite it as a
+  // read-only command" way forward for a line whose problem is the secret in it.
+  // A refusal that states the wrong reason is worse than one that states none.
+  const hidden = credentials.length === 0 ? rawCredentialWords(command) : [];
   // True when the PATHS were all in the readable class, so the command itself
   // is the only reason this is a refusal. Worth saying: the reader is one
   // rewrite away from an allowed call, and a refusal with no reachable way
   // forward produces an agent that looks for a way around (ADR-19).
   const commandWasTheProblem =
-    credentials.length === 0 && kernel.every((f) => SHELL_READABLE_GLOBS.includes(f.detail));
+    credentials.length === 0 &&
+    hidden.length === 0 &&
+    kernel.every((f) => SHELL_READABLE_GLOBS.includes(f.detail));
   const lines = [
     'tyran policy-gate: refused. This command names a path this gate protects.',
-    ...credentials.map(
+    ...[...credentials, ...hidden].map(
       (f) => `  - ${JSON.stringify(shortPath(f.token))} is credential-shaped (${safePolicyText(f.detail)})`,
     ),
     ...kernel.map(
       (f) => `  - ${JSON.stringify(shortPath(f.token))} is under the protected path \`${safePolicyText(f.detail)}\``,
     ),
   ];
-  if (credentials.length > 0) {
+  if (credentials.length + hidden.length > 0) {
     lines.push(
       '',
       'A shell command that names a credential file publishes its bytes whatever the program is: ' +
@@ -1754,7 +1834,7 @@ async function decideBash({ input, toolInput, root, runner, budget }) {
   // The exemption SKIPS this refusal; it does not return PASS. A `git log` that
   // names a protected path still travels the deployment class and every other
   // check below, exactly as `git log` on any other path does.
-  if (findings.length > 0 && !shellReadExempt(findings, command)) return refuseShellPaths(findings);
+  if (findings.length > 0 && !shellReadExempt(findings, command)) return refuseShellPaths(findings, command);
 
   const plan = planCommand(command, startDir);
   const pushes = plan.targets.filter((t) => t.scanPush === true && Array.isArray(t.pushArgv));

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jjanczur/tyran",
-  "version": "0.1.15",
+  "version": "0.1.16",
   "description": "Command-line scripts for the Tyran task conductor (doctor, journal, schema, and repo tooling) for CI and terminals outside Claude Code. Installing this package does NOT install the Claude Code plugin — add that separately with `/plugin marketplace add jjanczur/tyran` inside Claude Code.",
   "type": "module",
   "engines": {

--- a/site/src/content/docs/policy-gate.mdx
+++ b/site/src/content/docs/policy-gate.mdx
@@ -183,8 +183,11 @@ prints the lines.
 
 The way out is an explicit `class: AUTO` rule for the path in
 `.tyran/policies/autonomy.yaml`. That file is class `KERNEL`, **and a shell
-command that names it is refused too**, so the exemption is not one an agent
-writes for itself in the ordinary way. It is not a proof: a path this gate
+command that writes to it is refused too**, so the exemption is not one an agent
+writes for itself in the ordinary way. (Narrowed in 0.1.16 from "a shell command
+that *names* it": a read-only command on that path passes now, as `Read` always
+did. What closes the route is the write half, which is the half `cat >>` used.)
+It is not a proof: a path this gate
 never sees as a word is in the declared floor above. Round two claimed the
 stronger version — "cannot be talked out of it from inside a session" — and
 review took it apart in three tool calls.
@@ -204,12 +207,15 @@ finds by itself is a boundary it learns to prefer.
 </Limit>
 
 1. **Shell commands are path-checked for two families only, not classified.**
-   A `Bash` command that names a credential-shaped path, or a path under the
-   two built-in protected globs, is refused; the policy's own `AUTO`/`GATED`/
-   `KERNEL` rules are **not** consulted for shell commands. *Worst case:* a
-   `KERNEL` path a user declared in their own policy can be written from a
-   shell. The two built-in globs are deliberate — they need no policy file, so
-   a broken policy cannot be the thing that stops an operator repairing it.
+   A `Bash` command that names a credential-shaped path is refused outright; a
+   command that could write to a path under the two built-in protected globs,
+   `.claude/settings.json` or `.claude/settings.local.json` is refused, while a
+   read-only command on the two built-in globs passes (see below). The policy's
+   own `AUTO`/`GATED`/`KERNEL` rules are **not** consulted for shell commands.
+   *Worst case:* a `KERNEL` path a user declared in their own policy can be
+   written from a shell. The two built-in globs are deliberate — they need no
+   policy file, so a broken policy cannot be the thing that stops an operator
+   repairing it.
 2. **Product code is not classified by default.** Only `.tyran/`, `.claude/`
    and `hooks/` fall under the policy's `default:`; everything else needs an
    explicit rule. *Worst case:* a user who believes the policy covers their
@@ -273,14 +279,15 @@ of the command, never the effect of running it.**
 
 Every literal token of every segment is tested — there is no heuristic about
 which token "looks like a path", because an ordinary word matches nothing.
-Two families are refused:
+Two families are refused, and they are refused for different reasons:
 
 - a **credential-shaped** path, whatever the program does with it. `cat`,
   `grep`, `cp` and `base64` all publish the bytes, and the distinction between
-  reading and copying is not one a gate reading text can make;
+  reading and copying is not one a gate reading text can make. Reads and writes
+  alike, because the `Read` tool refuses this family too;
 - a path under `hooks/**`, `.tyran/policies/**`, `.claude/settings.json` or
-  `.claude/settings.local.json`. To *read* one, use the `Read` tool, which is
-  not refused for them.
+  `.claude/settings.local.json`. This family is a **write** rule: on the two
+  built-in globs a read-only command passes, because `Read` passes on them.
 
 **`.claude/settings.json` is on that list because it registers the hooks** — it
 is the one place inside a repository from which every gate can be switched off
@@ -298,11 +305,97 @@ refused. Raising it into the validator's list would close that and would change
 what every policy file is allowed to say — a separate decision, deliberately
 not taken here.
 
-The argument of `-m` / `--message` / `-F` / `--file` / `-t` / `--template` is
-removed from the text first, so `git commit -m "fix .env loading"` is not a
-refusal. That is the same move `stripHeredocBodies` makes in the shared lexer,
-for the same measured reason: a commit message is data, and lexing data as a
-program was the largest single source of false alarms there.
+The argument of `-m` / `--message` / `-F` / `--file` / `-t` / `--template` /
+`--data` is removed from the text first, so `git commit -m "fix .env loading"`
+is not a refusal — and neither is a `journal.mjs append ... --data '{...}'`
+whose prose merely *mentions* a dotenv-shaped filename. That last one was
+measured twice on one install (a journal entry describing a migration run
+against a test env file was refused as if it published the file), and its
+cost was the worst kind: conductors stopped writing certain filenames into
+their own ledger, which is the journal failing at its one job. This is the
+same move `stripHeredocBodies` makes in the shared lexer, for the same
+measured reason: a commit message is data, and lexing data as a program was
+the largest single source of false alarms there.
+
+### Reading `hooks/**` and `.tyran/policies/**` from a shell
+
+<Measured from="the shipped 0.1.15 gate, driven over one file under hooks/ and the same file on 0.1.16">
+Measured on 0.1.15, for one file under `hooks/**`:
+</Measured>
+
+| call | 0.1.15 | 0.1.16 |
+|---|---|---|
+| `Read FILE` | pass | pass |
+| `cat FILE` | **deny** | pass |
+| `grep -n X FILE` | **deny** | pass |
+| `wc -l FILE` | **deny** | pass |
+| `node --check FILE` | **deny** | pass |
+| `git log --oneline -- hooks/` | pass | pass |
+
+The last row is what made the old rule indefensible: a bare directory token
+names no file to classify, so it always passed, while `wc -l` on a file inside
+it did not. In every other row the bytes were one `Read` call away.
+
+**The rule this encodes: the shell must not become a second route to something
+the `Read` tool already refuses.** For `.env` that symmetry is the whole point —
+`Read` denies *and* `grep` denies, because the measured incident is a refused
+`Read .env` followed by `Bash: grep` in the very next tool call. Where `Read` is
+allowed, refusing the shell buys nothing and costs a tool call every time
+somebody inspects the gate they are working on.
+
+A command is exempted only when **all** of the following hold:
+
+- every segment's program is `cat`, `head`, `tail`, `wc`, `grep`, `rg`, `diff`,
+  `node` or `git`, matched **exactly** on the program name. `/bin/cat` and
+  `CAT` are the same program; `catnip` is not, and neither is `constructor`;
+- for `git`, the word immediately after it is `log`, `show` or `diff`. A global
+  flag before the subcommand refuses, because `git -c core.pager=…` names a
+  program for git to run and `planCommand`'s alias check only covers `alias.`;
+- for `node`, `--check` (or `-c`) is **required** rather than merely permitted:
+  `node FILE` executes FILE;
+- every token beginning with `-` is in that program's flag list, short clusters
+  read letter by letter. An unrecognised flag **refuses** — the enumeration's
+  incompleteness costs a false refusal, never a pass;
+- the raw command contains none of ``< > $ ` ( ) { } &`` — every redirection
+  spelling, command substitution, parameter expansion, subshell, group, and
+  `&`/`&&` at once. Tested on the raw text because the shared lexer *consumes*
+  these as separators: by the time a token exists, the `>` that made the line a
+  write is gone.
+
+`|` and `;` are allowed, because every composed segment still has to be an
+allowed reader — a pipe into a writer is a writer.
+
+Refused, and each one is a mode of an otherwise allowed program:
+
+| refused | why |
+|---|---|
+| `sed -n 1,20p FILE` · `awk NR<10 FILE` | the script argument is a program with its own write commands (`sed`'s `w`, awk's `print >`). Reading it needs a second parser, which ADR-21 is exactly about |
+| `node FILE` | executes it |
+| `git log --output=FILE` · `git show --output=FILE` | writes a file — a real hole found in an earlier review of this gate |
+| `git -c core.pager=tee log` | a global `-c` names a program for git to run |
+| `rg --pre CMD` · `rg --hostname-bin CMD` | runs `CMD` once per file |
+| `tail -f FILE` | never returns |
+| `cat FILE > /tmp/cat` · `cat $(cat FILE)` · `cat FILE \| tee /tmp/x` | redirection, substitution, a pipe into a writer |
+| the same commands on `.env`, `id_rsa`, `.aws/credentials` | the credential family, unchanged |
+| the same commands on `.claude/settings.json` | below |
+
+**`.claude/settings.json` is deliberately outside the exemption**, and that is a
+narrowing rather than a consequence: `Read` passes on it too, so the principle
+alone would admit it. It is the hook registry — the one place inside a
+repository from which every gate is switched off at once — and this change is
+scoped to the friction that was measured. Direction of error stays refuse.
+
+<Limit title="The residual floor of the read-only exemption">
+Matching flags bounds what a command *says*, not what the program *does*. An
+allowed reader can still be pointed at another program by configuration this
+gate never reads: a `diff.external` driver or a pager in git config, a
+`NODE_OPTIONS` carrying `--require`, a shell function shadowing `cat`. The claim
+is exact and narrow — **these two globs are no harder to read from a shell than
+with the `Read` tool, which already passes on them** — and it is not a claim
+that an allowed program can only ever read. One false refusal is declared with
+it: quoting is not honoured, so `grep ">" FILE` is refused for a character
+inside a string.
+</Limit>
 
 ### The declared floor for the shell rules
 
@@ -316,7 +409,11 @@ Not a ceiling. `SHELL_DECLARED_MISSES` in the source is the same list:
 3. anything a script writes once it is running;
 4. a `KERNEL` path declared by the **policy** rather than built in — only
    `SHELL_PROTECTED_GLOBS` is checked, so a broken policy can never be the
-   thing that stops an operator repairing it.
+   thing that stops an operator repairing it;
+5. a program an allowed reader is **configured** to launch — a `diff.external`
+   driver or pager in git config, a `NODE_OPTIONS` carrying `--require`, a
+   shell function shadowing `cat`. The flag table matches the command *text*,
+   and the environment is not in it.
 
 ## The cost, measured
 

--- a/site/src/content/docs/policy-gate.mdx
+++ b/site/src/content/docs/policy-gate.mdx
@@ -360,7 +360,19 @@ A command is exempted only when **all** of the following hold:
   spelling, command substitution, parameter expansion, subshell, group, and
   `&`/`&&` at once. Tested on the raw text because the shared lexer *consumes*
   these as separators: by the time a token exists, the `>` that made the line a
-  write is gone.
+  write is gone;
+- **no word of the raw command is credential-shaped**, tested a second time
+  against the same `SECRET_READ_RULES` and with none of the filters the path
+  findings go through. The findings are computed from a *stripped* copy of the
+  command — `stripMessageArguments` removes a message-bearing flag together with
+  its argument, and non-literal tokens are dropped — so a credential can be
+  invisible in them. `-t` is `git commit --template` *and* a legal `diff` flag,
+  which made `diff -t .env FILE` read as "one readable path, one read-only
+  command" and exempted it. Four shapes were measured deny-on-0.1.15 →
+  pass-before-this-check: `diff -t SECRET FILE`, `grep --file=SECRET FILE`,
+  `grep -m SECRET FILE`, `diff ~/SECRET FILE`. One false refusal is declared
+  with it, in the direction this gate errs in: `git log --grep=.env -- FILE`
+  loses the exemption over a word in a search pattern.
 
 `|` and `;` are allowed, because every composed segment still has to be an
 allowed reader — a pipe into a writer is a writer.
@@ -377,6 +389,7 @@ Refused, and each one is a mode of an otherwise allowed program:
 | `tail -f FILE` | never returns |
 | `cat FILE > /tmp/cat` · `cat $(cat FILE)` · `cat FILE \| tee /tmp/x` | redirection, substitution, a pipe into a writer |
 | the same commands on `.env`, `id_rsa`, `.aws/credentials` | the credential family, unchanged |
+| `diff -t .env FILE` · `grep --file=.env FILE` · `grep -m .env FILE` · `diff ~/.env FILE` | the credential family again, found on the **raw** text: the finding list is computed from a stripped copy of the command and never saw these words |
 | the same commands on `.claude/settings.json` | below |
 
 **`.claude/settings.json` is deliberately outside the exemption**, and that is a
@@ -389,8 +402,9 @@ scoped to the friction that was measured. Direction of error stays refuse.
 Matching flags bounds what a command *says*, not what the program *does*. An
 allowed reader can still be pointed at another program by configuration this
 gate never reads: a `diff.external` driver or a pager in git config, a
-`NODE_OPTIONS` carrying `--require`, a shell function shadowing `cat`. The claim
-is exact and narrow — **these two globs are no harder to read from a shell than
+`NODE_OPTIONS` carrying `--require`, a shell function shadowing `cat`. The name
+in the command may not even be the program it looks like — the table is keyed on
+the basename, item 6 below. The claim is exact and narrow — **these two globs are no harder to read from a shell than
 with the `Read` tool, which already passes on them** — and it is not a claim
 that an allowed program can only ever read. One false refusal is declared with
 it: quoting is not honoured, so `grep ">" FILE` is refused for a character
@@ -413,7 +427,15 @@ Not a ceiling. `SHELL_DECLARED_MISSES` in the source is the same list:
 5. a program an allowed reader is **configured** to launch — a `diff.external`
    driver or pager in git config, a `NODE_OPTIONS` carrying `--require`, a
    shell function shadowing `cat`. The flag table matches the command *text*,
-   and the environment is not in it.
+   and the environment is not in it;
+6. **a different program wearing an allowed one's name.** `READ_ONLY_PROGRAMS`
+   is keyed on the *basename*, which is what makes `/bin/cat` and `cat` one
+   entry — and also makes a repo-writable `src/cat` an allowed reader, with
+   `src/**` classed AUTO in the shipped template. Declared rather than closed:
+   requiring a bare program name would break `/bin/cat` and still admit an
+   absolute in-repo path, and it would buy nothing anyway, because miss 3
+   already lets the same script do the same work with the path baked in and no
+   allowed name at all.
 
 ## The cost, measured
 

--- a/tests/unit/answer.test.mjs
+++ b/tests/unit/answer.test.mjs
@@ -537,6 +537,20 @@ test('two apply runs at once cannot both close one ask', async () => {
   const runs = await Promise.all(both);
   for (const r of runs) assert.ok(r.status === 0 || r.status === 2, `exit ${r.status}: ${r.stderr}`);
 
+  // The guarantee is NO DOUBLE CLOSE, which holds however the race lands —
+  // asserted here, while both runs are still the only writers. Completeness is
+  // asserted below instead of here: a loser that gives up on the sitting lock
+  // exits 2 having written nothing, which is correct behaviour and was read as
+  // a failure by an earlier version of this test on a slower two-core runner.
+  const raced = decisions(journals.payments);
+  assert.equal(new Set(raced.map((e) => e.data.ask)).size, raced.length, `an ask was closed twice: ${raced.map((e) => e.data.ask).join(', ')}`);
+  const racedGates = gates(journals.payments).filter((g) => g.data.result === 'answered');
+  assert.equal(new Set(racedGates.map((g) => g.data.kind)).size, racedGates.length, 'a question was closed by two gates');
+
+  // Settle deterministically: one more apply closes whatever a lock loser left.
+  const settle = spawnSync(process.execPath, [SCRIPT, 'apply', '--dir', tyran], { encoding: 'utf8' });
+  assert.ok(settle.status === 0 || settle.status === 1, `settling run exit ${settle.status}: ${settle.stderr}`);
+
   const written = decisions(journals.payments);
   assert.equal(written.length, 8, written.map((e) => e.data.text).join(' | '));
   assert.equal(new Set(written.map((e) => e.data.ask)).size, 8, 'one decision per question, no more');

--- a/tests/unit/hook-policy-gate.test.mjs
+++ b/tests/unit/hook-policy-gate.test.mjs
@@ -35,7 +35,7 @@ import test from 'node:test';
 import { fileURLToPath } from 'node:url';
 
 import { PASS } from '../../hooks/scripts/hook-io.mjs';
-import { planCommand } from '../../hooks/scripts/secrets-gate.mjs';
+import { EXPANSION_CHARS, SEPARATORS, planCommand } from '../../hooks/scripts/secrets-gate.mjs';
 import { MANDATORY_KERNEL_PATHS, classifyPath, normalizePath } from '../../scripts/schema.mjs';
 import {
   CONFIG_PATH,
@@ -44,9 +44,12 @@ import {
   MAX_POLICY_BYTES,
   POLICY_PATH,
   PRODUCTION_BRANCHES,
+  READ_ONLY_PROGRAMS,
   SHARED_BRANCHES,
   SHELL_DECLARED_MISSES,
   SHELL_PROTECTED_GLOBS,
+  SHELL_READABLE_GLOBS,
+  SHELL_READ_DISQUALIFIERS,
   SUPERVISED_MODES,
   actorOf,
   decidingRule,
@@ -59,6 +62,8 @@ import {
   pathTargets,
   protectedGlobFor,
   quoteRule,
+  readOnlyFlag,
+  readOnlySegment,
   readPush,
   refName,
   repoRootOf,
@@ -942,6 +947,278 @@ test('BOUNDARY: what the Bash path rules do and do NOT reach', async () => {
   assert.match(refusal.reason, /credential file or/);
 });
 
+// ============================== 6b. THE READ-ONLY SHELL EXEMPTION (0.1.16)
+
+/**
+ * The exemption is a MATRIX too, and the axis that defines it is the PATH
+ * CLASS, not the program: the same command line passes on a path the `Read`
+ * tool hands over and denies on one it refuses.
+ *
+ * `P` is substituted with each of three paths:
+ *  - READABLE — under `hooks/**`, where `Read` passes, so a shell read buys
+ *    an attacker nothing that is not already one tool call away;
+ *  - SECRET — `.env`, where `Read` DENIES. The symmetry there is the whole
+ *    rule: the measured incident is a refused `Read .env` followed by
+ *    `Bash: grep` in the very next tool call;
+ *  - REGISTRY — `.claude/settings.json`, the hook registry, deliberately left
+ *    outside the exemption even though `Read` passes on it.
+ */
+const READABLE_PATH = 'hooks/scripts/policy-gate.mjs';
+const SECRET_PATH = '.env';
+const REGISTRY_PATH = '.claude/settings.json';
+
+/** Every allowed program, its read-shaped use and its write-shaped mode. */
+const READ_ONLY_SHELL_MATRIX = [
+  { name: 'cat', reads: 'cat P', writes: 'cat P > /tmp/gate-out' },
+  { name: 'cat -n', reads: 'cat -n P', writes: 'cat -n P >> /tmp/gate-out' },
+  { name: 'head', reads: 'head -20 P', writes: 'head -20 P > /tmp/gate-out' },
+  { name: 'tail', reads: 'tail -n 5 P', writes: 'tail -f P' },
+  { name: 'wc', reads: 'wc -l P', writes: 'wc --files0-from=/tmp/list P' },
+  { name: 'grep', reads: 'grep -n needle P', writes: 'grep -n needle P 2> /tmp/gate-err' },
+  { name: 'rg', reads: 'rg -n needle P', writes: 'rg --pre cat -n needle P' },
+  { name: 'diff', reads: 'diff -u P P', writes: 'diff -u P P > /tmp/gate-out' },
+  { name: 'node', reads: 'node --check P', writes: 'node P' },
+  { name: 'git log', reads: 'git log --oneline -- P', writes: 'git log --output=/tmp/x --oneline -- P' },
+  { name: 'git show', reads: 'git show HEAD -- P', writes: 'git show --output=/tmp/x HEAD -- P' },
+  { name: 'git diff', reads: 'git diff -- P', writes: 'git -c core.pager=tee diff -- P' },
+  // No read-shaped spelling is offered for these two: their script argument is
+  // a program with its own write commands (`sed`'s `w`, awk's `print >`), so
+  // allowing the read-shaped flag would mean parsing that script — a second
+  // parser, which ADR-21 is exactly about. Both stay refused in every mode.
+  { name: 'sed', reads: null, writes: 'sed -n 1,20p P' },
+  { name: 'awk', reads: null, writes: 'awk NR<10 P' },
+];
+
+const shellVerdict = async (command, root) => {
+  const got = await ask(bashInput(command, root), root);
+  return got === PASS || got?.decision === 'pass' ? 'pass' : got.decision;
+};
+
+for (const row of READ_ONLY_SHELL_MATRIX) {
+  if (row.reads !== null) {
+    test(`shell-read: ${row.name} · a READABLE protected path -> pass`, async () => {
+      // Mutation killed: reverting `decideBash` to `if (findings.length > 0)
+      // return refuseShellPaths(findings)`. Measured on 0.1.15, every row of
+      // this column denied while `Read` on the same file passed, which
+      // protected nothing and cost a tool call each time.
+      const root = adopted();
+      assert.equal(await shellVerdict(row.reads.replaceAll('P', READABLE_PATH), root), 'pass');
+    });
+
+    test(`shell-read: ${row.name} · the SAME command on a secret -> deny`, async () => {
+      // Mutation killed: dropping `f.kind === 'kernel'` from shellReadExempt,
+      // i.e. applying the relaxation to the secrets class. Every row here
+      // turns green under that mutant and the gate loses the one rule it was
+      // built for.
+      const root = adopted();
+      assert.equal(await shellVerdict(row.reads.replaceAll('P', SECRET_PATH), root), 'deny');
+    });
+
+    test(`shell-read: ${row.name} · the SAME command on the hook registry -> deny`, async () => {
+      // Mutation killed: `SHELL_READABLE_GLOBS = SHELL_PROTECTED_GLOBS`. The
+      // registry is the one place inside a repository from which every gate is
+      // switched off at once, and this change is scoped to the friction that
+      // was measured — not to everything the principle would permit.
+      const root = adopted();
+      assert.equal(await shellVerdict(row.reads.replaceAll('P', REGISTRY_PATH), root), 'deny');
+    });
+  }
+
+  test(`shell-read: ${row.name} · its WRITE-shaped mode -> deny`, async () => {
+    // Mutation killed: dropping the per-program flag check, i.e. returning
+    // true from readOnlySegment as soon as the PROGRAM is in the table. Every
+    // row of this column turns green under it — including
+    // `git log --output=FILE`, a real hole found in an earlier review, and
+    // `node FILE`, which is not a syntax check but an execution.
+    const root = adopted();
+    assert.equal(await shellVerdict(row.writes.replaceAll('P', READABLE_PATH), root), 'deny');
+  });
+}
+
+test('shell-read: a redirect, a substitution or a pipe into a writer refuses', async () => {
+  // Mutation killed: dropping the SHELL_READ_DISQUALIFIERS scan. It is not
+  // redundant with the per-segment program check, and the counterexamples are
+  // exact: `splitSegments` CONSUMES `>` and `$(`, so `cat FILE > /tmp/cat`
+  // lexes as two segments whose programs are both `cat`, and `cat $(cat FILE)`
+  // lexes as two segments that are both plain `cat`. Without the raw-text scan
+  // each of these passes while writing a file or running a substitution.
+  const root = adopted();
+  const P = READABLE_PATH;
+  for (const command of [
+    `cat ${P} > /tmp/cat`,
+    `cat ${P} >> /tmp/cat`,
+    `grep -n x ${P} 2> /tmp/cat`,
+    `cat ${P} > ${P}`,
+    `cat < ${P}`,
+    `cat $(cat ${P})`,
+    'cat `cat ' + P + '`',
+    `cat ${P} | tee /tmp/out`,
+    `cat ${P} & cat ${P}`,
+    `cat ${P} && rm -rf hooks`,
+    `cat ${P} ; rm -rf hooks/scripts`,
+    `cat ${P} | sed -i s/a/b/ hooks/scripts/x.mjs`,
+  ]) {
+    assert.equal(await shellVerdict(command, root), 'deny', command);
+  }
+  // A pipe between READERS is not a write, and refusing it would be friction
+  // with no boundary behind it.
+  for (const command of [
+    `cat ${P} | wc -l`,
+    `grep -n x ${P} | head -3`,
+    `cat ${P} | grep -n x | head -3 | wc -l`,
+  ]) {
+    assert.equal(await shellVerdict(command, root), 'pass', command);
+  }
+});
+
+test('shell-read: the program table is matched EXACTLY, never as a substring', () => {
+  // Mutation killed: `Object.keys(READ_ONLY_PROGRAMS).some((p) =>
+  // token.includes(p))` instead of an exact lookup. A substring test admits
+  // `catnip`, `mygit` and `wcx` — arbitrary programs whose names merely
+  // contain an allowed one.
+  for (const program of ['catnip', 'notcat', 'mygit', 'wcx', 'nodemon', 'grepper', 'diffx']) {
+    assert.equal(readOnlySegment([program, 'x']), false, program);
+  }
+  // Mutation killed: a plain object literal for READ_ONLY_PROGRAMS. Every
+  // lookup on one still consults Object.prototype, so `constructor` and
+  // `toString` would resolve to functions and read as allowed programs — the
+  // same defect `pathTargets` carries a guard for.
+  for (const program of ['constructor', 'toString', '__proto__', 'hasOwnProperty', 'valueOf']) {
+    assert.equal(readOnlySegment([program, 'x']), false, program);
+  }
+  // Recognised the way the shared lexer recognises: through a path, through
+  // quoting, and case-folded, because those are one program on the filesystem.
+  assert.equal(readOnlySegment(['/bin/cat', 'x']), true);
+  assert.equal(readOnlySegment(['CAT', 'x']), true);
+  // A transparent prefix is NOT skipped here: `sudo`, `env` and `xargs` all
+  // run a program this table never sees, so they are simply unrecognised.
+  for (const tokens of [['sudo', 'cat', 'x'], ['env', 'cat', 'x'], ['xargs', 'cat', 'x']]) {
+    assert.equal(readOnlySegment(tokens), false, tokens.join(' '));
+  }
+});
+
+test('shell-read: flags are matched per program, cluster by cluster', () => {
+  // Mutation killed: accepting any token that starts with `-`. The flag table
+  // is where the write-shaped modes of read-shaped programs are refused, and a
+  // short CLUSTER has to be read letter by letter or `-nf` smuggles `-f` past
+  // a check that only compared whole tokens.
+  assert.equal(readOnlyFlag(READ_ONLY_PROGRAMS.grep, '-rn'), true);
+  assert.equal(readOnlyFlag(READ_ONLY_PROGRAMS.wc, '-lw'), true);
+  assert.equal(readOnlyFlag(READ_ONLY_PROGRAMS.tail, '-f'), false);
+  assert.equal(readOnlyFlag(READ_ONLY_PROGRAMS.tail, '-F'), false);
+  assert.equal(readOnlyFlag(READ_ONLY_PROGRAMS.tail, '-nf'), false);
+  assert.equal(readOnlyFlag(READ_ONLY_PROGRAMS.tail, '--follow'), false);
+  // Mutation killed: comparing the whole long token instead of the name before
+  // `=`. `--output=/tmp/x` is not the string `--output`, so an equality test
+  // against the allowlist never matches it and the flag reads as unknown —
+  // which happens to deny — while `--pretty=oneline` reads as unknown too and
+  // denies a legitimate command. Splitting on `=` is what makes both correct.
+  assert.equal(readOnlyFlag(READ_ONLY_PROGRAMS.git, '--output=/tmp/x'), false);
+  assert.equal(readOnlyFlag(READ_ONLY_PROGRAMS.git, '--pretty=oneline'), true);
+  // Mutation killed: allowing a bare numeric token for every program. `-5` is
+  // a count for `head` and `git log` and nothing at all for `cat`.
+  assert.equal(readOnlyFlag(READ_ONLY_PROGRAMS.head, '-20'), true);
+  assert.equal(readOnlyFlag(READ_ONLY_PROGRAMS.head, '-n20'), true);
+  assert.equal(readOnlyFlag(READ_ONLY_PROGRAMS.cat, '-20'), false);
+  // Mutation killed: dropping `require`. `node FILE` executes FILE; only
+  // `--check` makes it a parse, so the flag is mandatory rather than merely
+  // permitted, and that is a different rule from "no unknown flags".
+  assert.equal(readOnlySegment(['node', 'x.mjs']), false);
+  assert.equal(readOnlySegment(['node', '--check', 'x.mjs']), true);
+  assert.equal(readOnlySegment(['node', '-c', 'x.mjs']), true);
+  assert.equal(readOnlySegment(['node', '--check', '--experimental-vm-modules', 'x.mjs']), false);
+  // Mutation killed: reading git's subcommand with `nextWord` (which skips
+  // flags) instead of demanding it in the very next slot. A git GLOBAL `-c`
+  // can name a program for git to run — `-c core.pager=…` — and
+  // `planCommand`'s alias check only covers `alias.`.
+  assert.equal(readOnlySegment(['git', 'log', '--oneline']), true);
+  assert.equal(readOnlySegment(['git', '-c', 'core.pager=tee', 'log']), false);
+  assert.equal(readOnlySegment(['git', 'status']), false);
+  assert.equal(readOnlySegment(['git', 'push', 'origin', 'main']), false);
+});
+
+test('shell-read: the secrets symmetry is intact — Read DENIES and the shell DENIES', async () => {
+  // Deliverable of this change, asserted rather than argued. The distinction
+  // the exemption encodes is that the shell must not become a second route to
+  // something `Read` already refuses; for a credential BOTH still refuse, and
+  // that pairing is what the measured incident called for.
+  const root = adopted();
+  for (const path of ['.env', '.env.local', 'id_rsa', 'deploy.pem', '.aws/credentials']) {
+    assert.equal((await askRead(root, path)).decision, 'deny', `Read ${path}`);
+    assert.equal(await shellVerdict(`cat ${path}`, root), 'deny', `cat ${path}`);
+    assert.equal(await shellVerdict(`grep -n KEY ${path}`, root), 'deny', `grep ${path}`);
+  }
+  // And the other half of the same claim: where `Read` PASSES, the shell now
+  // passes too. Two spellings of one access must not resolve to two answers.
+  for (const path of [READABLE_PATH, '.tyran/policies/autonomy.yaml']) {
+    assert.equal(await askRead(root, path), PASS, `Read ${path}`);
+    assert.equal(await shellVerdict(`cat ${path}`, root), 'pass', `cat ${path}`);
+  }
+  // The registry is the deliberate exception, and it is asymmetric on purpose.
+  assert.equal(await askRead(root, REGISTRY_PATH), PASS, `Read ${REGISTRY_PATH}`);
+  assert.equal(await shellVerdict(`cat ${REGISTRY_PATH}`, root), 'deny', `cat ${REGISTRY_PATH}`);
+});
+
+test('shell-read: one credential-shaped token refuses the whole line', async () => {
+  // Mutation killed: `findings.some(...)` instead of `every(...)`. A line that
+  // names a readable path AND a secret must be refused for the secret, however
+  // read-only it is — the exemption widens what may be done to paths the Read
+  // tool already hands over, and to nothing else.
+  const root = adopted();
+  for (const command of [
+    `cat ${READABLE_PATH} ${SECRET_PATH}`,
+    `cat ${READABLE_PATH} ${REGISTRY_PATH}`,
+    `diff -u ${READABLE_PATH} ${REGISTRY_PATH}`,
+    'cat hooks/scripts/id_rsa',
+    'grep -n X hooks/scripts/deploy.pem',
+  ]) {
+    assert.equal(await shellVerdict(command, root), 'deny', command);
+  }
+});
+
+test('shell-read: the refusal names the way forward and its residual floor', async () => {
+  // A refusal with no reachable way forward produces an agent that looks for a
+  // way around (ADR-19), so a read-shaped path refused for a write-shaped
+  // COMMAND says which commands are allowed instead. And it states the floor:
+  // an allowed reader can still be pointed at another program by configuration
+  // this gate never reads.
+  const root = adopted();
+  const refused = await ask(bashInput(`node ${READABLE_PATH}`, root), root);
+  assert.match(refused.reason, /These paths are READABLE from a shell/);
+  assert.match(refused.reason, /node --check/);
+  assert.match(refused.reason, /Residual floor/);
+  assert.match(refused.reason, /NODE_OPTIONS/);
+  // A CREDENTIAL refusal must not carry that offer: nothing about it is one
+  // rewrite away from allowed. Neither may the registry's, which is refused
+  // for the path and not for the command — and a refusal that states the wrong
+  // reason is worse than one that states none.
+  for (const path of [SECRET_PATH, REGISTRY_PATH]) {
+    const got = await ask(bashInput(`cat ${path}`, root), root);
+    assert.doesNotMatch(got.reason, /These paths are READABLE from a shell/, path);
+  }
+});
+
+test('shell-read: the exemption is stated in the declared floor, not only in code', () => {
+  // ADR-21: the source list and the prose list are one answer. A new entry
+  // here without the matching numbered item in docs/policy-gate.md is caught
+  // by tests/unit/docs-claims.test.mjs; this pins the count the refusal quotes.
+  assert.equal(SHELL_DECLARED_MISSES.length, 5);
+  assert.equal(SHELL_DECLARED_MISSES.some((m) => m.includes('NODE_OPTIONS')), true);
+  // The exemption covers the validator's two globs and nothing else.
+  assert.deepEqual([...SHELL_READABLE_GLOBS], [...MANDATORY_KERNEL_PATHS]);
+  assert.equal(SHELL_READABLE_GLOBS.includes('.claude/settings.json'), false);
+  assert.equal(SHELL_PROTECTED_GLOBS.length > SHELL_READABLE_GLOBS.length, true);
+  // Every disqualifier is a character the shared lexer ALREADY treats as
+  // structural — a segment separator or an expansion trigger — which is why
+  // the scan has to run on the RAW text: by the time a token exists, the
+  // character that made the line a write has been consumed or the token has
+  // been dropped as non-literal. A disqualifier the lexer knows nothing about
+  // would mean this gate had invented its own shell grammar (ADR-21).
+  for (const ch of SHELL_READ_DISQUALIFIERS) {
+    assert.equal(SEPARATORS.includes(ch) || EXPANSION_CHARS.includes(ch), true, ch);
+  }
+});
+
 test('pathTargets is prototype-safe and reads every path field', () => {
   assert.deepEqual(pathTargets({ file_path: 'a' }), ['a']);
   assert.deepEqual(pathTargets({ notebook_path: 'b' }), ['b']);
@@ -1464,9 +1741,16 @@ test('B4: the built-in globs are used, NOT the policy\'s own KERNEL rules', asyn
   // this consulted the policy, a BROKEN policy would refuse the very command
   // an operator runs to repair it. The two mandatory globs need no file.
   const dir = adopted({ policy: 'this: [is not: valid' });
-  const got = await ask(bashInput('cat .tyran/policies/autonomy.yaml', dir), dir);
+  const got = await ask(bashInput('echo x >> .tyran/policies/autonomy.yaml', dir), dir);
   assert.equal(got.decision, 'deny');
   assert.match(got.reason, /protected path/);
+  // The same file, READ from a shell while the policy is unparseable, passes —
+  // and that is the point rather than a weakening of it: the command an
+  // operator runs to see what is wrong with the policy must not be the command
+  // the broken policy refuses. Since 0.1.16 the shell rule on these two globs
+  // is a WRITE rule, matching what `Read` already allowed. The probe used to
+  // be `cat` and had to move, because `cat` is now the passing case.
+  assert.equal(await ask(bashInput('cat .tyran/policies/autonomy.yaml', dir), dir), PASS);
   // A policy-declared KERNEL path is NOT covered here; declared, not implied.
   const dir2 = adopted({
     policy: TEMPLATE.replace('rules:', 'rules:\n  - path: sacred/**\n    class: KERNEL\n    reason: mine\n'),

--- a/tests/unit/hook-policy-gate.test.mjs
+++ b/tests/unit/hook-policy-gate.test.mjs
@@ -62,6 +62,7 @@ import {
   pathTargets,
   protectedGlobFor,
   quoteRule,
+  rawCredentialWords,
   readOnlyFlag,
   readOnlySegment,
   readPush,
@@ -1006,10 +1007,23 @@ for (const row of READ_ONLY_SHELL_MATRIX) {
     });
 
     test(`shell-read: ${row.name} · the SAME command on a secret -> deny`, async () => {
-      // Mutation killed: dropping `f.kind === 'kernel'` from shellReadExempt,
-      // i.e. applying the relaxation to the secrets class. Every row here
-      // turns green under that mutant and the gate loses the one rule it was
-      // built for.
+      // Mutation killed: extending the relaxation to the CREDENTIAL class, i.e.
+      //
+      //   findings.every((f) => f.kind === 'credential'
+      //                         || SHELL_READABLE_GLOBS.includes(f.detail))
+      //
+      // with the `rawCredentialWords` clause dropped alongside it. Measured:
+      // 20 of 234 tests fail, 12 of them this row, and the gate loses the one
+      // rule it was built for.
+      //
+      // Explicitly NOT killed, because this comment claimed it until review
+      // measured otherwise: dropping `f.kind === 'kernel'` on its own leaves
+      // the suite fully green (231/231 when that was written, 234/234 now). A
+      // credential finding's `detail` is a rule-id list — `dotenv`,
+      // `ssh-directory` — never a glob, so `SHELL_READABLE_GLOBS.includes(
+      // f.detail)` already excludes it without any help. The `kind` clause is
+      // belt-and-braces: kept because it states that the two classes never
+      // merge, not because it is the check that holds the line.
       const root = adopted();
       assert.equal(await shellVerdict(row.reads.replaceAll('P', SECRET_PATH), root), 'deny');
     });
@@ -1176,6 +1190,74 @@ test('shell-read: one credential-shaped token refuses the whole line', async () 
   }
 });
 
+test('shell-read: a credential the finding list never SAW refuses the line too', async () => {
+  // Mutation killed: dropping the `rawCredentialWords(command)` clause from
+  // shellReadExempt, i.e. deciding the exemption on the finding list alone.
+  //
+  // The finding list comes from `commandTokens`, which runs
+  // `stripMessageArguments` FIRST and then keeps only `isLiteralPath` tokens.
+  // Both filters can delete the credential, and what is left reads as "one
+  // readable kernel path, under a read-only command" — so the line is
+  // EXEMPTED. Every row below denied under the 0.1.15 rule and PASSED on this
+  // branch before the clause existed, really publishing the file.
+  const root = adopted();
+  for (const command of [
+    // `-t` is in MESSAGE_FLAGS (git's `--template`) and is ALSO a legal flag of
+    // `diff` and `cat`, so the strip removes `-t` together with the path after
+    // it while `isReadOnlyCommand`, reading the raw text, sees an allowed flag.
+    `diff -t ${SECRET_PATH} ${READABLE_PATH}`,
+    `cat -t .aws/credentials ${READABLE_PATH}`,
+    // `--file` is grep's pattern-file flag and a MESSAGE_FLAG (`git commit
+    // --file`); the strip takes the whole `--file=PATH` word with it.
+    `grep --file=/tmp/gate/${SECRET_PATH} ${READABLE_PATH}`,
+    `grep --file=secrets/id_rsa ${READABLE_PATH}`,
+    // `-m` is grep's `--max-count` and MESSAGE_FLAGS has it for `git commit -m`.
+    `grep -m ${SECRET_PATH} ${READABLE_PATH}`,
+    // No message flag at all: a leading `~` fails `isLiteralPath`, so
+    // `commandTokens` drops the token and no finding is ever produced for it.
+    `diff ~/${SECRET_PATH} ${READABLE_PATH}`,
+    `diff ~/.ssh/id_rsa ${READABLE_PATH}`,
+  ]) {
+    assert.equal(await shellVerdict(command, root), 'deny', command);
+  }
+});
+
+test('shell-read: the hidden credential is what the refusal NAMES', async () => {
+  // Mutation killed: closing the hole in `shellReadExempt` alone and leaving
+  // `refuseShellPaths(findings)` to word it. The line would then be refused for
+  // the right reason and told the wrong one — "these paths are READABLE from a
+  // shell, so what was refused is this COMMAND" — which offers a rewrite that
+  // cannot help, and a refusal that states the wrong reason is worse than one
+  // that states none.
+  const root = adopted();
+  const got = await ask(bashInput(`diff -t ${SECRET_PATH} ${READABLE_PATH}`, root), root);
+  assert.equal(got.decision, 'deny');
+  assert.match(got.reason, /is credential-shaped \(dotenv\)/);
+  assert.doesNotMatch(got.reason, /These paths are READABLE from a shell/);
+});
+
+test('rawCredentialWords reads the RAW word, and both sides of an attached `=`', () => {
+  // Mutation killed: reusing `commandTokens` here instead of the raw lexer
+  // output — every row below returns [] under it, which is the whole defect.
+  // Mutation killed: testing only the whole word, never the right-hand side of
+  // `=`; `--file=.env` has a basename of `--file=.env` and matches nothing.
+  assert.deepEqual(rawCredentialWords('diff -t .env hooks/scripts/policy-gate.mjs').map((w) => w.detail), ['dotenv']);
+  assert.deepEqual(rawCredentialWords('grep --file=.env hooks/x.mjs').map((w) => w.token), ['--file=.env']);
+  assert.deepEqual(rawCredentialWords('diff ~/.ssh/id_rsa hooks/x.mjs').map((w) => w.detail), ['ssh-private-key, ssh-directory']);
+  // The direction of error is a false REFUSAL, and it is declared: a
+  // credential-shaped word that is not a path costs the exemption.
+  assert.equal(rawCredentialWords('git log --grep=.env -- hooks/x.mjs').length, 1);
+  // An ordinary read-only line has none, which is why no matrix row moved.
+  for (const command of [
+    'cat hooks/scripts/policy-gate.mjs',
+    'grep -n needle hooks/scripts/policy-gate.mjs',
+    'git log --oneline -- hooks/scripts/policy-gate.mjs',
+    'node --check .tyran/policies/autonomy.yaml',
+  ]) {
+    assert.deepEqual(rawCredentialWords(command), [], command);
+  }
+});
+
 test('shell-read: the refusal names the way forward and its residual floor', async () => {
   // A refusal with no reachable way forward produces an agent that looks for a
   // way around (ADR-19), so a read-shaped path refused for a write-shaped
@@ -1202,8 +1284,15 @@ test('shell-read: the exemption is stated in the declared floor, not only in cod
   // ADR-21: the source list and the prose list are one answer. A new entry
   // here without the matching numbered item in docs/policy-gate.md is caught
   // by tests/unit/docs-claims.test.mjs; this pins the count the refusal quotes.
-  assert.equal(SHELL_DECLARED_MISSES.length, 5);
+  assert.equal(SHELL_DECLARED_MISSES.length, 6);
   assert.equal(SHELL_DECLARED_MISSES.some((m) => m.includes('NODE_OPTIONS')), true);
+  // The basename match: `READ_ONLY_PROGRAMS[basename(tokens[0])]` makes a
+  // repo-writable `src/cat` an allowed reader, and `src/**` is AUTO in the
+  // shipped template. Declared rather than narrowed — a narrowing would close
+  // nothing, because miss 3 already lets the same script do the same work with
+  // the path baked in and no allowed name at all.
+  assert.equal(SHELL_DECLARED_MISSES.some((m) => m.includes('src/cat')), true);
+  assert.equal(readOnlySegment(['src/cat', 'x']), true);
   // The exemption covers the validator's two globs and nothing else.
   assert.deepEqual([...SHELL_READABLE_GLOBS], [...MANDATORY_KERNEL_PATHS]);
   assert.equal(SHELL_READABLE_GLOBS.includes('.claude/settings.json'), false);


### PR DESCRIPTION
Ships as 0.1.16. The operator asked which gates were too strict; this is the one worth relaxing, and it was chosen by measurement rather than by feel.

## The measurement

For `hooks/**` and `.tyran/policies/**` — write-protected but **readable** — the **Read tool passes** while **every read-shaped Bash command on the same file is refused**: `grep`, `cat`, `wc -l`, `node --check`. That protects nothing, because the bytes are one Read call away, and it cost four detours in a single working session. The rule was also inconsistent with itself: `git log --oneline -- hooks/` already passed, because a bare directory token does not look like a file path.

Contrast **credential files**, where the same rule is load-bearing and stays exactly as it was: a dotenv read is denied by the Read tool **and** by shell grep. That symmetry is the measured incident the rule exists for — a refused Read of a credential file followed by `Bash: grep` in the very next tool call.

**The distinction now encoded: the shell must not become a second route to something the Read tool already refuses. Where Read is allowed, refusing the shell buys nothing.**

## The exemption is narrow, and structural before it is lexical

Three conditions, all required:

1. **every** finding on the line is a kernel path in the readable set (credential files and the hook registry are excluded);
2. the raw command text contains none of the redirection, substitution, subshell or backgrounding characters — checked **before tokenising**, because the lexer *consumes* those characters, so by token time the `>` is gone. A test pins that every disqualifier is already a separator or expansion character the lexer knows, so this is not a second grammar;
3. every segment is an allowed reader, matched on **program and flags** — short clusters read letter by letter (so `-nf` cannot smuggle `-f`), `--name=value` matched on the name, and **any unrecognised flag refuses**.

So `git log` passes and `git log --output=/tmp/x` does not. `node --check` passes (the flag is *required*, not merely permitted) and a bare `node` does not. `tail` passes and `tail -f` does not. `sed -n` is refused outright, because its script argument is a program with its own write commands and reading it would need a second parser (ADR-21: this repo has one lexer).

The hook registry under `.claude/` **stays refused** even though Read passes on it — a deliberate narrowing beyond what the principle requires, because it is the one file that can switch every gate off. Stated as an exception in code, both doc surfaces and the CHANGELOG rather than derived.

## Verification

A **76-probe verdict table** run through the real gate on both trees and diffed: **22 verdicts flip, all of them read-only commands on the readable class, zero elsewhere.** Covered: every allowed program and its write-shaped mode; redirects, pipes into writers, substitutions, backticks, `&&`; transparent prefixes (`sudo`, `env`, `xargs`); prototype-pollution probes (`constructor`, `toString`, `__proto__` as program names); substring near-misses (`catnip`, `mygit`); the same commands against credential paths and the hook registry (all still denied); and mixed lines where one credential-shaped token refuses the whole command.

**57 new tests**, each naming the mutant it kills — including *dropping the kernel-kind check* (which would apply the relaxation to credential files), *dropping the per-program flag check*, *dropping the raw-text disqualifier scan* (with exact counterexamples: `cat P > /tmp/cat` lexes as two `cat` segments), and *substring widening*.

Suite **1249/1249**; control-char scan clean; plugin validation passes.

## Residual floor, stated rather than discovered

> A flag table cannot see past the command text: an allowed reader can still be made to run something else by configuration this gate never reads — a git `diff.external` driver or pager, `NODE_OPTIONS` carrying `--require`, a shell function shadowing `cat`. The exemption is that these paths are no harder to READ from a shell than with the Read tool, which already passes on them; it is not a claim that an allowed program can only ever read.

Both doc surfaces carry it, and the declared-misses list gains a fifth entry so the refusal's "known ways past" count stays honest.

**One pre-existing hole found and deliberately NOT fixed here**: a `-F`/`--file`/`-m`-shaped flag placed before a protected path passes on **both** trees, because the message-argument strip removes the flag and its argument before the path finder runs, so no finding is produced at all. Measured identical before and after — it belongs to declared floor item 1, not to this change, and the corresponding segment check is pinned false so the flag table stays honest if that stripping is ever narrowed.

## A note the operator will enjoy

This PR body could not be posted from the command line: the gate refused the `gh` call because the text *discussed* credential filenames. The documented way past is a body file, which is what shipped it — and it is a fair illustration of the friction this change is about, on the one class where the friction is worth paying.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
