### PR TITLE
ci(npm): the dist-tag is earned, not inherited from the last run

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -24,6 +24,16 @@ name: Publish to npm
 # and still publishes. The two triggers are idempotent in the only way that
 # matters: npm refuses a version that already exists, so whichever fires second
 # fails loudly instead of publishing something different under the same number.
+#
+# That last sentence used to be the whole safety argument, and it was too
+# small. npm refusing a DUPLICATE version is not npm refusing an OLD one.
+# Measured: GitHub releases were created for sixteen historical tags in one
+# batch, each fired this workflow, and four of those versions had never
+# reached npm at all — so they published cleanly and every one of them took
+# the `latest` dist-tag on the way past. For about a minute
+# `npm i @jjanczur/tyran` served 0.1.2. The dist-tag step below is the fix:
+# `latest` is earned by being the highest version on the registry, not by
+# being the most recent thing this workflow happened to run.
 on:
   push:
     tags: ['v*']
@@ -83,8 +93,33 @@ jobs:
         # at the first require.
         run: npm pack --dry-run
 
+      - name: Which dist-tag this version has earned
+        # `npm publish` defaults to `--tag latest`. That is right for a release
+        # and wrong for a backfill, and this workflow cannot tell the two apart
+        # from its trigger — a `release: published` event looks identical
+        # whether the tag was cut today or two months ago. So the question is
+        # asked of the registry instead: `latest` goes to the version that is
+        # actually the highest one published. Anything older is reachable by
+        # exact version and by `historical`, and moves nothing.
+        #
+        # `sort -V` is the comparison, not string order: `0.1.9` sorts ABOVE
+        # `0.1.10` alphabetically, which would have handed `latest` to the
+        # older of the two on every 0.1.x release past the ninth.
+        id: disttag
+        run: |
+          PKG=$(jq -r .version package.json)
+          HIGHEST=$(npm view "$(jq -r .name package.json)" versions --json 2>/dev/null \
+            | jq -r 'if type == "array" then .[] else . end' | sort -V | tail -1)
+          if [ -z "$HIGHEST" ] || [ "$(printf '%s\n%s\n' "$HIGHEST" "$PKG" | sort -V | tail -1)" = "$PKG" ]; then
+            TAG=latest
+          else
+            TAG=historical
+          fi
+          echo "publishing $PKG as --tag $TAG (highest on npm: ${HIGHEST:-none})"
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+
       - name: Publish
         if: github.event_name == 'release' || inputs.dry_run == false
-        run: npm publish --provenance --access public
+        run: npm publish --provenance --access public --tag "${{ steps.disttag.outputs.tag }}"
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,27 @@ narrower advice each time.
 - **The dashboard GIF runs at 4 fps instead of 8.3** — the same recording, at a
   speed a tab can actually be read at.
 
+### The dist-tag is earned, not inherited from the last run
+
+Creating GitHub Releases for sixteen historical tags in one batch fired
+`npm-publish.yml` sixteen times. The workflow's safety argument was that npm
+refuses a version that already exists — true, and too small: **npm refusing a
+DUPLICATE version is not npm refusing an OLD one.** Four of those versions had
+never reached npm, so they published cleanly and each took the `latest`
+dist-tag on the way past. For roughly a minute `npm i @jjanczur/tyran` served
+**0.1.2**. Found within two minutes, by checking the registry rather than the
+sixteen green workflow runs, and self-corrected when 0.1.20's own publish
+landed last.
+
+The workflow now asks the registry which version is highest and publishes
+`--tag latest` only when the version in hand IS that one; anything older
+gets `--tag historical` and moves nothing. The comparison is `sort -V`, not
+string order — `0.1.9` sorts above `0.1.10` alphabetically, which would have
+mis-tagged every 0.1.x release past the ninth.
+
+Side effect, kept: 0.1.1, 0.1.2, 0.1.15 and 0.1.16 are now on npm, so the
+registry finally carries every released version.
+
 ## 0.1.19 — 2026-08-14
 
 ### The board answered four questions on one scroll


### PR DESCRIPTION
## What happened

Sixteen GitHub Releases were created for historical tags in one batch. Each fired `npm-publish.yml`. The workflow's safety argument, written in its own header, was:

> npm refuses a version that already exists, so whichever fires second fails loudly instead of publishing something different under the same number.

True, and too small. **npm refusing a duplicate version is not npm refusing an old one.** Four of those versions — 0.1.1, 0.1.2, 0.1.15, 0.1.16 — had never reached npm, so they published cleanly, and `npm publish` defaults to `--tag latest`. Each one took `latest` on the way past. For about a minute `npm i @jjanczur/tyran` served **0.1.2**.

Sixteen workflow runs went green while this happened. It was found by reading the registry, not the runs.

It self-corrected — 0.1.20's own publish landed last and took `latest` back — which is luck, not a mechanism.

## The fix

`latest` is now earned by being the highest version on the registry, asked of the registry at publish time. Anything older publishes under `--tag historical` and moves nothing.

The comparison is `sort -V`, not string order. `0.1.9` sorts above `0.1.10` alphabetically, which would have handed `latest` to the older of the two on every 0.1.x release past the ninth — the bug the fix would have shipped with if the obvious comparison had been used.

## Evidence

```
$ printf '%s\n%s\n' 0.1.9  0.1.10 | sort -V | tail -1   → 0.1.10
$ printf '%s\n%s\n' 0.1.20 0.1.16 | sort -V | tail -1   → 0.1.20
$ printf '%s\n%s\n' 0.1.2  0.1.20 | sort -V | tail -1   → 0.1.20

$ npm view @jjanczur/tyran dist-tags                    → { latest: '0.1.20' }
```

`npm view <name> versions --json` returns a string rather than an array for a single-version package, so the jq handles both shapes.

## Kept

0.1.1, 0.1.2, 0.1.15 and 0.1.16 stay on npm. Publishing is irreversible, and the outcome is one the registry is better for: it now carries every released version instead of four gaps.

No version bump — this changes CI only, nothing a `claude plugin update` reads.

🤖 Generated with [Claude Code](https://claude.com/claude-code)