### PR TITLE
test(answer): a race test must not pick a winner (0.1.17)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
     {
       "name": "tyran",
       "description": "A task conductor for Claude Code: multi-agent orchestration with an enforced evidence contract, repo-specific learning, and update-safe local evolution.",
-      "version": "0.1.16",
+      "version": "0.1.17",
       "source": "./",
       "author": {
         "name": "Jacek Janczura",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "tyran",
-  "version": "0.1.16",
+  "version": "0.1.17",
   "description": "A task conductor for Claude Code: multi-agent orchestration with an enforced evidence contract, repo-specific learning, and update-safe local evolution.",
   "author": {
     "name": "Jacek Janczura",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Changelog
 
+## 0.1.17 — 2026-08-14
+
+### A race test that picked a winner
+
+`two apply runs at once cannot both close one ask` accepted only two of the
+three exits its own race can produce. On a runner slow enough to serialise
+the two spawns, the first closes the queue and the second finds it empty and
+exits 1 — correct behaviour, asserted as a failure. It passed locally and in
+the PR checks and failed in the publish job, which is where a timing
+assumption usually surfaces, and it kept 0.1.15 and 0.1.16 off npm although
+both are merged and tagged.
+
+All three exits are now accepted, and the guarantee is asserted where it
+holds regardless of who won: no ask closed twice and no question closed by
+two gates, checked while the racing runs are the only writers, then
+completeness after one sequential settling run. Dropping the sitting lock
+still fails the test.
+
 ## 0.1.16 — 2026-08-14
 
 ### `cat hooks/…` was refused while `Read` handed you the same bytes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jjanczur/tyran",
-  "version": "0.1.16",
+  "version": "0.1.17",
   "description": "Command-line scripts for the Tyran task conductor (doctor, journal, schema, and repo tooling) for CI and terminals outside Claude Code. Installing this package does NOT install the Claude Code plugin — add that separately with `/plugin marketplace add jjanczur/tyran` inside Claude Code.",
   "type": "module",
   "engines": {

--- a/tests/unit/answer.test.mjs
+++ b/tests/unit/answer.test.mjs
@@ -535,7 +535,14 @@ test('two apply runs at once cannot both close one ask', async () => {
       }),
   );
   const runs = await Promise.all(both);
-  for (const r of runs) assert.ok(r.status === 0 || r.status === 2, `exit ${r.status}: ${r.stderr}`);
+  // All three exits are legitimate outcomes of this race and the test must not
+  // pick a winner: 0 closed some, 2 gave up on the sitting lock, and 1 found
+  // the queue already empty — which is what a runner slow enough to serialise
+  // the two spawns produces, and what failed a publish run that had passed
+  // both locally and in the PR checks. The guarantee is below, not here.
+  for (const r of runs) {
+    assert.ok([0, 1, 2].includes(r.status), `exit ${r.status}: ${r.stderr}`);
+  }
 
   // The guarantee is NO DOUBLE CLOSE, which holds however the race lands —
   // asserted here, while both runs are still the only writers. Completeness is


### PR DESCRIPTION
0.1.15 and 0.1.16 are merged and tagged but **not on npm**: their publish jobs both failed on one test, and it was the test that was wrong.

`two apply runs at once cannot both close one ask` accepted only two of the three exits its own race can produce. On a runner slow enough to serialise the two spawns, the first run closes the queue and the second finds it empty and exits **1** — correct, documented behaviour, asserted as a failure:

```
not ok 27 - two apply runs at once cannot both close one ask
  error: 'exit 1: answer: nothing is waiting on you'
```

It passed locally and in both PRs' checks and failed only in the publish job, which is the usual place for a timing assumption to surface — a two-core runner serialises what an eight-core laptop overlaps.

All three exits are accepted now (0 closed some, 1 found nothing left, 2 gave up on the sitting lock), and the guarantee is asserted where it holds **regardless of who won**: no ask closed twice and no question closed by two gates, checked while the racing runs are the only writers, then completeness after one sequential settling run. Dropping the sitting lock still fails the test, so the mutant it names still dies.

Verified by running the test five times locally. This release carries nothing else — 0.1.15's ask-queue and 0.1.16's gate relaxation reach npm with it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)