### PR TITLE
docs(notes): six board defects found by audit

### DIFF
--- a/NOTES-REQUESTS.md
+++ b/NOTES-REQUESTS.md
@@ -66,7 +66,47 @@ Standing instruction from the operator: merge to `main` over PRs proactively;
 work parked in an open PR is wasted work. Check open PRs before finishing a
 session.
 
-## 5. Video with hyperframes + TTS — NOT ASSESSED
+## 5. Board defects found by audit, 2026-08-14 — NOT FIXED
+
+Six findings from an audit of `board.mjs` / `board-html.mjs` / `project.mjs`,
+each verified against the code rather than the page. Ordered by how badly they
+break the page's own promise, which is that it never shows "all is well" when
+it is not.
+
+1. **A partially corrupt journal renders as healthy.** `board.mjs` guards only
+   total loss (`total === 0`); three readable tickets plus one unparseable line
+   produce `errors: []` and a clean board. `warnings()` in `project.mjs`
+   produces exactly the text that is missing, and `board.mjs` never calls it.
+2. **The "needs a human" tile counts lanes, not humans.** It sums `blocked` +
+   `changes-requested`. A ticket parked by a `ticket.status` override whose
+   agent is `blocked` lands in neither, so the tile reads 0 while an agent chip
+   on the same screen says "blocked" — the override is tested before the
+   blockage in `boardOf`.
+3. **Staleness is shown but never escalated.** Three colour buckets, the last
+   of which is "30 minutes or six hours". Agents render in spawn order, not
+   staleness order, so the stalest chip can be last; nothing counts them and no
+   tab badge carries them. The agent's own `next` field is folded into
+   `board.json` and never rendered.
+4. **The drill-down shows no files.** Five rows: lane, initiative, agents,
+   note, spend. `board.mjs` already resolves each initiative's journal path —
+   whose directory holds `PLAN.md`, `NOTES.md`, `RETRO.md` — and discards it.
+   Listing only what `existsSync` confirms satisfies "do not invent files".
+   Note `--serve` routes exactly three paths, so a file link needs a route.
+5. **A cost failure is indistinguishable from `file://`.** The client maps any
+   non-OK response to null and returns silently; the error text `board.mjs`
+   builds for the 503 is never displayed. A broken rate card, a crashed reader
+   and an unserved page all look the same.
+6. **Sixty-five initiatives is a 500 loop.** Over the cap, `renderAll` throws
+   inside the request handler and the page becomes plain-text 500 — re-fetched
+   every 30 s by its own meta refresh. Below the cap there is no filter, search
+   or grouping, so 64 initiatives is one flat pile.
+
+Also: empty state and idle state are byte-identical in shape (`0% · 0 of 0
+merged` for both a fresh initiative and a fully stalled one), and no card for a
+finished ticket names the agents that did it — `state.tickets[].agents` is
+folded and dropped.
+
+## 6. Video with hyperframes + TTS — NOT ASSESSED
 
 `https://github.com/heygen-com/hyperframes` plus an OpenAI TTS voiceover, to
 produce short explainer videos and GIFs. I have **not** evaluated the tool and


### PR DESCRIPTION
Audit of the board against its own promise — that it never shows 'all is well' when it is not. Six findings, each cited to code rather than to the rendered page, recorded in `NOTES-REQUESTS.md` rather than fixed, so that the finding outlives the session that produced it.

The first is the one that matters: **a partially corrupt journal renders as a healthy board.** `board.mjs` guards only total loss; three readable tickets plus one unparseable line give `errors: []` and a clean page. `project.mjs` already produces the warning text for exactly this case, and `board.mjs` never calls it.

Notes only — no code change, no version bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)