### PR TITLE
board: the page stops saying "all is well" in five ways it should not have (+ 0.1.21)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
     {
       "name": "tyran",
       "description": "A task conductor for Claude Code: multi-agent orchestration with an enforced evidence contract, repo-specific learning, and update-safe local evolution.",
-      "version": "0.1.20",
+      "version": "0.1.21",
       "source": "./",
       "author": {
         "name": "Jacek Janczura",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "tyran",
-  "version": "0.1.20",
+  "version": "0.1.21",
   "description": "A task conductor for Claude Code: multi-agent orchestration with an enforced evidence contract, repo-specific learning, and update-safe local evolution.",
   "author": {
     "name": "Jacek Janczura",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,81 @@
 # Changelog
 
+## 0.1.21 — 2026-08-14
+
+### The board said "all is well" in five different ways it should not have
+
+An audit read the page against its own promise — that it never shows a healthy
+board over an unhealthy repo — and it failed that promise five times.
+
+**A partially damaged journal rendered as a healthy initiative.** The existing
+guard fires only when NOTHING was readable. Three good tickets plus one
+unparseable line folded to a board with `errors: []` on it, and the lost line
+left no mark anywhere. `project.mjs` has produced exactly the right sentences
+for this since the projection layer existed — `board.mjs` had simply never
+asked for them. It asks now, and the page carries a **Warnings** section
+naming the initiative and what could not be accounted for: a skipped line, a
+lease released by a non-holder, an override for a ticket that does not exist.
+The likelier damage is the partial kind, because a crash mid-write takes the
+tail, not the file.
+
+**"Needs a human" counted lanes, not humans.** A ticket parked by a
+`ticket.status` override leaves no card in the `blocked` lane — `boardOf`
+resolves the override before the blockage — so an agent could sit blocked on
+that ticket while the tile read **0**. Measured on the shipped fixture: the
+tile now reads 2 where it read 0, and both are agents rather than lanes. It
+counts from both sources, on the server, and the sub-label breaks out which is
+which.
+
+**Staleness was shown and never escalated.** Agents rendered in the order the
+journals spawned them, so the one that had said nothing longest could be last.
+They are now sorted stalest-first, said so above the strip, and three hours of
+silence gets its own bucket and its own red — "468 HOURS since last signal —
+likely dead" is not the same event as thirty minutes, and the two used to
+share a colour. Each chip also carries **what the agent said it would do
+next**, which has been in `board.json` since the fold learned to read
+`progress` events and had never been rendered.
+
+**A spend failure was indistinguishable from having no server.** A crashed
+reader, an unparseable rate card and a page opened over `file://` all ended as
+the same silently missing section — and the server had already built the
+sentence that tells them apart, for a 503 nothing displayed. Each now says
+which it was; `file://` still says nothing, because there it is not a failure.
+
+**Over the initiative ceiling, the served page was a plain-text 500 that the
+page's own 30-second refresh re-fetched twice a minute.** It is now a readable
+page that names the cause and does not reload itself. The CLI still refuses
+loudly with exit 2 — that is right when a human is reading exit codes.
+
+### The drill-down reaches the files an initiative actually has
+
+Selecting a card now lists that initiative's `PLAN.md`, `NOTES.md`, `RETRO.md`,
+`STATE.md` and `PROGRESS.md` — **the ones that exist**, checked with
+`existsSync`, never a list of what a well-run initiative ought to contain and
+never created to satisfy a link.
+
+The recorded path is repo-relative, and that is not cosmetic. `board.json` is
+committed and compared byte for byte, so an absolute path would make two
+clones of one journal disagree and fail `--check` on any machine whose home
+directory is spelled differently — the same reason spend is served rather than
+embedded. It was nearly shipped absolute; there is now a test that fails on
+any `"path"` starting at the filesystem root.
+
+Nothing is served: `--serve` still answers exactly three URLs and derives a
+filesystem path from none of them, which is worth more than a clickable link.
+
+### How to open the dashboard, said once, plainly
+
+`docs/board.md` gains an **Opening it** section, mirrored on the site: the
+serve command and the URL it prints, the `open`/`xdg-open`/`start` line for
+the file, what the difference between them is (spend, and only spend), and the
+fact that inside a session you type neither, because `/tyran:status`
+regenerates the board and tells you where it is. The README says the same in
+three lines instead of implying it.
+
+Verified in a browser against a two-initiative tree, one of whose journals was
+deliberately corrupted: 0 console errors, 0 failed requests, the tile at 2,
+three warnings listed, the file rows repo-relative.
+
 ## 0.1.20 — 2026-08-14
 
 ### `.tyran/` was tracked, and an entire initiative inside it was not

--- a/README.md
+++ b/README.md
@@ -162,16 +162,32 @@ echo "wrong branch — hold everything" > .tyran/STOP
 npx @jjanczur/tyran board --dir .tyran --serve
 ```
 
-A read-only board on loopback, re-rendered on every request. That command is
-the one place a Node version matters — `npx` runs the scripts outside Claude
-Code, and they need **Node ≥ 22**. Four tabs, because the page answers four
-questions:
+It prints `board: serving http://127.0.0.1:4173/` — **open that URL.** The
+board is read-only, bound to loopback, re-rendered on every request, and it
+reloads itself every 30 seconds; `--port <n>` if 4173 is taken, `Ctrl-C` to
+stop. That command is the one place a Node version matters, because `npx` runs
+the scripts outside Claude Code and they need **Node ≥ 22**.
 
-- **Overview** — what is waiting on you, agents running, progress, tickets that
-  need a human; then the agent strip, each chip carrying the time since that
-  agent last signalled.
+No terminal, no server: the same page is written to **`.tyran/state/board.html`**
+after every agent, so you can just open the file —
+
+```bash
+open .tyran/state/board.html      # xdg-open on Linux, start on Windows
+```
+
+— and inside a session you need neither command, because **`/tyran:status`
+regenerates the board and tells you where it is.**
+
+Four tabs, because the page answers four questions:
+
+- **Overview** — what is waiting on you, agents running, progress, and what
+  needs a human (blocked lanes **and** blocked agents); then the agent strip,
+  stalest first, each chip carrying its last signal and what it said it would
+  do next. Anything a journal could not account for is listed here rather than
+  quietly dropped.
 - **Board** — every ticket in exactly one of ten kanban lanes, strongest verdict
-  first. Click a card for its initiative, agents, note and spend.
+  first. Click a card for its initiative, agents, note, spend, and the files
+  that initiative actually has on disk.
 - **Waiting on you** — the open questions with their recommendations and
   recorded defaults, above the commands that answer them. The count sits in the
   tab label, so a pending question survives being on another tab.
@@ -179,9 +195,9 @@ questions:
   composition bar across input / cache write / cache read / output, and three
   ranked charts (by model, agent type, ticket) with a tokens/cost toggle.
 
-The same page is written to `.tyran/state/board.html` and refreshed after every
-agent, so you can also just open the file. Spend is served rather than embedded
-and absent over `file://` — [the board](https://jjanczur.github.io/tyran/board/) says why.
+Spend is served rather than embedded, so it is the one thing missing when you
+open the file directly — [the board](https://jjanczur.github.io/tyran/board/)
+says why, and covers the lanes, the drill-down and answering a question.
 
 ## What ships
 
@@ -215,7 +231,7 @@ enforces the cap (4352 of 5000 characters). What each one assumes, when it
 fires and who invokes it, is in
 [skills and agents](https://jjanczur.github.io/tyran/skills/); the prompts
 themselves are in [`skills/`](skills/) and [`agents/`](agents/). Behind all of
-it: 1297 unit tests, run with `node --test "tests/**/*.test.mjs"`.
+it: 1306 unit tests, run with `node --test "tests/**/*.test.mjs"`.
 
 ## Documentation
 

--- a/docs/board.md
+++ b/docs/board.md
@@ -98,6 +98,42 @@ into can have. Re-render it at the start of each sitting rather than reusing
 the last one — every block in an applied sheet names an ask that is now
 closed, and `apply` refuses the whole file rather than appending a duplicate.
 
+## Opening it
+
+Two ways, and the difference between them is spend.
+
+**Serve it** — the whole page, spend included:
+
+```bash
+npx @jjanczur/tyran board --dir .tyran --serve
+```
+
+It prints `board: serving http://127.0.0.1:4173/`. Open that. The board
+re-renders on every request, so a reload is always current, and the page
+reloads itself every 30 seconds anyway. `--port <n>` if 4173 is taken.
+`Ctrl-C` stops it. It binds loopback only and pins the `Host` header, so
+nothing outside your machine can reach it — and it is read-only: the server
+answers three URLs and derives a filesystem path from none of them.
+
+**Open the file** — no server, no spend:
+
+```bash
+open .tyran/state/board.html          # macOS
+xdg-open .tyran/state/board.html      # Linux
+start .tyran\state\board.html         # Windows
+```
+
+That file is regenerated after every agent and at every merge, so it is a
+real answer, not a stale one. It carries everything except the Spend tab,
+which is fetched rather than embedded — see [Spend](#spend) for why. Over
+`file://` the tab is empty and says nothing is wrong; over the server, a
+spend failure now says which failure it was.
+
+Inside a session you never type either command: **`/tyran:status` regenerates
+the board and tells you where it is.** The three commands are the same board
+from three directions — `--serve` for a browser you keep open, the file for a
+quick look, `BOARD.md` for reading in the terminal or in a diff.
+
 ## board.html, in four tabs
 
 The page an operator leaves open overnight: self-contained (inline CSS/JS,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jjanczur/tyran",
-  "version": "0.1.20",
+  "version": "0.1.21",
   "description": "Command-line scripts for the Tyran task conductor (doctor, journal, schema, and repo tooling) for CI and terminals outside Claude Code. Installing this package does NOT install the Claude Code plugin — add that separately with `/plugin marketplace add jjanczur/tyran` inside Claude Code.",
   "type": "module",
   "engines": {

--- a/scripts/board-html.mjs
+++ b/scripts/board-html.mjs
@@ -52,7 +52,7 @@ const CSS = `
   --hairline:#332e27;--hairline-soft:#26221d;
   --brass:#a8863c;--brass-bright:#cfae63;--brass-low:#221c11;--brass-edge:#5d4c22;
   --steel:#7d9ea9;--steel-bright:#9dbcc6;--steel-low:#17242a;--steel-edge:#3a545d;
-  --clay:#c07a70;--clay-low:#2a1a18;--sage:#88a06a;
+  --clay:#c07a70;--clay-bright:#d9998f;--clay-low:#2a1a18;--sage:#88a06a;
   --display:ui-serif,'Iowan Old Style','Palatino Linotype',Palatino,'Book Antiqua',Georgia,'Times New Roman',serif;
   --font:ui-sans-serif,system-ui,-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,'Helvetica Neue',Arial,sans-serif;
   --mono:ui-monospace,SFMono-Regular,'SF Mono',Menlo,Consolas,'Liberation Mono',monospace;
@@ -97,6 +97,19 @@ h3{font-family:var(--font);color:var(--heading);font-size:.85rem;margin:1.1rem 0
 .agent .age-fresh{color:var(--sage)}
 .agent .age-warm{color:var(--brass-bright)}
 .agent .age-cold{color:var(--clay)}
+/* A dead agent gets the only bold red on the page: three hours of silence is
+   a different event from thirty minutes, and it used to share a colour. */
+.agent .age-dead{color:var(--clay-bright);font-weight:700}
+
+/* ---- what did not render ---- */
+.damaged{background:var(--bg-raised);border-left:3px solid var(--brass);border-radius:.45rem;padding:.42rem .65rem;margin:.3rem 0;font-family:var(--mono);font-size:.78rem;color:var(--brass-bright)}
+.err{background:var(--bg-raised);border-left:3px solid var(--clay);border-radius:.45rem;padding:.6rem .75rem;color:var(--clay-bright);font-size:.85rem}
+
+/* ---- the files an initiative actually has ---- */
+.files{display:flex;flex-direction:column;gap:.2rem;margin-top:.3rem}
+.file{display:flex;gap:.5rem;align-items:baseline;flex-wrap:wrap;font-size:.76rem}
+.file .fname{color:var(--steel-bright);font-family:var(--mono);font-weight:600;min-width:6rem}
+.file code{color:var(--muted);font-size:.72rem;word-break:break-all}
 
 /* ---- lanes ---- */
 .lanes{display:grid;grid-template-columns:repeat(auto-fill,minmax(15rem,1fr));gap:.6rem;align-items:start}
@@ -206,6 +219,7 @@ if (data.schema !== 1) {
   var lanes = data.lanes || {};
   var errors = data.errors || [];
   var cost = null;
+  var costError = null;
 
   var app = document.getElementById('app');
   var head = el('div');
@@ -282,10 +296,20 @@ if (data.schema !== 1) {
       chip.appendChild(el('div', 'name', a.agent + (a.role ? ' · ' + a.role : '')));
       chip.appendChild(el('div', null, (a.init ? a.init + ' · ' : '') + (a.ticket || 'no ticket') + ' · ' + a.state));
       if (a.detail) chip.appendChild(el('div', 'note', a.detail));
+      // What the agent said it would do next. It has been in board.json since
+      // the fold learned to read progress events, and the strip has never
+      // shown it — so the chip could say an agent went quiet without saying
+      // what it went quiet in the middle of.
+      if (a.next) chip.appendChild(el('div', 'note', 'next: ' + a.next));
       var ageMs = a.last_signal ? Date.now() - Date.parse(a.last_signal) : null;
       var cls = ageMs === null ? 'age-cold' : ageMs < 600000 ? 'age-fresh' : ageMs < 1800000 ? 'age-warm' : 'age-cold';
-      var ageText = ageMs === null ? 'no signal' : Math.round(ageMs / 60000) + ' min since last signal';
-      chip.appendChild(el('div', cls, ageText));
+      // Four buckets, not three. The old top bucket was "30 minutes or six
+      // hours", which are not the same event: one is a long test run, the
+      // other is an agent that is not coming back.
+      var ageText = ageMs === null ? 'no signal recorded'
+        : ageMs >= 10800000 ? Math.round(ageMs / 3600000) + ' HOURS since last signal — likely dead'
+        : Math.round(ageMs / 60000) + ' min since last signal';
+      chip.appendChild(el('div', ageMs !== null && ageMs >= 10800000 ? 'age-dead' : cls, ageText));
       strip.appendChild(chip);
     });
     return strip;
@@ -302,11 +326,21 @@ if (data.schema !== 1) {
     asks.length === 0 ? 'nothing blocked on a decision' : 'answer them on the next tab', asks.length > 0 ? 'lead' : null));
   ovTiles.appendChild(tile('agents running', String(agents.length), 'across ' + (totals.initiatives || 0) + ' initiative(s)'));
   ovTiles.appendChild(tile('progress', (totals.percent || 0) + '%', (totals.merged || 0) + ' of ' + (totals.tickets || 0) + ' merged'));
-  var stuck = laneCount('blocked') + laneCount('changes-requested');
+  // Counted by the server, from the lanes AND the agents. Counting lanes here
+  // read zero while an agent chip on the same screen said "blocked", because a
+  // ticket parked by an override leaves no card in the blocked lane.
+  var blockedAgents = agents.filter(function (a) { return a.state === 'blocked'; }).length;
+  var stuck = totals.blocked !== undefined ? totals.blocked
+    : laneCount('blocked') + laneCount('changes-requested') + blockedAgents;
   ovTiles.appendChild(tile('needs a human', String(stuck),
-    laneCount('blocked') + ' blocked · ' + laneCount('changes-requested') + ' changes requested', stuck > 0 ? 'warn' : null));
+    laneCount('blocked') + ' blocked · ' + laneCount('changes-requested') + ' changes requested · '
+      + blockedAgents + ' agent(s) blocked', stuck > 0 ? 'warn' : null));
   ov.appendChild(ovTiles);
   ov.appendChild(el('h2', null, 'Agents'));
+  // Named, not implied by the order: the strip is sorted stalest-first by the
+  // server, and a reader who does not know that reads the first chip as the
+  // newest one.
+  if (agents.length > 1) ov.appendChild(el('div', 'hint', 'Stalest first — the agent that has said nothing longest is at the top.'));
   ov.appendChild(agentStrip());
   var ovSpend = el('div');
   ov.appendChild(ovSpend);
@@ -318,6 +352,22 @@ if (data.schema !== 1) {
     ov.appendChild(el('h2', null, 'Unreadable (' + errors.length + ')'));
     errors.forEach(function (e) {
       ov.appendChild(el('div', 'paused', 'UNREADABLE — ' + e.name + ': ' + e.error));
+    });
+  }
+
+  // The same argument one step down. An initiative whose journal is PARTLY
+  // damaged folds to a board with nothing wrong on it — the lost half leaves
+  // no trace — so it used to render as an initiative in perfect health.
+  var warned = data.warned || [];
+  if (warned.length > 0) {
+    var warnCount = 0;
+    warned.forEach(function (d) { warnCount += d.warnings.length; });
+    ov.appendChild(el('h2', null, 'Warnings (' + warnCount + ')'));
+    ov.appendChild(el('div', 'hint', 'These initiatives rendered. What follows is what the fold could not account for — a skipped line is missing from every lane above, and a lease released by a non-holder is still open.'));
+    warned.forEach(function (d) {
+      d.warnings.forEach(function (w) {
+        ov.appendChild(el('div', 'damaged', d.name + ': ' + w));
+      });
     });
   }
 
@@ -347,8 +397,26 @@ if (data.schema !== 1) {
     if (cost) {
       var hit = (cost.by_ticket || []).filter(function (r) { return r.ticket === card.id; })[0];
       if (hit) row('spend', fmtTokens(hit.tokens) + ' tokens · ' + fmtUsd(hit.usd));
+    } else if (costError) {
+      row('spend', costError);
     }
     box.appendChild(dl);
+    // The files this initiative ACTUALLY has, listed by the server after an
+    // existsSync — never a fixed list of what a well-run initiative ought to
+    // contain. Paths, not links: the board serves three URLs and derives a
+    // filesystem path from none of them, which is worth more than a click.
+    var docs = (data.files || {})[card.init] || [];
+    if (docs.length > 0) {
+      box.appendChild(el('div', 'dt', 'Files'));
+      var list = el('div', 'files');
+      docs.forEach(function (f) {
+        var line = el('div', 'file');
+        line.appendChild(el('span', 'fname', f.name));
+        line.appendChild(el('code', null, f.path));
+        list.appendChild(line);
+      });
+      box.appendChild(list);
+    }
     detail.appendChild(box);
   };
   Object.keys(lanes).forEach(function (lane) {
@@ -520,11 +588,33 @@ if (data.schema !== 1) {
   // the operator's home directory — machine-local, different in every clone —
   // so writing it into board.json would break the byte-exact --check contract
   // and make two people with one journal disagree.
+  // Three different things used to look identical here: an unserved page, a
+  // crashed reader, and a rate card that does not parse. All three ended as a
+  // silently absent section, so the operator could not tell "there is nothing
+  // to show" from "the thing that shows it is broken". The server already
+  // builds an error string for the 503 and it was never displayed.
+  var showCostFailure = function (why) {
+    costError = why;
+    clear(spBody);
+    spBody.appendChild(el('div', 'err', why));
+  };
   if (typeof fetch === 'function') {
     fetch('cost.json', { headers: { accept: 'application/json' } })
-      .then(function (r) { return r.ok ? r.json() : null; })
-      .then(function (payload) {
-        if (!payload || payload.schema !== 1 || !payload.transcripts_found) return;
+      .then(function (r) {
+        return r.json().then(function (body) { return { ok: r.ok, body: body }; });
+      })
+      .then(function (res) {
+        var payload = res.body;
+        if (!res.ok) {
+          showCostFailure('Spend could not be read: ' + ((payload && payload.error) || 'the server refused the request') + '.');
+          return;
+        }
+        if (!payload || payload.schema !== 1) {
+          showCostFailure('Spend was served in a format this page does not know (schema ' +
+            ((payload && payload.schema) || 'absent') + ') — regenerate the board with the Tyran that served it.');
+          return;
+        }
+        if (!payload.transcripts_found) return; // genuinely nothing to show
         cost = payload;
         renderSpend(spBody, 'tokens');
         var t = cost.totals || {};
@@ -534,7 +624,12 @@ if (data.schema !== 1) {
         ovSpend.appendChild(el('h2', null, 'Spend'));
         ovSpend.appendChild(strip);
       })
-      .catch(function () { /* no server: the board is complete without it */ });
+      .catch(function () {
+        // Over file:// there is no server to ask, which is not a failure —
+        // it is the documented shape of this page without one.
+        if (String(location.protocol) === 'file:') return;
+        showCostFailure('Spend could not be read: the board server did not answer. It is served, never embedded — start it with: npx @jjanczur/tyran board --dir .tyran --serve');
+      });
   }
 
   select('overview');
@@ -550,6 +645,39 @@ if (data.schema !== 1) {
  * bytes of board.json, so the two artefacts can never disagree). The extra
  * `<` escape is the script-element breakout layer.
  */
+/**
+ * The page for a board that could not be rendered at all.
+ *
+ * Built through the same JSON channel as the real page rather than by
+ * interpolating the message into markup: the text comes from an exception, an
+ * exception carries a path, and a path is attacker-adjacent input on a page
+ * the operator opens in a browser. `<` on the JSON, `textContent` on the
+ * other side, no innerHTML anywhere — the same three rules the board itself
+ * follows.
+ */
+export function renderBoardError(message) {
+  const data = JSON.stringify({ message }).replace(/</g, '\\u003C');
+  return (
+    '<!doctype html>\n' +
+    '<html lang="en"><head><meta charset="utf-8">\n' +
+    '<meta name="viewport" content="width=device-width, initial-scale=1">\n' +
+    '<title>Tyran board — cannot render</title>\n' +
+    `<style>${CSS}</style>\n` +
+    '</head><body><main id="app"></main>\n' +
+    `<script type="application/json" id="board-error">${data}</script>\n` +
+    '<script>\n' +
+    'var d = JSON.parse(document.getElementById("board-error").textContent);\n' +
+    'var app = document.getElementById("app");\n' +
+    'var h = document.createElement("h1"); h.textContent = "The board cannot be rendered";\n' +
+    'var p = document.createElement("p"); p.className = "err"; p.textContent = d.message;\n' +
+    'var n = document.createElement("p");\n' +
+    'n.textContent = "This page does not refresh itself \\u2014 fix the cause above, then reload.";\n' +
+    'app.appendChild(h); app.appendChild(p); app.appendChild(n);\n' +
+    '</script>\n' +
+    '</body></html>\n'
+  );
+}
+
 export function renderBoardHtml(payloadJsonText) {
   const embedded = payloadJsonText.replace(/</g, '\\u003C');
   return (

--- a/scripts/board.mjs
+++ b/scripts/board.mjs
@@ -25,7 +25,7 @@
  */
 import { existsSync, readdirSync, statSync, readFileSync } from 'node:fs';
 import { createServer } from 'node:http';
-import { join, resolve } from 'node:path';
+import { basename, join, resolve } from 'node:path';
 import { realpathSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import { readJournal } from './journal.mjs';
@@ -37,10 +37,11 @@ import {
   checkFile,
   fold,
   inline,
+  warnings,
   writeAllAtomic,
 } from './project.mjs';
 import { jsonEscapeInvisible } from './invisible.mjs';
-import { renderBoardHtml } from './board-html.mjs';
+import { renderBoardError, renderBoardHtml } from './board-html.mjs';
 import { COST_SCHEMA, costJson, costReport } from './cost.mjs';
 
 export const BOARD_HTML_FILE = 'board.html';
@@ -80,11 +81,21 @@ export function readInitiativeBoards(tyranDir) {
   }
   const initiatives = [];
   const errors = [];
+  const warned = [];
   for (const name of dirs) {
     const journal = join(stateDir, name, 'journal.jsonl');
     if (!existsSync(journal)) continue;
     try {
       const state = fold(readJournal(journal));
+      // PARTIAL damage, which the guard below cannot see. That guard fires only
+      // when NOTHING was readable; three good tickets plus one unparseable line
+      // folds to a board with no errors on it and renders as an initiative in
+      // perfect health. `warnings()` has produced exactly the right sentences
+      // for this since the projection layer existed — the board simply never
+      // asked for them. A page whose stated reason to exist is not saying "all
+      // is well" when it is not cannot be silent about the damaged half.
+      const flaws = warnings(state);
+      if (flaws.length > 0) warned.push({ name, warnings: flaws });
       // `readJournal` does NOT throw on unparseable content — it returns zero
       // events and counts the damage — so the catch below never sees a corrupt
       // journal. Without this guard a damaged file renders as an initiative
@@ -102,36 +113,74 @@ export function readInitiativeBoards(tyranDir) {
       // `journal` is returned, not re-derived by consumers: answer.mjs writes
       // to the file this function already located, so there is one rule for
       // where an initiative's journal lives (ADR-21).
-      initiatives.push({ name, journal, state, board: boardOf(state) });
+      initiatives.push({ name, journal, state, board: boardOf(state), files: initiativeFiles(tyranDir, name) });
     } catch (err) {
       errors.push({ name, error: String(err?.message ?? err) });
     }
   }
-  return { initiatives, errors };
+  return { initiatives, errors, warned };
+}
+
+/**
+ * The files an initiative ACTUALLY has beside its journal.
+ *
+ * Named set, `existsSync`, no creation and no guessing: the operator asked to
+ * reach an agent's plan from the board and asked in the same breath that
+ * nothing be created to satisfy the link. A listed file that is not there is
+ * the same lie as a missing one, in the other direction.
+ *
+ * The recorded path is REPO-RELATIVE, and that is not cosmetic: `board.json`
+ * is a committed, byte-compared artefact, so an absolute path would make two
+ * clones of one journal disagree and fail `--check` on a machine whose home
+ * directory is spelled differently. It is the same reason spend is served
+ * rather than embedded. Relative is also the more useful form — it is what
+ * the reader pastes, from the repo root, into an editor.
+ *
+ * Nothing is served: `--serve` routes three URLs and derives a filesystem
+ * path from none of them, which is worth more than a clickable link.
+ */
+export const INITIATIVE_FILES = Object.freeze(['PLAN.md', 'NOTES.md', 'RETRO.md', 'STATE.md', 'PROGRESS.md']);
+
+export function initiativeFiles(tyranDir, name) {
+  const dir = join(tyranDir, 'state', name);
+  const shown = join(basename(resolve(tyranDir)), 'state', name);
+  return INITIATIVE_FILES.filter((file) => existsSync(join(dir, file))).map((file) => ({
+    name: file,
+    path: join(shown, file),
+  }));
 }
 
 /** Pure merge of per-initiative boards into the one payload. */
-export function crossBoard({ initiatives, errors }) {
+export function crossBoard({ initiatives, errors, warned = [] }) {
   const asks = [];
   const agents = [];
   const paused = [];
+  const files = {};
   const lanes = Object.fromEntries(LANES.map((lane) => [lane, []]));
   let merged = 0;
   let tickets = 0;
   let asOf = null;
 
-  for (const { name, state, board } of initiatives) {
+  for (const { name, state, board, files: docs } of initiatives) {
     merged += state.merged;
     tickets += state.ticketList.length;
     if (state.lastTs !== null && (asOf === null || state.lastTs > asOf)) asOf = state.lastTs;
     for (const a of board.asks) asks.push({ ...a, init: name });
     for (const a of board.agents) agents.push({ ...a, init: name });
     if (board.paused !== null) paused.push({ ...board.paused, init: name });
+    if (docs !== undefined && docs.length > 0) files[name] = docs;
     for (const lane of LANES) {
       for (const card of board.lanes.get(lane)) lanes[lane].push({ ...card, init: name });
     }
   }
   asks.sort((a, b) => String(a.since ?? '').localeCompare(String(b.since ?? '')));
+  // Stalest FIRST. Rendering agents in the order the journals happened to spawn
+  // them puts the one that has said nothing for six hours anywhere at all,
+  // including last — and the whole reason the strip carries a last-signal time
+  // is that the silent agent is the one worth looking at. `last_signal` is an
+  // ISO string from the journal, so ascending string order IS ascending time;
+  // an agent with no signal at all sorts to the front, where it belongs.
+  agents.sort((a, b) => String(a.last_signal ?? '').localeCompare(String(b.last_signal ?? '')));
 
   return {
     schema: 1,
@@ -142,12 +191,21 @@ export function crossBoard({ initiatives, errors }) {
       merged,
       tickets,
       percent: tickets === 0 ? 0 : Math.round((merged / tickets) * 100),
+      // Counted here rather than on the page, from BOTH sources of "a human is
+      // needed": the lanes, and the agents. A ticket parked by a `ticket.status`
+      // override leaves no card in `blocked` — the override is resolved before
+      // the blockage in `boardOf` — so an agent could sit blocked on it while a
+      // tile counting lanes alone read zero. It did.
+      blocked: lanes.blocked.length + lanes['changes-requested'].length
+        + agents.filter((a) => a.state === 'blocked').length,
     },
     paused,
     asks,
     agents,
+    files,
     lanes,
     errors,
+    warned,
   };
 }
 
@@ -168,6 +226,9 @@ export function renderCrossMd(payload) {
   for (const e of payload.errors) {
     parts.push(`\n**UNREADABLE** — ${inline(e.name)}: ${inline(e.error)}\n`);
   }
+  for (const d of payload.warned ?? []) {
+    for (const w of d.warnings) parts.push(`\n**WARNING** — ${inline(d.name)}: ${inline(w)}\n`);
+  }
 
   parts.push('\n## Waiting on you\n\n');
   if (payload.asks.length === 0) parts.push('_none — the agents have what they need_\n');
@@ -184,8 +245,17 @@ export function renderCrossMd(payload) {
     parts.push(
       `- \`${inline(a.agent)}\` (${inline(a.role)}) — ${inline(a.init)}` +
         `${a.ticket != null ? ` · \`${inline(a.ticket)}\`` : ''} · ${inline(a.state)}` +
-        `${a.detail != null ? ` — ${inline(a.detail)}` : ''} · last signal ${inline(a.last_signal)}\n`,
+        `${a.detail != null ? ` — ${inline(a.detail)}` : ''} · last signal ${inline(a.last_signal)}` +
+        `${a.next != null ? ` · next: ${inline(a.next)}` : ''}\n`,
     );
+  }
+
+  const withFiles = Object.keys(payload.files ?? {}).sort();
+  if (withFiles.length > 0) {
+    parts.push('\n## Files\n\n');
+    for (const name of withFiles) {
+      parts.push(`- ${inline(name)}: ${payload.files[name].map((f) => `\`${inline(f.name)}\``).join(', ')}\n`);
+    }
   }
 
   for (const lane of LANES) {
@@ -318,8 +388,14 @@ function main() {
           res.end('not found\n');
         }
       } catch (err) {
-        res.writeHead(500, { 'content-type': 'text/plain' });
-        res.end(`board render failed: ${String(err?.message ?? err)}\n`);
+        // Readable, and 200 on purpose. The page refreshes itself every 30
+        // seconds, so a plain-text 500 becomes a browser tab re-fetching an
+        // error nobody can act on twice a minute. The state that reaches here
+        // is real and fixable — over the initiative ceiling, an unreadable
+        // state directory — and the operator needs the sentence, not a status
+        // code they will never see.
+        res.writeHead(200, { 'content-type': 'text/html; charset=utf-8' });
+        res.end(renderBoardError(String(err?.message ?? err)));
       }
     });
     // A busy port is an ordinary operator mistake, not a crash worth a stack

--- a/site/src/content/docs/board.mdx
+++ b/site/src/content/docs/board.mdx
@@ -101,6 +101,42 @@ into can have. Re-render it at the start of each sitting rather than reusing
 the last one — every block in an applied sheet names an ask that is now
 closed, and `apply` refuses the whole file rather than appending a duplicate.
 
+## Opening it
+
+Two ways, and the difference between them is spend.
+
+**Serve it** — the whole page, spend included:
+
+```bash
+npx @jjanczur/tyran board --dir .tyran --serve
+```
+
+It prints `board: serving http://127.0.0.1:4173/`. Open that. The board
+re-renders on every request, so a reload is always current, and the page
+reloads itself every 30 seconds anyway. `--port <n>` if 4173 is taken.
+`Ctrl-C` stops it. It binds loopback only and pins the `Host` header, so
+nothing outside your machine can reach it — and it is read-only: the server
+answers three URLs and derives a filesystem path from none of them.
+
+**Open the file** — no server, no spend:
+
+```bash
+open .tyran/state/board.html          # macOS
+xdg-open .tyran/state/board.html      # Linux
+start .tyran\state\board.html         # Windows
+```
+
+That file is regenerated after every agent and at every merge, so it is a
+real answer, not a stale one. It carries everything except the Spend tab,
+which is fetched rather than embedded — see [Spend](#spend) for why. Over
+`file://` the tab is empty and says nothing is wrong; over the server, a
+spend failure now says which failure it was.
+
+Inside a session you never type either command: **`/tyran:status` regenerates
+the board and tells you where it is.** The three commands are the same board
+from three directions — `--serve` for a browser you keep open, the file for a
+quick look, `BOARD.md` for reading in the terminal or in a diff.
+
 ## board.html, in four tabs
 
 The page an operator leaves open overnight: self-contained (inline CSS/JS,

--- a/tests/unit/board.test.mjs
+++ b/tests/unit/board.test.mjs
@@ -30,7 +30,7 @@ import {
   renderAll,
   renderCrossMd,
 } from '../../scripts/board.mjs';
-import { renderBoardHtml } from '../../scripts/board-html.mjs';
+import { renderBoardError, renderBoardHtml } from '../../scripts/board-html.mjs';
 import { BOARD_FILE, BOARD_JSON_FILE, LANES } from '../../scripts/project.mjs';
 
 const SCRIPT = fileURLToPath(new URL('../../scripts/board.mjs', import.meta.url));
@@ -301,4 +301,144 @@ test('spend reaches three places from the one fetch, and explains itself when th
   assert.match(html, /if \(cost\) \{/, 'a selected card must be able to show its own spend');
   assert.match(html, /row\('spend', fmtTokens\(hit\.tokens\) \+ ' tokens [^']*' \+ fmtUsd\(hit\.usd\)\);/);
   assert.match(html, /Over file:\/\/ there is no server, so this tab stays empty\./);
+});
+
+// --- the half that did not render -----------------------------------------
+//
+// The damage guard above fires only when NOTHING was readable. Everything
+// below is the other half of the same argument: an initiative that folded
+// successfully can still have lost lines, agents can go quiet, spend can fail
+// to load, and each of those used to render as a board with nothing wrong.
+
+/** The fixture with one line replaced by garbage — readable, but not whole. */
+function partlyDamaged() {
+  const lines = demo().trimEnd().split('\n');
+  lines.splice(3, 0, '{not json at all');
+  return lines.join('\n') + '\n';
+}
+
+test('a PARTIALLY damaged journal renders, and says what it lost', () => {
+  // MUTANT: drop the warnings() call in readInitiativeBoards. The board folds
+  // the readable events, reports errors: [], and renders an initiative in
+  // perfect health while a line of its ledger is gone. This is the exact
+  // shape the total-loss guard cannot see, and it is the likelier one: a
+  // crash mid-write damages the tail, not the whole file.
+  const dir = tree({ demo: partlyDamaged() });
+  const read = readInitiativeBoards(dir);
+  assert.equal(read.errors.length, 0, 'it is readable — this is not the total-loss case');
+  assert.equal(read.initiatives.length, 1, 'and it must still render');
+  assert.match(read.warned[0].warnings.join(' '), /corrupt line/);
+
+  assert.match(renderCrossMd(crossBoard(read)), /\*\*WARNING\*\* — demo: .*corrupt line/);
+  const html = renderAll(dir).files[BOARD_HTML_FILE];
+  assert.match(html, /Warnings \(/, 'the page too — BOARD.md is not what the operator stares at');
+});
+
+test('an intact journal is never accused of corruption', () => {
+  // The other half of the mutant above. A banner that is always on is a
+  // banner nobody reads, which is the failure mode of the FIX rather than of
+  // the bug — so the claim pinned here is specific: no integrity warning on a
+  // journal whose bytes are all there. (The shipped fixture does carry one
+  // state warning, a lease released by a non-holder, and that one is
+  // deliberately surfaced too.)
+  const read = readInitiativeBoards(tree({ demo: demo() }));
+  const all = read.warned.flatMap((w) => w.warnings).join(' ');
+  assert.doesNotMatch(all, /corrupt|truncated|non-object/);
+  assert.ok(readInitiativeBoards(tree({ demo: partlyDamaged() })).warned[0].warnings.length > read.warned.length);
+});
+
+test('needs-a-human counts blocked AGENTS, not only blocked lanes', () => {
+  // MUTANT: count lanes.blocked + lanes['changes-requested'] alone. A ticket
+  // parked by a ticket.status override leaves no card in the blocked lane —
+  // boardOf resolves the override BEFORE the blockage — so the tile read 0
+  // while an agent chip on the same screen said "blocked". Measured on the
+  // shipped fixture.
+  const payload = crossBoard(readInitiativeBoards(tree({ demo: demo() })));
+  const blockedAgents = payload.agents.filter((a) => a.state === 'blocked').length;
+  assert.ok(blockedAgents > 0, 'the fixture must keep an agent blocked or this test proves nothing');
+  const lanes = payload.lanes.blocked.length + payload.lanes['changes-requested'].length;
+  assert.equal(payload.totals.blocked, lanes + blockedAgents);
+  assert.ok(payload.totals.blocked > lanes, 'the agent is the whole point — lanes alone missed it');
+});
+
+test('the agent strip is ordered stalest first, whatever order the journals spawned them', () => {
+  // MUTANT: keep journal order. The strip carries a last-signal age precisely
+  // because the silent agent is the one worth looking at, and journal order
+  // puts it anywhere — including last, below the fold.
+  const dir = tree({ alpha: demo(), beta: demo().replaceAll('"init":"demo"', '"init":"beta"') });
+  const { agents } = crossBoard(readInitiativeBoards(dir));
+  assert.ok(agents.length >= 2);
+  const signals = agents.map((a) => String(a.last_signal ?? ''));
+  assert.deepEqual(signals, [...signals].sort(), 'ascending ISO time is ascending staleness-first');
+
+  // MUTANT: drop the 'next:' line from the chip. The board then says an agent
+  // went quiet without saying what it went quiet in the MIDDLE of — and the
+  // field has been in board.json since the fold learned to read progress.
+  assert.match(demoHtml(), /'next: ' \+ a\.next/);
+  // MUTANT: keep three age buckets. Thirty minutes and six hours then share a
+  // colour and a sentence, and they are not the same event.
+  assert.match(demoHtml(), /likely dead/);
+});
+
+test('the drill-down lists the initiative files that exist, and invents none', () => {
+  // MUTANT: return a fixed list of PLAN.md/NOTES.md/RETRO.md without the
+  // existsSync. The panel then names files that are not there, which is the
+  // same lie as omitting the ones that are — and the operator asked
+  // explicitly that nothing be created to satisfy the link.
+  const dir = tree({ demo: demo() });
+  writeFileSync(join(dir, 'state', 'demo', 'PLAN.md'), '# plan\n');
+  const payload = crossBoard(readInitiativeBoards(dir));
+  assert.deepEqual(payload.files.demo.map((f) => f.name), ['PLAN.md']);
+  assert.match(payload.files.demo[0].path, /state\/demo\/PLAN\.md$/);
+
+  const bare = crossBoard(readInitiativeBoards(tree({ demo: demo() })));
+  assert.deepEqual(bare.files, {}, 'no files on disk, no files claimed');
+});
+
+test('over the ceiling the SERVED page is readable prose, not a 500 it re-fetches every 30 s', () => {
+  // MUTANT: leave the handler's catch writing a plain-text 500. The page sets
+  // its own meta refresh, so the browser then re-requests an error nobody can
+  // read twice a minute. The CLI keeps throwing — that pin is one test above,
+  // and refusing loudly is right when a human is reading exit codes.
+  const html = renderBoardError('65 initiative directories — the ceiling is 64.');
+  assert.match(html, /The board cannot be rendered/);
+  assert.match(html, /the ceiling is 64/);
+  assert.doesNotMatch(html, /http-equiv="refresh"/, 'an error page that reloads itself is a loop');
+  assert.doesNotMatch(html, /innerHTML/);
+});
+
+test('a hostile message on the error page stays text', () => {
+  // MUTANT: interpolate the message into the markup. It comes from an
+  // exception, an exception carries a path, and a path is input.
+  const html = renderBoardError('<img src=x onerror=alert(1)> /tmp/</script><script>');
+  assert.doesNotMatch(html, /<img src=x/);
+  assert.ok(html.includes('\\u003C'), 'the message travels through the same JSON channel the board uses');
+});
+
+test('a spend failure says which failure it was', () => {
+  // MUTANT: map every non-OK response to null and return silently. A crashed
+  // reader, an unparseable rate card and an unserved page then look identical
+  // — all three are simply a missing section — and the server had already
+  // built the sentence that tells them apart.
+  const html = demoHtml();
+  assert.match(html, /Spend could not be read/);
+  assert.match(html, /showCostFailure/);
+  assert.match(html, /location\.protocol/, 'file:// is not a failure and must not be reported as one');
+});
+
+test('board.json carries no absolute path, so two clones of one journal agree', () => {
+  // MUTANT: record the absolute path of each initiative file — which is the
+  // obvious thing to record, since it is what an operator pastes. board.json
+  // is committed and compared BYTE for byte, so an absolute path makes
+  // `--check` fail on any machine whose home directory is spelled
+  // differently. It is the same reason spend is served instead of embedded,
+  // and it was nearly shipped here before this test existed.
+  const dir = tree({ demo: demo() });
+  writeFileSync(join(dir, 'state', 'demo', 'PLAN.md'), '# plan\n');
+  const json = renderAll(dir).files[BOARD_JSON_FILE];
+  assert.match(json, /PLAN\.md/, 'the file has to be in there or this proves nothing');
+  assert.ok(!json.includes(dir), 'the temp directory leaked into a committed artefact');
+  for (const line of json.split('\n')) {
+    assert.doesNotMatch(line, /"path": "\//, 'a path starting at the filesystem root is machine-specific');
+  }
 });


### PR DESCRIPTION
An audit read the board against the promise in its own header comment — *"a board that omits a broken initiative reads as 'all is well' exactly when it is not"* — and found five ways it broke that promise. All five are fixed here, each with a test naming the mutant it kills.

## 1. A partially damaged journal rendered as a healthy initiative

The existing guard fires only when **nothing** was readable. Three good tickets plus one unparseable line folded to `errors: []`, and the lost line left no mark anywhere on the page. That is the likelier damage, too — a crash mid-write takes the tail, not the file.

`project.mjs` has produced exactly the right sentences for this since the projection layer existed. `board.mjs` had never asked for them. It asks now, into a **Warnings** section naming the initiative and what could not be accounted for.

## 2. "Needs a human" counted lanes, not humans

A ticket parked by a `ticket.status` override leaves no card in the `blocked` lane — `boardOf` resolves the override *before* the blockage — so an agent could sit blocked on that ticket while the tile read **0**.

Measured on the shipped fixture, in a browser: the tile now reads **2**, and both are agents rather than lanes.

```
needs a human  2   ·  0 blocked · 0 changes requested · 2 agent(s) blocked
```

## 3. Staleness was shown and never escalated

Agents rendered in journal spawn order, so the one that had said nothing longest could be last. Thirty minutes and six hours shared a colour and a sentence.

Now: sorted stalest-first (and the page says so), a fourth bucket past three hours with its own red — `468 HOURS since last signal — likely dead` — and each chip carries **what the agent said it would do next**, a field that has been in `board.json` since the fold learned to read `progress` events and was never rendered.

## 4. A spend failure was indistinguishable from having no server

A crashed reader, an unparseable rate card and a page opened over `file://` all ended as the same silently absent section. The server had already built the sentence that tells them apart, for a 503 that nothing displayed. Each now says which it was — and `file://` still says nothing, because there it is not a failure.

## 5. Over the ceiling, the served page was a 500 the page re-fetched twice a minute

`renderAll` throws past 64 initiatives; the handler wrote a plain-text 500, and the board's own 30-second meta refresh re-requested it forever. Now a readable page naming the cause, with no refresh on it. The CLI still refuses loudly with exit 2 — right when a human is reading exit codes.

## The drill-down reaches the files that exist

`PLAN.md`, `NOTES.md`, `RETRO.md`, `STATE.md`, `PROGRESS.md` — the ones `existsSync` confirms, never a list of what a well-run initiative ought to have, never created to satisfy a link.

**The path is repo-relative, and that is load-bearing.** `board.json` is committed and compared byte for byte, so an absolute path would make two clones of one journal disagree and fail `--check` on any machine whose home directory is spelled differently — the same reason spend is served rather than embedded. I nearly shipped it absolute. There is now a test that fails on any `"path"` starting at the filesystem root.

`--serve` still answers exactly three URLs and derives a filesystem path from none of them.

## How to open the dashboard

Asked for directly, so it is said once and plainly. `docs/board.md` gains **Opening it**, mirrored on the site: the serve command and the URL it prints, the `open`/`xdg-open`/`start` line for the file, what differs between them (spend, and only spend), and that inside a session you type neither because `/tyran:status` regenerates the board and tells you where it is. The README says the same in three lines.

## Mutants killed

| test | mutant |
|---|---|
| a PARTIALLY damaged journal says what it lost | drop the `warnings()` call — folds clean, renders healthy |
| an intact journal is never accused | make the banner unconditional — always-on is never-read |
| needs-a-human counts blocked AGENTS | count lanes alone — the parked-ticket blind spot |
| stalest first | keep journal order — the silent agent lands below the fold |
| `next:` on the chip | drop it — says an agent went quiet, not what it went quiet mid-way through |
| four age buckets | keep three — 30 min and 6 h are not the same event |
| files that exist | return a fixed list without `existsSync` |
| no absolute path in board.json | record the absolute path — the obvious choice, breaks `--check` |
| error page is prose | keep the plain-text 500 — a refresh loop |
| hostile message stays text | interpolate the exception into markup |
| spend failure says which | map every non-OK to null and return silently |

## Evidence

```
node --test "tests/**/*.test.mjs"      → 1306 pass / 0 fail
node scripts/desc-budget.mjs .         → 4352/5000
node scripts/scan-control-chars.mjs .  → clean, 192 tracked text files
claude plugin validate .               → Validation passed
site build                             → 18 pages, 488 of 488 prefixed links
```

Driven in a real browser against a two-initiative tree with one journal deliberately corrupted:

```
consoleErrors: []      failedRequests: []
tiles:   needs a human 2  ·  0 blocked · 0 changes requested · 2 agent(s) blocked
h2:      ["Agents", "Warnings (3)"]
warned:  broken: journal has 1 corrupt line(s) mid-file — they were skipped
         alpha:  1 lease release(s) by a non-holder — leases stay open
         broken: 1 lease release(s) by a non-holder — leases stay open
detail:  files → PLAN.md   .tyran/state/alpha/PLAN.md
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)