### PR TITLE
board: a Settings tab that writes, and keeps your comments (+ 0.1.24)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
     {
       "name": "tyran",
       "description": "A task conductor for Claude Code: multi-agent orchestration with an enforced evidence contract, repo-specific learning, and update-safe local evolution.",
-      "version": "0.1.23",
+      "version": "0.1.24",
       "source": "./",
       "author": {
         "name": "Jacek Janczura",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "tyran",
-  "version": "0.1.23",
+  "version": "0.1.24",
   "description": "A task conductor for Claude Code: multi-agent orchestration with an enforced evidence contract, repo-specific learning, and update-safe local evolution.",
   "author": {
     "name": "Jacek Janczura",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,38 @@ Both found by the same study, both reproduced before being believed.
   is the same inert state as omitting it. `doctor`'s `limit-telemetry-missing`
   could never fire before this either, for the same reason.
 
+### Four findings from the independent review, fixed before merge
+
+- **The editor only worked on two-space indentation.** `yaml-lite` recurses
+  with whatever indent the next line has, so a four-space `config.yaml` is
+  entirely legal and `validateConfig` accepts it — but the patcher assumed a
+  step of 2, so on such a file eleven of the fifteen controls rendered
+  **enabled and populated** (the page reads the parsed document) and then
+  failed on click with *"is not in this file"*, which was false, and whose
+  paired advice told the operator to add a key that was already there. The
+  step is now read from the file. The one step that stays fixed is a sequence
+  item's siblings at dash + 2, because `- ` is two characters wide and that is
+  what `yaml-lite` itself does.
+- **A value the subset cannot spell returned 500.** `formatScalar` throws for
+  a newline or an invisible codepoint — ordinary rejected input, someone
+  pasting a model name with a stray newline — and it escaped as a server
+  fault, complete with a `settings write failed` line in the terminal the docs
+  designate as the audit trail. Now a 400, quietly.
+- **The round-trip proof had no test that failed when it was deleted.** The
+  reviewer neutered the comparison and the suite stayed green; 2772 fuzzed
+  triples fired it zero times, because every wrong case is refused earlier by
+  the locator, the comment guard or `formatScalar`. `sameValue` is now
+  exported and tested directly — it is the mutable logic the guarantee rests
+  on — and the module says plainly that the proof is defence in depth with no
+  known reachable input. Two bare `assert.throws` calls gained an error class;
+  the missing one is what let the 500 above through.
+- **A wrong number in three places.** `templates/config.yaml` is 90 lines of
+  which 63 are comments, not 60 of 91.
+
+Also from the review, unprompted: a failure inside the settings renderer was
+being reported as "the board server did not answer", sending the operator to
+restart something that was answering perfectly well.
+
 ### The sandbox has a Settings tab too
 
 `site/scripts/build-sandbox.mjs` runs the real `readSettings` over the shipped

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,85 @@
 # Changelog
 
+## 0.1.24 — 2026-08-15
+
+### Settings: the board can now change what Tyran does
+
+`board --serve --write` turns the dashboard's new **Settings** tab into an
+editor for the two operator-owned files — `.tyran/config.yaml` and
+`.tyran/policies/autonomy.yaml`. Every knob carries a sentence saying what
+turning it actually does, and every policy rule shows its own recorded reason.
+Until now the answer to "where do I change this?" was an editor and a memory
+of what each key meant.
+
+**Writes are off by default and per-invocation.** Without `--write` the tab
+renders with every control disabled and the command that turns it on. A board
+someone left running is reachable by anything on the machine, and the
+difference between reading that and editing the autonomy policy through it is
+the difference the flag exists to make.
+
+**One line moves, and the comments stay.** The plan of record said the
+comments were expendable because the screen could carry the explanations. That
+turned out not to be necessary: `scripts/yaml-patch.mjs` rewrites the line
+that owns a value rather than round-tripping the document through a
+serializer, so `templates/config.yaml` keeps all 60 of its comment lines — the
+only place anyone is told that bare `off` is the YAML boolean false, which is
+also the value that would have silently changed meaning had this been done the
+obvious way.
+
+**The edit is proved, not trusted.** Every patch is applied, parsed back, and
+compared against the document that was intended: the target holds the new
+value and every other path holds exactly what it held before. Then the whole
+result goes through the same `validateConfig` / `validatePolicy` that
+`schema.mjs validate` runs. A locator bug cannot ship a wrong file — it can
+only fail loudly, and a refused write leaves the file byte-identical.
+
+### Loosening a boundary is not the same click as tightening one
+
+Found by an independent review of the above, before it shipped, and it was
+worse than the review guessed. `validatePolicy` defends exactly two globs —
+`hooks/**` and `.tyran/policies/**` — so the first version of this screen
+would take `.claude/settings.json` from KERNEL to AUTO in one press, on a rule
+whose own stated reason is *"anything that can edit it can switch every gate
+off"*. So would `.tyran/STOP` (*"a loop that can clear its own stop signal has
+none"*), and so would the policy `default`, and `autonomy: P1 → P3` sat in an
+ordinary dropdown next to the cost profile.
+
+Loosening now takes a second, deliberate act: the first request is refused
+with the rule's own reason quoted back and a confirmation token, and the token
+is **the new value itself** rather than a boolean, so nothing widens a
+boundary by sending a truthy flag beside whatever value it liked. Tightening
+still applies on the first click — friction on making a boundary stricter is
+how you teach someone to stop making boundaries stricter.
+
+What guards the route, stated exactly: the `Host` pin, an `Origin` check and a
+required `application/json` content type close the browser paths. They do not
+stop another process on the machine that can already reach loopback; nothing
+served on localhost does. The flag is the control that matters there, and the
+kernel invariant is what holds even when the flag is on. `docs/board.md` says
+this in those words rather than claiming a sandbox.
+
+### Two things a fresh install could not do
+
+Both found by the same study, both reproduced before being believed.
+
+- **`board --dir .tyran` crashed on a repo that had been set up and never
+  run** — `ENOENT`, naming a temp file nobody had heard of, on the one command
+  the README leads with. `.tyran/state/` is created by the first initiative;
+  `writeAllAtomic` staged into it and never made it.
+- **A scanned config carried no `limits:` block at all**, so the entire
+  Overnight section of the new Settings tab was seven lines of dead text on
+  every fresh install — the editor deliberately refuses to invent keys. It is
+  now written out in full at the shipped defaults, with the feature off, which
+  is the same inert state as omitting it. `doctor`'s `limit-telemetry-missing`
+  could never fire before this either, for the same reason.
+
+### The sandbox has a Settings tab too
+
+`site/scripts/build-sandbox.mjs` runs the real `readSettings` over the shipped
+templates, so the published sample board shows the real defaults, laid out by
+the code an operator's own board runs, read-only and saying which flag would
+make it otherwise.
+
 ## 0.1.23 — 2026-08-15
 
 ### The sandbox Spend tab shows spend

--- a/NOTES-REQUESTS.md
+++ b/NOTES-REQUESTS.md
@@ -30,26 +30,40 @@ Notes before anyone builds this:
   than the routing table promised, which is exactly the property the tier table
   exists to make legible.
 
-## 2. Config editing from the dashboard — DECIDED, not built
+## 2. Config editing from the dashboard — SHIPPED 2026-08-15 (0.1.24)
 
-The operator decided (2026-08-14) that the comments in `.tyran/config.yaml` are
-not worth preserving, because the dashboard can explain what each knob does at
-the point of editing. So **`autonomy` and the whole config may be editable from
-the dashboard**, not only the safe subset I proposed.
+`board --serve --write` → the **Settings** tab. Config *and* the autonomy
+policy, every knob with a sentence of prose. See
+[docs/board.md](docs/board.md#settings).
 
-Also wanted: default agent settings, default models, per-role tier overrides.
+Three of the constraints recorded here were resolved differently than planned,
+and the difference is worth keeping:
 
-Constraints that still hold:
+- **Comments are preserved after all.** The operator accepted losing them; it
+  turned out not to be necessary. `scripts/yaml-patch.mjs` edits the LINE, not
+  the document, and proves the result by re-parsing and comparing. So the file
+  keeps the 60 comment lines that are the only place anyone is told that bare
+  `off` is the YAML boolean false — and the screen carries the prose too.
+- **`.tyran/policies/**` is editable, and its own protection is not.** Keeping
+  the policy file out entirely would have removed the most useful thing on the
+  screen (tightening `.tyran/config.yaml` back to GATED is the case the
+  template's own comment invites). What stays out is the ability to lower
+  `hooks/**` or `.tyran/policies/**` — refused by name and again by
+  `validatePolicy`.
+- **No journal event.** A config change is repo-wide and journals are
+  per-initiative, so there is no correct journal to append to. The record is
+  the terminal line the server prints plus `git diff`, which is where a
+  reviewer looks anyway.
 
-- `yaml-lite` does not round-trip comments. Writing the file from a form
-  deletes every comment in it. The operator accepts this; the dashboard must
-  therefore carry the explanations the file used to carry.
-- The write route needs the same treatment as `POST /answer`: `Host` pin
-  (already there), an `Origin` check, and the initiative/field validated against
-  a known list rather than trusted from the request body.
-- `.tyran/policies/**` is KERNEL and must stay out of this. Editing `autonomy`
-  in `config.yaml` is a privilege change; it should be visible in the journal
-  as a `decision` event, not just a silent file write.
+What was ADDED beyond the request, because a review found the gap: loosening
+any class, or raising `autonomy`, takes a second deliberate confirmation
+naming the exact new value. Without it, `.claude/settings.json` — whose own
+reason reads "anything that can edit it can switch every gate off" — was one
+click from AUTO.
+
+Still not built from this item: **default agent settings, default models per
+role, per-role tier overrides.** The four `tiers:` are editable; a per-role
+override table is not, and there is no such key in the schema yet.
 
 ## 3. One dashboard per repo — NOT BUILT
 
@@ -112,3 +126,90 @@ folded and dropped.
 produce short explainer videos and GIFs. I have **not** evaluated the tool and
 should not pretend otherwise. The README GIF (`assets/board-demo.gif`) is
 recorded from the real board and covers the immediate need.
+
+## 7. Feature plan from the munder-difflin study, 2026-08-15
+
+Researched at the operator's request: [munderdiffl.in](https://munderdiffl.in/#how)
+and [chaitanyagiri/munder-difflin](https://github.com/chaitanyagiri/munder-difflin)
+(v0.4.3, MIT). An Electron desktop app that wraps ten agent CLIs as a "hive":
+a GOD orchestrator prompt routing work through atomic-file mailboxes, a
+markdown-first semantic memory, per-agent git worktrees, a Pixi.js office
+floor, and a Command Center with kanban, fleet, budgets and a Monaco IDE.
+Read in full: the repo's `hive.ts` / `hooks.ts` / `config.ts` / renderer, plus
+eighteen of its blog posts.
+
+**What does not transfer, and why:** almost all of its surface is a
+consequence of being an Electron app with a live main process — a hook socket
+server, in-process timers, PTY streams, SQLite, a rendered office. Tyran is a
+plugin with no process of its own. Its architectural choices we already share
+(append-only log, atomic rename, identity from the path, hooks that exit 0)
+are convergent rather than borrowable.
+
+Four lenses proposed 27 ideas against the real code; a synthesis pass verified
+each against the repo and killed thirteen. Two of the survivors were shipped
+immediately because they were defects rather than features, both found by
+this study and both confirmed by reproduction:
+
+- the Settings tab would lower `.claude/settings.json`, `.tyran/STOP` and the
+  policy `default` in one click — now behind a confirmation (0.1.24);
+- `board.mjs --dir .tyran` crashed with ENOENT on a repo that had been set up
+  and never run, and a scanned config carried no `limits:` block at all, so
+  the whole Overnight section of the new Settings tab was dead text on every
+  fresh install (0.1.24).
+
+Ranked, still to build:
+
+1. **`/run.json`: is the run supposed to be running?** Three chips reading
+   "6 HOURS since last signal" cover four unrelated situations — an operator
+   `STOP`, an overnight pause waiting on a reset, a dead resume watcher, and
+   genuinely dead agents — and the board distinguishes none of them. Split by
+   doctrine: `.tyran/STOP` is committed repo state so it belongs in
+   `crossBoard()`'s payload; `paused-until.json` / `resume.json` / `usage.json`
+   are machine-local and gitignored, so they must be SERVED, on the same
+   argument `cost.json` already makes. `scheduleDecision`, `watcherAlive` and
+   `humanWait` are already exported from `scripts/overnight.mjs`. **M.**
+2. **Blast radius on the waiting-on-you queue.** Asks sort by age alone, so
+   the question holding up six tickets sits below the one holding up nothing.
+   `deps[]` is resolved forward in `boardOf` and never reversed. Build the
+   reverse index, walk it transitively, sort by it in both `crossBoard()` and
+   `answer.mjs renderSheet` — one queue, two renderings. Guard: `deps` is
+   optional, and "blocks 0" everywhere is an absence rendered as a
+   measurement. **M.**
+3. **Signal is not evidence.** Agent freshness comes from `progressByAgent`,
+   which is the agent's own self-report: an agent emitting `working` every few
+   minutes while achieving nothing is the healthiest-looking chip on the
+   board. Keep a second map fed only by events another party produced
+   (`report`, `review`, `merge`, `finding`, `lease.acquired` — not `gate`,
+   which is conductor-written), show both ages. **M.**
+4. **A ticketless `error` event is invisible.** `fold()` collects
+   `state.errors`; `crossBoard()` carries neither it nor
+   `unknownErrorTickets`, so an agent logging a hard error shows nothing on the
+   board that exists to say "not all is well". Needs a NEW key — `errors` in
+   the board payload already means "this journal was unreadable", and one key
+   with two meanings is the ADR-21 defect by name. **S.**
+5. **Cards say how long they have stood still.** `boardOf()` already puts
+   `since` on every card and the page never renders it. Client-side only. **S.**
+6. **Escalate the tier on a failed attempt.** A ticket that comes back
+   `changes-requested` is re-spawned at the same tier and fails the same way,
+   because the escalation rule lives in the conductor's memory — which iron
+   rule 7 already names the least reliable store in the system. `tiers.mjs`
+   gains `--journal --ticket`, counts prior failed attempts, shifts up the
+   order with a ceiling. Note the honest weakness: "failed attempt" would be a
+   regex over verdict strings, and `APPROVING_RE` was written for lane
+   assignment, not for spend decisions. **S.**
+
+Rejected with reasons, so nobody re-proposes them: a rolling `recent[]` event
+feed inside the byte-compared `board.json` (unbounded growth in a committed
+artefact); spend bucketed by hour (bumps the incremental cache schema that
+makes the 30-second refresh affordable); a nonce on the write route (the
+`application/json` requirement already forces a preflight the server answers
+for no origin — the insider path is not a header's problem); journalling a
+`decision` per settings write (no correct per-initiative journal exists for a
+repo-wide file); a `missions:` scheduler (a new subsystem contending for the
+2 KB session-start budget); making `/tyran:hello` a second spelling of
+`doctor`; and bending the 64-initiative ceiling before anyone has crossed it —
+the measured install is at 31.
+
+One piece of dead weight the study found on the way: `budget:` in
+`scripts/schema.mjs`'s `known` list is validated, documented by its own
+validation, and read by nothing. It should be deleted.

--- a/README.md
+++ b/README.md
@@ -184,10 +184,15 @@ npx @jjanczur/tyran board --dir .tyran --serve
 ```
 
 It prints `board: serving http://127.0.0.1:4173/` — **open that URL.** The
-board is read-only, bound to loopback, re-rendered on every request, and it
-reloads itself every 30 seconds; `--port <n>` if 4173 is taken, `Ctrl-C` to
-stop. That command is the one place a Node version matters, because `npx` runs
-the scripts outside Claude Code and they need **Node ≥ 22**.
+board is bound to loopback, re-rendered on every request, and it reloads itself
+every 30 seconds; `--port <n>` if 4173 is taken, `Ctrl-C` to stop. That command
+is the one place a Node version matters, because `npx` runs the scripts outside
+Claude Code and they need **Node ≥ 22**.
+
+Add `--write` and the **Settings** tab becomes an editor for `.tyran/config.yaml`
+and the autonomy policy — every knob with a sentence explaining it, your
+comments kept, and loosening a boundary behind a second deliberate press. It is
+read-only without that flag.
 
 No terminal, no server: the same page is written to **`.tyran/state/board.html`**
 after every agent, so you can just open the file —

--- a/docs/board.md
+++ b/docs/board.md
@@ -266,9 +266,9 @@ What it edits, with a sentence of prose on every knob:
 **One line moves.** The file is not round-tripped through a serializer —
 `scripts/yaml-patch.mjs` finds the line that owns the value and rewrites that
 line, keeping its trailing comment, the blank lines, the key order and your
-own spacing. `templates/config.yaml` is 60 lines of comment out of 91, and
-those comments are the only place anyone is told that bare `off` is the YAML
-boolean false; a serializer round-trip would delete all of it silently the
+own spacing. `templates/config.yaml` is 63 comment lines out of 90, and those
+comments are the only place anyone is told that bare `off` is the YAML boolean
+false; a serializer round-trip would delete all of it silently the
 first time someone moved a control.
 
 **The edit is proved, not trusted.** Every patch is applied and then parsed

--- a/docs/board.md
+++ b/docs/board.md
@@ -117,8 +117,9 @@ It prints `board: serving http://127.0.0.1:4173/`. Open that. The board
 re-renders on every request, so a reload is always current, and the page
 reloads itself every 30 seconds anyway. `--port <n>` if 4173 is taken.
 `Ctrl-C` stops it. It binds loopback only and pins the `Host` header, so
-nothing outside your machine can reach it — and it is read-only: the server
-answers three URLs and derives a filesystem path from none of them.
+nothing outside your machine can reach it, and it derives a filesystem path
+from no URL at all. It is read-only unless you add `--write`, which turns on
+the [Settings](#settings) tab and nothing else.
 
 **Open the file** — no server, no spend:
 
@@ -129,17 +130,18 @@ start .tyran\state\board.html         # Windows
 ```
 
 That file is regenerated after every agent and at every merge, so it is a
-real answer, not a stale one. It carries everything except the Spend tab,
-which is fetched rather than embedded — see [Spend](#spend) for why. Over
-`file://` the tab is empty and says nothing is wrong; over the server, a
-spend failure now says which failure it was.
+real answer, not a stale one. It carries everything except **Spend** and
+**Settings**, which are fetched rather than embedded — see [Spend](#spend)
+for why, and the same reasoning covers config. Over `file://` both tabs say
+where their data comes from rather than rendering an empty panel; over the
+server, a failure says which failure it was.
 
 Inside a session you never type either command: **`/tyran:status` regenerates
 the board and tells you where it is.** The three commands are the same board
 from three directions — `--serve` for a browser you keep open, the file for a
 quick look, `BOARD.md` for reading in the terminal or in a diff.
 
-## board.html, in four tabs
+## board.html, in five tabs
 
 The page an operator leaves open overnight: self-contained (inline CSS/JS,
 zero external hosts and zero CDNs, complete over `file://`; the one
@@ -158,6 +160,7 @@ and the page opens on Overview:
 | **Board** | where every ticket is — the lanes, and the detail of whichever card you select |
 | **Waiting on you** | what is blocked on a decision, and the commands that unblock it |
 | **Spend** | what the work has cost |
+| **Settings** | what Tyran is configured to do, and — with `--write` — how to change it |
 
 The queue's tab label carries its open count, because the operator is usually
 looking at one of the other three, and a question they cannot see is a
@@ -194,10 +197,13 @@ client builds DOM with `createElement`/`textContent` only.
 node scripts/board.mjs --dir .tyran            # render all three artefacts
 node scripts/board.mjs --dir .tyran --check    # byte-exact drift check, exit 1
 node scripts/board.mjs --dir .tyran --serve    # localhost viewer, always fresh
+node scripts/board.mjs --dir .tyran --serve --write   # ... and Settings can edit
 ```
 
 `--serve` binds `127.0.0.1` only, re-renders per request, and never derives a
-filesystem path from a URL. The initiative ceiling is 64, refused loudly —
+filesystem path from a URL; `--write` adds the [Settings](#settings) routes and
+nothing else, and refuses on its own (`--write` without `--serve` is a usage
+error, not a silent no-op). The initiative ceiling is 64, refused loudly —
 archive closed initiatives rather than boarding them. An unreadable journal
 renders as a visible **UNREADABLE** entry: a board that omits a broken
 initiative would read as "all is well" exactly when it is not.
@@ -231,6 +237,92 @@ one same-origin request to loopback, and the same defences cover it: the
 `--serve` (a foreign `Host` gets 403, verified), and a cost read that fails
 returns 503 rather than taking the board down — the board answers "what is
 going on", and that answer does not depend on knowing what it cost.
+
+## Settings
+
+The **Settings** tab is the only thing on this page that writes. Everything
+else is a projection of the journal, where hand-editing is drift; config and
+the autonomy policy are the opposite — operator-owned files that nothing
+generates, and until this tab existed the only way to change them was an
+editor and a memory of what each key meant.
+
+```bash
+npx @jjanczur/tyran board --dir .tyran --serve --write
+```
+
+Without `--write` the tab still renders, every control disabled, with the
+command that turns it on. **Writes are off by default and per-invocation**:
+a board left running is reachable by anything on the machine, and the
+difference between reading that and editing the autonomy policy through it is
+the difference this flag exists to make.
+
+What it edits, with a sentence of prose on every knob:
+
+| | |
+|---|---|
+| `.tyran/config.yaml` | cost profile · deployment autonomy · the four model tiers · validation commands · shared zones · the whole `limits:` block |
+| `.tyran/policies/autonomy.yaml` | the `default` class, and the class of any existing rule |
+
+**One line moves.** The file is not round-tripped through a serializer —
+`scripts/yaml-patch.mjs` finds the line that owns the value and rewrites that
+line, keeping its trailing comment, the blank lines, the key order and your
+own spacing. `templates/config.yaml` is 60 lines of comment out of 91, and
+those comments are the only place anyone is told that bare `off` is the YAML
+boolean false; a serializer round-trip would delete all of it silently the
+first time someone moved a control.
+
+**The edit is proved, not trusted.** Every patch is applied and then parsed
+back and compared to the document that was intended: the target holds the new
+value, and every other path holds exactly what it held before. Then the result
+goes through the same `validateConfig` / `validatePolicy` that
+`node scripts/schema.mjs validate` runs. If either check fails, nothing is
+written and the page says why. A refused change leaves the file byte-identical.
+
+**The boundary still protects itself.** `hooks/**` and `.tyran/policies/**`
+are rendered as locked KERNEL rows with no control at all, and the write route
+refuses them twice over — once by name, and once because `validatePolicy`
+rejects any policy in which a kernel path resolves below KERNEL, however the
+rule is spelled. A screen that could lower the class of its own enforcement
+would be the way around the gate rather than the way to configure it.
+
+**Loosening takes a second, deliberate act. Tightening does not.** Those two
+protected globs are the only ones the validator defends, and the shipped
+policy carries several more whose own stated reason is that they must not
+move — `.claude/settings.json` ("anything that can edit it can switch every
+gate off"), `.tyran/STOP` ("a loop that can clear its own stop signal has
+none"). A dropdown treats those like any other choice, so:
+
+- **moving a class toward AUTO**, or **raising `autonomy`** (P1 → P2 → P3), is
+  refused on the first request. The refusal quotes the rule's own `reason:`
+  and names a confirmation token; the page turns that into one extra
+  **Yes — loosen it** press, and the second request carries the token.
+- the token is the **new value itself**, not a boolean, so nothing can widen a
+  boundary by sending a truthy flag beside whatever value it liked.
+- **tightening applies on the first click**, exactly like every other setting.
+  Friction on making a boundary stricter is how you teach someone to stop
+  making boundaries stricter.
+
+`validation:` is not in that set, deliberately. It is a list of shell commands
+and it looks like it belongs — but `.tyran/config.yaml` is class AUTO in the
+shipped policy, so an agent can already edit it directly. A confirmation on
+the page would add friction without adding a boundary; tighten that rule
+instead, on the same screen, if the trade is wrong for your repo.
+
+**What it deliberately will not do**: create a key that is not already in the
+file (absent knobs render as "add it by hand once"), author or delete a policy
+rule (a boundary's written `reason` is load-bearing, and a one-line reason
+typed into a form is how a policy turns into a list of unexplained globs), or
+edit `pricing:` (a rate card is a table copied from a vendor's price list).
+
+**What guards the route, stated exactly.** The `Host` pin that covers the whole
+server, plus an `Origin` check and a required `application/json` content type —
+together those close the browser paths: a page on another origin cannot read
+the board, and its POST is preflighted and refused. What they do **not** do is
+stop another process on your machine that can already reach loopback; nothing
+served on localhost can. The flag is the control that matters there, and the
+KERNEL invariant is what holds even if the flag is on. Every write also prints
+a line to the terminal running the server, and lands in `git diff` — those two
+are the audit trail.
 
 ## board.json, schema 1
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -6,6 +6,12 @@ written by `scripts/scan-repo.mjs` · validated by
 All per-repo configuration lives in `.tyran/config.yaml` — committed, human
 reviewable, written by `/tyran:setup` and editable by hand.
 
+**Or from the board.** `npx @jjanczur/tyran board --serve --write` puts every
+key below on a screen with a sentence explaining what it does, and writes your
+change back into this file one line at a time, comments intact — including the
+autonomy policy. See [the Settings tab](board.md#settings) for what it will and
+will not touch, and for why loosening a boundary there takes a second press.
+
 ## `.tyran/config.yaml`
 
 ```yaml

--- a/docs/projections.md
+++ b/docs/projections.md
@@ -1,6 +1,6 @@
 # Projections reference
 
-`scripts/project.mjs` · 68 unit tests, including byte-exact
+`scripts/project.mjs` · 69 unit tests, including byte-exact
 golden files
 
 The journal stays the only source of truth; everything on this page is a

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jjanczur/tyran",
-  "version": "0.1.23",
+  "version": "0.1.24",
   "description": "Command-line scripts for the Tyran task conductor (doctor, journal, schema, and repo tooling) for CI and terminals outside Claude Code. Installing this package does NOT install the Claude Code plugin — add that separately with `/plugin marketplace add jjanczur/tyran` inside Claude Code.",
   "type": "module",
   "engines": {

--- a/scripts/board-html.mjs
+++ b/scripts/board-html.mjs
@@ -52,7 +52,8 @@ const CSS = `
   --hairline:#332e27;--hairline-soft:#26221d;
   --brass:#a8863c;--brass-bright:#cfae63;--brass-low:#221c11;--brass-edge:#5d4c22;
   --steel:#7d9ea9;--steel-bright:#9dbcc6;--steel-low:#17242a;--steel-edge:#3a545d;
-  --clay:#c07a70;--clay-bright:#d9998f;--clay-low:#2a1a18;--sage:#88a06a;
+  --clay:#c07a70;--clay-bright:#d9998f;--clay-low:#2a1a18;--clay-edge:#5a3430;
+  --sage:#88a06a;--sage-bright:#a3ba86;
   --display:ui-serif,'Iowan Old Style','Palatino Linotype',Palatino,'Book Antiqua',Georgia,'Times New Roman',serif;
   --font:ui-sans-serif,system-ui,-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,'Helvetica Neue',Arial,sans-serif;
   --mono:ui-monospace,SFMono-Regular,'SF Mono',Menlo,Consolas,'Liberation Mono',monospace;
@@ -178,6 +179,39 @@ pre.how .c{color:var(--muted)}
 .chartrow.dim .rl{color:var(--muted);font-style:italic}
 .chartrow.dim .rb i{background:var(--hairline)}
 .chartrow .rv{font-family:var(--mono);font-variant-numeric:tabular-nums;color:var(--text);min-width:5.5rem;text-align:right}
+
+/* ---- settings ---- */
+.setnote{border:1px solid var(--hairline);border-left:3px solid var(--steel);border-radius:.4rem;padding:.6rem .8rem;margin:.2rem 0 1.2rem;font-size:.85rem;color:var(--muted);line-height:1.6}
+.setnote.warn{border-left-color:var(--brass)}
+.setnote.bad{border-left-color:var(--clay)}
+.setnote b{color:var(--heading);font-weight:600}
+.setnote code{font-family:var(--mono);font-size:.8rem;color:var(--brass-bright);background:var(--brass-low);padding:.08rem .3rem;border-radius:.25rem}
+.sgroup{margin:0 0 1.6rem}
+.sgroup .blurb{font-size:.85rem;color:var(--muted);line-height:1.6;margin:.15rem 0 .9rem;max-width:60rem}
+.srow{display:grid;grid-template-columns:minmax(10rem,14rem) 1fr;gap:.4rem 1.1rem;padding:.75rem 0;border-top:1px solid var(--hairline);align-items:start}
+.srow .sname{font-weight:600;color:var(--heading);font-size:.88rem;padding-top:.3rem}
+.srow .sname .sunit{font-family:var(--mono);font-weight:400;color:var(--muted);font-size:.76rem}
+.srow .sbody{min-width:0}
+.srow select,.srow input[type="text"],.srow textarea{display:block;font-family:var(--font);font-size:.85rem;background:var(--bg-raised);color:var(--text);border:1px solid var(--hairline);border-radius:.35rem;padding:.3rem .5rem;max-width:32rem;width:100%}
+.srow textarea{font-family:var(--mono);font-size:.8rem;line-height:1.7;min-height:5rem;resize:vertical}
+.srow input[type="number"]{display:block;font-family:var(--mono);font-size:.85rem;background:var(--bg-raised);color:var(--text);border:1px solid var(--hairline);border-radius:.35rem;padding:.3rem .5rem;width:7rem}
+.srow select:focus-visible,.srow input:focus-visible,.srow textarea:focus-visible{outline:2px solid var(--steel);outline-offset:1px}
+.srow select:disabled,.srow input:disabled,.srow textarea:disabled{opacity:.55;cursor:not-allowed}
+.srow .shelp{font-size:.8rem;color:var(--muted);line-height:1.6;margin-top:.35rem;max-width:52rem}
+.srow .schoice{font-size:.8rem;color:var(--text);line-height:1.6;margin-top:.3rem;padding-left:.6rem;border-left:2px solid var(--steel-edge)}
+.sstat{font-family:var(--mono);font-size:.75rem;line-height:1.7;margin-top:.35rem;color:var(--muted);word-break:break-word;white-space:pre-wrap}
+.sstat.ok{color:var(--sage-bright)}
+.sstat.bad{color:var(--clay-bright)}
+.sbtn{font-family:var(--font);font-size:.78rem;font-weight:600;background:var(--brass-low);color:var(--brass-bright);border:1px solid var(--brass-edge);border-radius:.35rem;padding:.26rem .7rem;cursor:pointer;margin-top:.4rem}
+.sbtn:hover:not(:disabled){background:var(--brass-edge)}
+.sbtn:disabled{opacity:.5;cursor:not-allowed}
+.sbtn.danger{background:var(--clay-low);color:var(--clay-bright);border-color:var(--clay-edge);margin-top:.5rem}
+.sbtn.danger:hover:not(:disabled){background:var(--clay-edge);color:var(--heading)}
+.rule{display:grid;grid-template-columns:1fr minmax(7rem,9rem);gap:.3rem .9rem;padding:.6rem 0;border-top:1px solid var(--hairline);align-items:start}
+.rule .glob{font-family:var(--mono);font-size:.82rem;color:var(--heading);word-break:break-all}
+.rule .why{font-size:.78rem;color:var(--muted);line-height:1.6;grid-column:1;max-width:52rem}
+.rule .lock{font-family:var(--mono);font-size:.72rem;color:var(--clay-bright);border:1px solid var(--clay-edge);background:var(--clay-low);border-radius:.3rem;padding:.16rem .4rem;text-align:center;align-self:start}
+.rule .sstat{grid-column:1 / -1}
 .caveat{color:var(--muted);font-size:.76rem;margin-top:.5rem;max-width:52rem}
 footer{margin-top:2rem;color:var(--muted);font-size:.72rem;border-top:1px solid var(--hairline-soft);padding-top:.6rem}
 `;
@@ -301,6 +335,7 @@ if (data.schema !== 1) {
     ['board', 'Board', null],
     ['questions', 'Waiting on you', asks.length],
     ['spend', 'Spend', null],
+    ['settings', 'Settings', null],
   ];
   var select = function (key) {
     for (var i = 0; i < TABS.length; i += 1) {
@@ -778,6 +813,290 @@ if (data.schema !== 1) {
         showCostFailure('Spend could not be read: the board server did not answer. It is served, never embedded — start it with: npx @jjanczur/tyran board --dir .tyran --serve');
       });
   }
+
+  // ---- settings ---------------------------------------------------------
+  //
+  // The one tab that writes. Everything else on this page is a projection of
+  // the journal and hand-editing it would be drift; config and the autonomy
+  // policy are the opposite — operator-owned files that nothing generates, and
+  // the only place they could be changed until now was an editor and a memory
+  // of what each key meant.
+  //
+  // Served, never embedded, exactly like spend: these are not journal state,
+  // so writing them into board.json would break the byte-exact check and make
+  // two clones of one journal disagree.
+  var st = panels.settings;
+  var stBody = el('div');
+  st.appendChild(stBody);
+  stBody.appendChild(el('div', 'setnote', 'Settings are read from .tyran/config.yaml and .tyran/policies/autonomy.yaml, and they are served rather than embedded — open this board with "board.mjs --serve" to see them.'));
+
+  // A meta refresh and a form are incompatible: half a typed model name would
+  // vanish every thirty seconds. The tag stays in the HTML (a page whose JS
+  // never runs still refreshes, and the docs sandbox strips the tag to stop
+  // itself reloading), but at boot it is swapped for a timer that can be
+  // paused — and the Settings tab pauses it. Present tag, same 30 seconds;
+  // absent tag, no timer at all, which is what the sandbox wants.
+  var refreshTag = document.querySelector('meta[http-equiv="refresh"]');
+  var refreshTimer = null;
+  var armRefresh = function () {
+    if (refreshTag === null || refreshTimer !== null) return;
+    refreshTimer = setTimeout(function () { location.reload(); }, 30000);
+  };
+  var holdRefresh = function () {
+    if (refreshTimer !== null) { clearTimeout(refreshTimer); refreshTimer = null; }
+  };
+  if (refreshTag !== null && refreshTag.parentNode) {
+    refreshTag.parentNode.removeChild(refreshTag);
+    armRefresh();
+  }
+
+  var post = function (route, body, status, onDone) {
+    status.className = 'sstat';
+    status.textContent = 'saving\\u2026';
+    fetch(route, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify(body)
+    }).then(function (r) {
+      return r.json().then(function (payload) { return { ok: r.ok, payload: payload }; });
+    }).then(function (result) {
+      var payload = result.payload || {};
+      if (!result.ok || payload.ok !== true) {
+        status.className = 'sstat bad';
+        status.textContent = show(payload.error || 'the change was refused');
+        // A refusal the operator can answer, rather than one they can only
+        // read. The server sends back the exact token that answers it, and
+        // pressing this re-sends the same change carrying that token — which
+        // is why nothing here decides what "confirmed" means.
+        if (payload.widens === true && typeof payload.confirm_with === 'string') {
+          var go = el('button', 'sbtn danger', 'Yes \\u2014 loosen it');
+          go.setAttribute('type', 'button');
+          go.addEventListener('click', function () {
+            var again = {};
+            Object.keys(body).forEach(function (k) { again[k] = body[k]; });
+            again.confirm = payload.confirm_with;
+            post(route, again, status, onDone);
+          });
+          status.appendChild(document.createElement('br'));
+          status.appendChild(go);
+        }
+        if (onDone) onDone(false);
+        return;
+      }
+      status.className = 'sstat ok';
+      status.textContent = show('saved \\u2014 ' + JSON.stringify(payload.before) + ' \\u2192 ' + JSON.stringify(payload.after));
+      if (onDone) onDone(true);
+    }).catch(function () {
+      status.className = 'sstat bad';
+      status.textContent = 'the board server did not answer \\u2014 nothing was written';
+      if (onDone) onDone(false);
+    });
+  };
+
+  var settingRow = function (setting, writable) {
+    var row = el('div', 'srow');
+    var name = el('div', 'sname', setting.label);
+    if (setting.unit) name.appendChild(el('span', 'sunit', ' ' + setting.unit));
+    row.appendChild(name);
+    var bodyCell = el('div', 'sbody');
+    row.appendChild(bodyCell);
+
+    var status = el('div', 'sstat');
+    var choiceNote = null;
+    var control = null;
+
+    if (setting.present !== true) {
+      // Absent is not the same as unset, and saying so beats an empty box: a
+      // key that is not in the file has no line for the patcher to edit, and
+      // inventing one means choosing where it goes and what comment explains
+      // it. That is authoring, and it stays a hand edit.
+      bodyCell.appendChild(el('div', 'shelp', 'Not set in this config. Add the key by hand once and it becomes editable here.'));
+      bodyCell.appendChild(el('div', 'shelp', setting.help));
+      return row;
+    }
+
+    if (setting.kind === 'choice') {
+      control = el('select');
+      setting.choices.forEach(function (c) {
+        var option = el('option', null, c.value);
+        option.value = c.value;
+        if (c.value === setting.value) option.selected = true;
+        control.appendChild(option);
+      });
+      choiceNote = el('div', 'schoice');
+      var describe = function () {
+        var picked = setting.choices.filter(function (c) { return c.value === control.value; })[0];
+        choiceNote.textContent = show(picked ? picked.describe : '');
+      };
+      describe();
+      control.addEventListener('change', function () {
+        describe();
+        post('/settings/config', { id: setting.id, value: control.value }, status);
+      });
+    } else if (setting.kind === 'boolean') {
+      control = el('select');
+      [['false', 'off'], ['true', 'on']].forEach(function (pair) {
+        var option = el('option', null, pair[1]);
+        option.value = pair[0];
+        if ((pair[0] === 'true') === (setting.value === true)) option.selected = true;
+        control.appendChild(option);
+      });
+      control.addEventListener('change', function () {
+        post('/settings/config', { id: setting.id, value: control.value === 'true' }, status);
+      });
+    } else if (setting.kind === 'number') {
+      control = el('input');
+      control.type = 'number';
+      control.value = String(setting.value);
+      if (setting.min !== null) control.min = String(setting.min);
+      if (setting.max !== null) control.max = String(setting.max);
+      control.addEventListener('change', function () {
+        post('/settings/config', { id: setting.id, value: Number(control.value) }, status);
+      });
+    } else if (setting.kind === 'list') {
+      control = el('textarea');
+      control.value = (setting.value || []).join('\\n');
+      if (setting.placeholder) control.placeholder = setting.placeholder + '\\n(one per line)';
+    } else {
+      control = el('input');
+      control.type = 'text';
+      control.value = String(setting.value === null ? '' : setting.value);
+      if (setting.placeholder) control.placeholder = setting.placeholder;
+    }
+
+    control.disabled = !writable;
+    bodyCell.appendChild(control);
+
+    // Discrete controls save the moment they change; free text does not,
+    // because there is no moment during typing that is the whole value.
+    if (setting.kind === 'list' || setting.kind === 'text') {
+      var save = el('button', 'sbtn', 'Save');
+      save.setAttribute('type', 'button');
+      save.disabled = !writable;
+      control.addEventListener('input', holdRefresh);
+      save.addEventListener('click', function () {
+        var value = setting.kind === 'list'
+          ? control.value.split('\\n').map(function (line) { return line.trim(); }).filter(function (line) { return line !== ''; })
+          : control.value;
+        post('/settings/config', { id: setting.id, value: value }, status, function (ok) { if (ok) armRefresh(); });
+      });
+      bodyCell.appendChild(save);
+    }
+
+    if (choiceNote) bodyCell.appendChild(choiceNote);
+    bodyCell.appendChild(el('div', 'shelp', setting.help));
+    bodyCell.appendChild(status);
+    return row;
+  };
+
+  // The address is what the write route is told to change, and it is NOT the
+  // label: the file's own default key is addressed as null, while a rule is
+  // addressed by its path glob. By glob and not by position, so that a file
+  // edited underneath an open page cannot land the write on a neighbouring
+  // boundary — the server re-resolves the glob against the file as it is now.
+  var ruleRow = function (rule, classes, describe, writable, address) {
+    var row = el('div', 'rule');
+    row.appendChild(el('div', 'glob', rule.path));
+    var status = el('div', 'sstat');
+    if (rule.locked) {
+      var lock = el('div', 'lock', rule.class + ' \\u00b7 locked');
+      lock.title = 'This path protects the gate itself and cannot be lowered.';
+      row.appendChild(lock);
+    } else {
+      var pick = el('select');
+      classes.forEach(function (klass) {
+        var option = el('option', null, klass);
+        option.value = klass;
+        if (klass === rule.class) option.selected = true;
+        pick.appendChild(option);
+      });
+      pick.disabled = !writable;
+      pick.addEventListener('change', function () {
+        post('/settings/policy', { path: address, class: pick.value }, status);
+      });
+      row.appendChild(pick);
+    }
+    if (rule.reason) row.appendChild(el('div', 'why', rule.reason));
+    else if (rule.locked) row.appendChild(el('div', 'why', describe[rule.class] || ''));
+    row.appendChild(status);
+    return row;
+  };
+
+  var renderSettings = function (payload) {
+    clear(stBody);
+    var writable = payload.writable === true;
+    var note = el('div', writable ? 'setnote' : 'setnote warn');
+    if (writable) {
+      note.appendChild(el('b', null, 'Changes are written straight to disk.'));
+      note.appendChild(el('span', null,
+        ' Comments in these files are kept; the value on one line is all that moves, and every write is checked by the same validator "tyran doctor" runs before it lands. Nothing is written if the result would be invalid. Review what changed with git diff.'));
+    } else {
+      note.appendChild(el('b', null, 'Read-only.'));
+      note.appendChild(el('span', null, ' This board was started without editing. To turn these controls on, restart it with: '));
+      note.appendChild(el('code', null, 'npx @jjanczur/tyran board --dir .tyran --serve --write'));
+    }
+    stBody.appendChild(note);
+
+    [['config', payload.files.config], ['policy', payload.files.policy]].forEach(function (pair) {
+      if (pair[1].present && pair[1].error === null) return;
+      var bad = el('div', 'setnote bad');
+      bad.appendChild(el('b', null, pair[1].present ? 'This file does not parse: ' : 'This file is missing: '));
+      bad.appendChild(el('span', null, pair[1].path + (pair[1].error ? ' \\u2014 ' + pair[1].error : '')));
+      stBody.appendChild(bad);
+    });
+
+    payload.groups.forEach(function (group) {
+      var box = el('div', 'sgroup');
+      box.appendChild(el('h2', null, group.title));
+      box.appendChild(el('div', 'blurb', group.blurb));
+      group.settings.forEach(function (setting) { box.appendChild(settingRow(setting, writable)); });
+      stBody.appendChild(box);
+    });
+
+    var policy = payload.policy || {};
+    var pol = el('div', 'sgroup');
+    pol.appendChild(el('h2', null, 'Autonomy policy'));
+    pol.appendChild(el('div', 'blurb',
+      'Which paths agents may write on their own. The most specific matching rule wins, and a path no rule matches gets the default. ' +
+      (policy.classes || []).map(function (k) { return k + ' \\u2014 ' + (policy.describe || {})[k]; }).join('  \\u00b7  ')));
+    if (policy.default !== null && policy.default !== undefined) {
+      pol.appendChild(ruleRow(
+        { path: 'default \\u2014 everything no rule matches', class: policy.default, reason: 'GATED is the safe answer: it means "ask me".', locked: false },
+        policy.classes || [], policy.describe || {}, writable, null));
+    }
+    (policy.rules || []).forEach(function (rule) {
+      pol.appendChild(ruleRow(rule, policy.classes || [], policy.describe || {}, writable, rule.path));
+    });
+    stBody.appendChild(pol);
+  };
+
+  // Leaving this tab re-arms the refresh, entering it stops it. A page that
+  // reloads under an open select is a page that loses the change you were
+  // halfway through making, and the board has three other tabs that want to
+  // stay live.
+  Object.keys(buttons).forEach(function (key) {
+    buttons[key].addEventListener('click', function () {
+      if (key === 'settings') holdRefresh(); else armRefresh();
+    });
+  });
+
+  fetch('settings.json', { headers: { accept: 'application/json' } })
+    .then(function (r) { return r.ok ? r.json() : Promise.reject(new Error(String(r.status))); })
+    .then(function (payload) {
+      if (payload.schema !== 1) {
+        clear(stBody);
+        stBody.appendChild(el('div', 'setnote bad', 'Settings were served in a format this page does not know (schema ' +
+          (payload.schema || 'absent') + ') \\u2014 regenerate the board with the Tyran that served it.'));
+        return;
+      }
+      renderSettings(payload);
+    })
+    .catch(function () {
+      if (String(location.protocol) === 'file:') return;
+      clear(stBody);
+      stBody.appendChild(el('div', 'setnote bad',
+        'Settings could not be read: the board server did not answer. They are served, never embedded \\u2014 start it with: npx @jjanczur/tyran board --dir .tyran --serve --write'));
+    });
 
   select('overview');
 

--- a/scripts/board-html.mjs
+++ b/scripts/board-html.mjs
@@ -1089,7 +1089,18 @@ if (data.schema !== 1) {
           (payload.schema || 'absent') + ') \\u2014 regenerate the board with the Tyran that served it.'));
         return;
       }
-      renderSettings(payload);
+      // A failure INSIDE the renderer is not a failure to reach the server,
+      // and reporting it as one sends the operator to restart something that
+      // was answering perfectly well. Caught here so the outer handler keeps
+      // its one meaning: the fetch did not land.
+      try {
+        renderSettings(payload);
+      } catch (err) {
+        clear(stBody);
+        stBody.appendChild(el('div', 'setnote bad',
+          'Settings were served but this page could not draw them: ' + show(String((err && err.message) || err)) +
+          ' \\u2014 the board and the Tyran that served it are probably different versions.'));
+      }
     })
     .catch(function () {
       if (String(location.protocol) === 'file:') return;

--- a/scripts/board.mjs
+++ b/scripts/board.mjs
@@ -20,7 +20,7 @@
  * initiative reads as "all is well" exactly when it is not.
  *
  * CLI:
- *   node board.mjs [--dir <.tyran>] [--check] [--serve [--port <n>]]
+ *   node board.mjs [--dir <.tyran>] [--check] [--serve [--port <n>] [--write]]
  * Exit: 0 ok · 1 drift (--check) · 2 usage/IO
  */
 import { existsSync, readdirSync, statSync, readFileSync } from 'node:fs';
@@ -39,10 +39,12 @@ import {
   inline,
   warnings,
   writeAllAtomic,
+  writeAtomic,
 } from './project.mjs';
 import { jsonEscapeInvisible } from './invisible.mjs';
 import { renderBoardError, renderBoardHtml } from './board-html.mjs';
 import { COST_SCHEMA, costJson, costReport } from './cost.mjs';
+import { SettingsError, applyPolicyClass, applySetting, readSettings } from './settings.mjs';
 
 export const BOARD_HTML_FILE = 'board.html';
 
@@ -136,8 +138,10 @@ export function readInitiativeBoards(tyranDir) {
  * rather than embedded. Relative is also the more useful form — it is what
  * the reader pastes, from the repo root, into an editor.
  *
- * Nothing is served: `--serve` routes three URLs and derives a filesystem
- * path from none of them, which is worth more than a clickable link.
+ * Nothing is served from here: `--serve` derives a filesystem path from no
+ * URL at all, which is worth more than a clickable link. The one route that
+ * writes — Settings, behind `--write` — reaches two fixed files named in
+ * `settings.mjs` and takes a KEY from the request, never a path.
  */
 export const INITIATIVE_FILES = Object.freeze(['PLAN.md', 'NOTES.md', 'RETRO.md', 'STATE.md', 'PROGRESS.md']);
 
@@ -289,13 +293,116 @@ export function renderAll(tyranDir) {
   };
 }
 
+// ------------------------------------------------------- the write channel
+
+/** A request body big enough for any setting and small enough to ignore. */
+const MAX_BODY_BYTES = 64 * 1024;
+
+/**
+ * Read a JSON request body, or reject it.
+ *
+ * Three refusals, all deliberate. A body over the cap is dropped rather than
+ * buffered, because this server has no reason to hold a megabyte of anything.
+ * A body that is not `application/json` is refused BEFORE it is read — that
+ * content type is what forces a browser to preflight a cross-origin POST, and
+ * accepting `text/plain` here would hand back the exact hole the preflight
+ * closes. And anything that is not a JSON object is refused, so a handler
+ * never reasons about a string that happens to have a `.value`.
+ */
+function readJsonBody(req) {
+  return new Promise((resolve_, reject) => {
+    const type = String(req.headers['content-type'] ?? '').split(';')[0].trim().toLowerCase();
+    if (type !== 'application/json') {
+      reject(new SettingsError('this route takes application/json'));
+      return;
+    }
+    let size = 0;
+    const chunks = [];
+    req.on('data', (chunk) => {
+      size += chunk.length;
+      if (size > MAX_BODY_BYTES) {
+        reject(new SettingsError('request body is too large'));
+        req.destroy();
+        return;
+      }
+      chunks.push(chunk);
+    });
+    req.on('error', (err) => reject(err));
+    req.on('end', () => {
+      let parsed;
+      try {
+        parsed = JSON.parse(Buffer.concat(chunks).toString('utf8'));
+      } catch {
+        reject(new SettingsError('request body is not JSON'));
+        return;
+      }
+      if (parsed === null || typeof parsed !== 'object' || Array.isArray(parsed)) {
+        reject(new SettingsError('request body must be a JSON object'));
+        return;
+      }
+      resolve_(parsed);
+    });
+  });
+}
+
+/**
+ * `Origin`, on top of the `Host` pin the whole server already carries.
+ *
+ * The two answer different questions and neither covers the other. `Host` says
+ * which name the client dialled, which stops DNS rebinding. `Origin` says
+ * which page is asking, which is the only thing that distinguishes the board's
+ * own fetch from a POST issued by some other tab the operator has open. A
+ * request with no `Origin` at all is allowed: that is `curl`, and a local
+ * process that can reach loopback needs no browser's help — see the honest
+ * statement of what this does and does not defend in `docs/board.md`.
+ */
+function originAllowed(req) {
+  const origin = req.headers.origin;
+  if (origin === undefined || origin === 'null') return true;
+  try {
+    const { hostname } = new URL(String(origin));
+    return hostname === '127.0.0.1' || hostname === 'localhost' || hostname === '[::1]' || hostname === '::1';
+  } catch {
+    return false;
+  }
+}
+
+const sendJson = (res, status, body) => {
+  res.writeHead(status, { 'content-type': 'application/json; charset=utf-8' });
+  res.end(JSON.stringify(body) + '\n');
+};
+
+/**
+ * Apply one edit and write it, or change nothing and say why.
+ *
+ * The write itself is `writeAtomic` — the same rename-into-place the
+ * projections use — so a config file can never be found half-written, however
+ * the process dies.
+ */
+function handleSettingsWrite(dir, route, body) {
+  // `confirm` is only ever compared for equality against the value the server
+  // itself computed, so a caller cannot widen anything by sending a truthy
+  // flag — it has to name the exact change it is making.
+  const confirm = typeof body.confirm === 'string' ? body.confirm : null;
+  const applied =
+    route === 'config'
+      ? applySetting(dir, String(body.id ?? ''), body.value, confirm)
+      : applyPolicyClass(dir, body.path === null || body.path === undefined ? null : String(body.path), String(body.class ?? ''), confirm);
+  writeAtomic(applied.file, applied.text);
+  // The operator's terminal is the audit trail. A change made from a web page
+  // that left no trace anywhere a person looks is how a settings screen turns
+  // into a thing nobody trusts.
+  console.log(`board: wrote ${applied.file} — ${applied.path.join('.')}: ${JSON.stringify(applied.before)} -> ${JSON.stringify(applied.after)}`);
+  return { ok: true, file: applied.file, path: applied.path, before: applied.before, after: applied.after };
+}
+
 // ------------------------------------------------------------------- CLI
 
-const BOOLEAN_FLAGS = ['check', 'serve'];
+const BOOLEAN_FLAGS = ['check', 'serve', 'write'];
 const VALUE_FLAGS = ['dir', 'port'];
 
 function parseArgs(argv) {
-  const flags = { dir: '.tyran', port: 4173, check: false, serve: false };
+  const flags = { dir: '.tyran', port: 4173, check: false, serve: false, write: false };
   for (let i = 0; i < argv.length; i += 1) {
     const arg = argv[i];
     if (!arg.startsWith('--')) throw new UsageError(`unexpected argument "${arg}"`);
@@ -321,7 +428,11 @@ function main() {
   } catch (err) {
     if (!(err instanceof UsageError)) throw err;
     console.error(`board: ${err.message}`);
-    console.error('usage: board.mjs [--dir <.tyran>] [--check] [--serve [--port <n>]]');
+    console.error('usage: board.mjs [--dir <.tyran>] [--check] [--serve [--port <n>] [--write]]');
+    process.exit(2);
+  }
+  if (flags.write && !flags.serve) {
+    console.error('board: --write only means anything with --serve (it is what the served page may edit)');
     process.exit(2);
   }
   const dir = resolve(flags.dir);
@@ -352,6 +463,55 @@ function main() {
         if (host !== '127.0.0.1' && host !== 'localhost' && host !== '[::1]') {
           res.writeHead(403, { 'content-type': 'text/plain' });
           res.end('forbidden: this board answers to 127.0.0.1 only\n');
+          return;
+        }
+        // ---- settings: the routes that read and write config -----------
+        //
+        // Config is served rather than embedded for the same reason spend is:
+        // it is not journal state, it is not a projection, and writing it into
+        // `board.json` would break the byte-exact `--check` contract. Over
+        // `file://` the fetch fails and the tab says how to open the board
+        // with a server, which is the honest answer.
+        if (req.url === '/settings.json') {
+          sendJson(res, 200, { ...readSettings(dir), writable: flags.write });
+          return;
+        }
+        if (req.url === '/settings/config' || req.url === '/settings/policy') {
+          const route = req.url.slice('/settings/'.length);
+          if (req.method !== 'POST') {
+            sendJson(res, 405, { ok: false, error: 'this route takes POST' });
+            return;
+          }
+          // Writes are OFF unless the operator asked for them on the command
+          // line. A board someone left running is a board that can be reached
+          // by anything on this machine, and the difference between reading
+          // that and editing the autonomy policy through it is the difference
+          // this flag exists to make. The refusal names the flag, because a
+          // 403 an operator cannot act on is just a bug report.
+          if (!flags.write) {
+            sendJson(res, 403, {
+              ok: false,
+              error: 'this board is read-only. Restart it with: npx @jjanczur/tyran board --serve --write',
+            });
+            return;
+          }
+          if (!originAllowed(req)) {
+            sendJson(res, 403, { ok: false, error: 'forbidden: this board answers its own pages only' });
+            return;
+          }
+          readJsonBody(req)
+            .then((body) => sendJson(res, 200, handleSettingsWrite(dir, route, body)))
+            .catch((err) => {
+              const known = err instanceof SettingsError;
+              if (!known) console.error(`board: settings write failed: ${String(err?.message ?? err)}`);
+              sendJson(res, known ? 400 : 500, {
+                ok: false,
+                error: String(err?.message ?? err),
+                // Present only on a refusal the operator can answer, and it
+                // carries the exact token that answers it.
+                ...(err?.widens === true ? { widens: true, confirm_with: err.confirm_with } : {}),
+              });
+            });
           return;
         }
         // Spend is served, never rendered into the artefacts. It is derived
@@ -409,7 +569,10 @@ function main() {
       process.exitCode = 2;
     });
     server.listen(flags.port, '127.0.0.1', () => {
-      console.log(`board: serving http://127.0.0.1:${flags.port}/ (read-only; Ctrl-C to stop)`);
+      console.log(
+        `board: serving http://127.0.0.1:${flags.port}/ ` +
+          `(${flags.write ? 'Settings can edit config.yaml and autonomy.yaml' : 'read-only'}; Ctrl-C to stop)`,
+      );
     });
     return;
   }

--- a/scripts/project.mjs
+++ b/scripts/project.mjs
@@ -1210,6 +1210,13 @@ export function writeAllAtomic(entries) {
   const staged = [];
   try {
     for (const [path, content] of entries) {
+      // The directory may not exist yet, and the first time that matters is
+      // the worst time: `.tyran/state/` is created by the first initiative, so
+      // `board.mjs --dir .tyran` on a freshly set-up repo — the command the
+      // README leads with — died with an ENOENT naming a temp file nobody had
+      // heard of. Staging into a directory is not a decision, it is what
+      // writing a file there means.
+      mkdirSync(dirname(path), { recursive: true });
       const tmp = tempPathFor(path);
       writeFileSync(tmp, content, 'utf8');
       staged.push([tmp, path]);

--- a/scripts/scan-repo.mjs
+++ b/scripts/scan-repo.mjs
@@ -355,6 +355,26 @@ export function scanRepo(dir, { run = gitRunner(dir) } = {}) {
     tiers: { cheap: 'haiku', work: 'sonnet', deep: 'opus', top: 'fable' },
     validation,
     shared_zones: [],
+    // Written out in full, every value at its shipped default, with the
+    // feature OFF. Nothing here enables anything — `mode: 'off'` is the same
+    // inert state as omitting the block entirely.
+    //
+    // The difference is that an absent key cannot be edited. The board's
+    // Settings tab patches values that exist and deliberately refuses to
+    // invent keys (choosing where a key goes and what comment explains it is
+    // authoring, not editing), so a scanned config with no `limits:` rendered
+    // the whole Overnight section as dead text on every fresh install. So did
+    // doctor's `limit-telemetry-missing`, which is conditioned on a mode that
+    // was never written.
+    limits: {
+      mode: 'off',
+      pause_at_percent: 97,
+      weekly_pause_at_percent: 97,
+      wait_max_hours: 5,
+      long_wait: 'hold',
+      resume_margin_minutes: 5,
+      keep_awake: false,
+    },
   };
 
   const questions = [];

--- a/scripts/settings.mjs
+++ b/scripts/settings.mjs
@@ -1,0 +1,542 @@
+#!/usr/bin/env node
+/**
+ * settings — the knobs an operator may turn, and what each one means.
+ *
+ * `.tyran/config.yaml` and `.tyran/policies/autonomy.yaml` were editable in
+ * exactly one way before this file existed: open them in an editor and know
+ * what you are doing. That is fine for the person who wrote them and useless
+ * for everyone else, and the board — the one screen an operator already has
+ * open — could not answer "where do I change this?" at all.
+ *
+ * So this module is the CATALOGUE: every knob, its type, its legal values, and
+ * a sentence of prose saying what turning it actually does. The board renders
+ * it; `applySetting` writes it back through `yaml-patch`, which keeps the
+ * file's comments; `schema.mjs` validates the result before anything lands.
+ *
+ * ## One answer in one place
+ *
+ * The legal values are IMPORTED, never restated: `PROFILES`, `AUTONOMY_CLASSES`,
+ * `TIER_KEYS`, `LIMITS_MODES`, `LIMITS_LONG_WAIT`, `ARTIFACT_CLASSES` all come
+ * from `schema.mjs`, which is the validator. A second list here would drift
+ * from the one that enforces it, and the UI would offer a choice the file
+ * rejects. The prose is the only thing this file owns.
+ *
+ * ## What is deliberately NOT here
+ *
+ * `pricing:` — a rate card is a table of numbers copied from a vendor's price
+ * list, which is a spreadsheet task, not a knob. It stays a hand edit.
+ *
+ * Adding and removing POLICY RULES. A rule is a path glob, a class and a
+ * written reason, and the reason is the load-bearing part: `docs/policy-gate.md`
+ * asks every boundary to say why it exists. Changing an existing rule's class
+ * is a decision the operator can make from a screen; authoring a new boundary
+ * with a one-line reason typed into a web form is how a policy file turns into
+ * a list of unexplained globs. Class changes are here; authoring is not.
+ */
+import { existsSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import {
+  ARTIFACT_CLASSES,
+  AUTONOMY_CLASSES,
+  LIMITS_LONG_WAIT,
+  LIMITS_MODES,
+  MANDATORY_KERNEL_PATHS,
+  PROFILES,
+  TIER_KEYS,
+  validateConfig,
+  validatePolicy,
+} from './schema.mjs';
+import { parse, YamlLiteError } from './yaml-lite.mjs';
+import { patch, YamlPatchError } from './yaml-patch.mjs';
+
+export const SETTINGS_SCHEMA = 1;
+
+export const CONFIG_FILE = 'config.yaml';
+export const POLICY_FILE = join('policies', 'autonomy.yaml');
+
+export class SettingsError extends Error {
+  constructor(message, detail = {}) {
+    super(message);
+    Object.assign(this, detail);
+  }
+}
+
+const choice = (values, describe) => ({ kind: 'choice', choices: values.map((v) => ({ value: v, describe: describe[v] })) });
+
+/**
+ * Every editable knob in `config.yaml`, grouped the way an operator thinks
+ * about them rather than the way YAML nests them.
+ *
+ * `path` addresses the value inside the document. Fields that `schema.mjs`
+ * wraps in provenance (`profile`, `autonomy`, `validation` can each be either
+ * a bare value or `{value, source, confidence}`) are resolved at read time by
+ * `resolvePath` — the catalogue names the logical field, not the spelling a
+ * particular file happens to use.
+ */
+export const GROUPS = Object.freeze([
+  {
+    id: 'work',
+    title: 'How work gets done',
+    blurb: 'What Tyran spends, and how far it may go on its own.',
+    settings: [
+      {
+        id: 'profile',
+        path: ['profile'],
+        label: 'Cost profile',
+        help: 'How much verification each piece of work carries. The cheaper profiles skip review passes, not tests.',
+        ...choice(PROFILES, {
+          eco: 'Fewest agents and fewest review passes. Good for small, well-understood changes.',
+          balanced: 'The default. Implementation plus an independent review on anything non-trivial.',
+          full: 'Every gate, every review, the strongest tier where it matters. Slow and thorough.',
+        }),
+      },
+      {
+        id: 'autonomy',
+        path: ['autonomy'],
+        label: 'Deployment autonomy',
+        help: 'How far a finished piece of work may travel without you. The gate enforces this downward — it will not stop someone who edits this file from raising it, which is why the policy below decides who may.',
+        ...choice(AUTONOMY_CLASSES, {
+          P1: 'Branch only. Agents commit and push a branch; you open and merge the PR.',
+          P2: 'Through to staging. Agents may merge and deploy to a non-production environment.',
+          P3: 'Merge to main. Agents may land work on the default branch by themselves.',
+        }),
+      },
+    ],
+  },
+  {
+    id: 'tiers',
+    title: 'Model tiers',
+    blurb:
+      'The only place model names appear. Skills, agents and policies are all written in ROLE names, so a model deprecation is four lines here and nothing else moves.',
+    settings: TIER_KEYS.map((key) => ({
+      id: `tiers.${key}`,
+      path: ['tiers', key],
+      label: key,
+      kind: 'text',
+      help: {
+        cheap: 'Scouts, mechanical sweeps, ledger bookkeeping. Work where being fast beats being clever.',
+        work: 'The default tier: ordinary implementation and ordinary review. Most work lands here.',
+        deep: 'Root-cause diagnosis, hard implementation, risky review — where a wrong answer is expensive.',
+        top: 'Security review, arbitration, final acceptance. The last word, used sparingly.',
+      }[key],
+      placeholder: 'a model id or alias your CLI accepts',
+    })),
+  },
+  {
+    id: 'proof',
+    title: 'Proving it works',
+    blurb: 'What every agent must run before it is allowed to call anything done.',
+    settings: [
+      {
+        id: 'validation',
+        path: ['validation'],
+        label: 'Validation commands',
+        kind: 'list',
+        help: 'Run in order before any work is reported. Each must EXIT — a watch-mode test runner here hangs every agent you ever spawn, which is a real measured incident, not a hypothetical.',
+        placeholder: 'npm test',
+      },
+      {
+        id: 'shared_zones',
+        path: ['shared_zones'],
+        label: 'Shared zones',
+        kind: 'list',
+        help: 'Files more than one agent may touch in parallel. Writes to these are append-only and serialized by the conductor, so two agents cannot clobber each other.',
+        placeholder: 'src/registry.ts',
+      },
+    ],
+  },
+  {
+    id: 'overnight',
+    title: 'Overnight mode',
+    blurb:
+      'Pause near the subscription usage limit and resume after the window resets. Needs the statusline helper installed — it is the only place the platform reports usage, and without it this whole section is inert and doctor says so.',
+    settings: [
+      {
+        id: 'limits.mode',
+        path: ['limits', 'mode'],
+        label: 'Mode',
+        ...choice(LIMITS_MODES, {
+          off: 'Nothing pauses. The usage gate never denies a tool call.',
+          warn: 'Surfaces how close you are, but never denies anything.',
+          pause: 'Winds work down at the threshold, checkpoints it, and schedules the resume.',
+        }),
+        help: 'What happens as the usage window fills up.',
+      },
+      {
+        id: 'limits.pause_at_percent',
+        path: ['limits', 'pause_at_percent'],
+        label: 'Pause at (5-hour window)',
+        kind: 'number',
+        min: 50,
+        max: 100,
+        unit: '%',
+        help: 'How full the five-hour window must be before work winds down. The floor of 50 exists to catch 0.97 pasted where 97 belongs.',
+      },
+      {
+        id: 'limits.weekly_pause_at_percent',
+        path: ['limits', 'weekly_pause_at_percent'],
+        label: 'Pause at (weekly window)',
+        kind: 'number',
+        min: 50,
+        max: 100,
+        unit: '%',
+        help: 'The same threshold for the seven-day window. Hitting this one means a much longer wait.',
+      },
+      {
+        id: 'limits.wait_max_hours',
+        path: ['limits', 'wait_max_hours'],
+        label: 'Longest silent wait',
+        kind: 'number',
+        min: 0.5,
+        max: 24,
+        unit: 'h',
+        help: 'A reset further away than this is a LONG pause: it gets announced rather than silently waited out. The weekly window can be days.',
+      },
+      {
+        id: 'limits.long_wait',
+        path: ['limits', 'long_wait'],
+        label: 'Beyond that',
+        ...choice(LIMITS_LONG_WAIT, {
+          hold: 'Stop and tell you. You decide when to pick it back up.',
+          resume: 'Schedule the resume anyway, however far out it is.',
+        }),
+        help: 'What the scheduler does when the reset is further away than the wait above.',
+      },
+      {
+        id: 'limits.resume_margin_minutes',
+        path: ['limits', 'resume_margin_minutes'],
+        label: 'Resume margin',
+        kind: 'number',
+        min: 1,
+        max: 240,
+        unit: 'min',
+        help: 'How long after the window resets before work restarts. A little slack absorbs clock skew between your machine and the platform.',
+      },
+      {
+        id: 'limits.keep_awake',
+        path: ['limits', 'keep_awake'],
+        label: 'Hold the machine awake',
+        kind: 'boolean',
+        help: 'A laptop that suspends takes the resume watcher down with it. This holds the SYSTEM awake while it waits — never the display, so your screen lock is untouched.',
+      },
+    ],
+  },
+]);
+
+const BY_ID = new Map(GROUPS.flatMap((g) => g.settings.map((s) => [s.id, s])));
+
+/**
+ * Which way is looser.
+ *
+ * Two changes on this screen are not like the others: lowering a path's class
+ * lets agents write something they previously had to ask about, and raising
+ * the deployment class lets finished work travel further without a human. A
+ * dropdown treats both as ordinary, and the shipped policy carries rules whose
+ * own stated reason is that they must not move — `.claude/settings.json`
+ * ("anything that can edit it can switch every gate off"), `.tyran/STOP` ("a
+ * loop that can clear its own stop signal has none"). None of those is in
+ * `MANDATORY_KERNEL_PATHS`, so the validator does not stop them and nothing
+ * else did either.
+ *
+ * The rule is strictly one-directional. TIGHTENING applies on one click,
+ * exactly like every other setting — friction on making a boundary stricter is
+ * how you teach people to stop making boundaries stricter. Loosening needs a
+ * second, deliberate act, and the page shows the rule's own reason first.
+ */
+const LOOSER_FIRST = Object.freeze({
+  class: Object.freeze(['AUTO', 'GATED', 'KERNEL']),
+  autonomy: Object.freeze(['P3', 'P2', 'P1']),
+});
+
+function widens(scale, before, after) {
+  const order = LOOSER_FIRST[scale];
+  const from = order.indexOf(before);
+  const to = order.indexOf(after);
+  // An unknown value is treated as a widening: this guard exists for the case
+  // where something unexpected is happening, and a value nobody recognises is
+  // not the moment to wave a change through.
+  if (from === -1 || to === -1) return before !== after;
+  return to < from;
+}
+
+/**
+ * The confirmation a widening write must carry.
+ *
+ * It is the new value itself rather than a boolean, so a caller cannot satisfy
+ * it by sending `confirm: true` alongside whatever value it liked — the token
+ * only matches the change the operator was actually shown.
+ */
+function requireConfirm(scale, before, after, confirm, consequence) {
+  if (!widens(scale, before, after)) return;
+  if (confirm === after) return;
+  throw new SettingsError(
+    `${before} -> ${after} loosens this boundary, so it needs a second, deliberate confirmation. ${consequence}`,
+    { widens: true, confirm_with: after },
+  );
+}
+
+/** Every setting, flat, in catalogue order. */
+export function allSettings() {
+  return GROUPS.flatMap((g) => g.settings);
+}
+
+/**
+ * The real path to a value, allowing for provenance.
+ *
+ * `profile: balanced` and `profile: {value: balanced, source: ...}` are both
+ * legal and mean the same thing, so the catalogue names `profile` and this
+ * decides which of the two spellings the file in front of us is using.
+ */
+function resolvePath(doc, path) {
+  let node = doc;
+  for (const segment of path) {
+    if (node === null || typeof node !== 'object') return null;
+    node = node[segment];
+  }
+  if (node !== null && typeof node === 'object' && !Array.isArray(node) && 'value' in node) {
+    return [...path, 'value'];
+  }
+  return path;
+}
+
+function readAt(doc, path) {
+  let node = doc;
+  for (const segment of path) {
+    if (node === null || typeof node !== 'object') return undefined;
+    node = node[segment];
+  }
+  return node;
+}
+
+/** Read a YAML file, reporting a parse failure as data rather than throwing. */
+function loadFile(file) {
+  if (!existsSync(file)) return { present: false, doc: null, error: null, text: '' };
+  let text;
+  try {
+    text = readFileSync(file, 'utf8');
+  } catch (err) {
+    return { present: true, doc: null, error: String(err?.message ?? err), text: '' };
+  }
+  try {
+    return { present: true, doc: parse(text), error: null, text };
+  } catch (err) {
+    // A config that does not parse is exactly when an operator most wants to
+    // see this screen, so the failure is rendered rather than thrown.
+    return { present: true, doc: null, error: err instanceof YamlLiteError ? err.message : String(err?.message ?? err), text };
+  }
+}
+
+/**
+ * A rule may only be shown as editable if changing its class could ever be
+ * accepted. The kernel paths that protect the gate itself can be tightened but
+ * never lowered — `validatePolicy` enforces that and would refuse the write —
+ * so offering the choice would be offering a button that always fails.
+ */
+function ruleLocked(rulePath) {
+  return MANDATORY_KERNEL_PATHS.includes(rulePath);
+}
+
+/** Everything the board needs to draw the Settings tab. */
+export function readSettings(tyranDir) {
+  const configFile = join(tyranDir, CONFIG_FILE);
+  const policyFile = join(tyranDir, POLICY_FILE);
+  const config = loadFile(configFile);
+  const policy = loadFile(policyFile);
+
+  const groups = GROUPS.map((group) => ({
+    id: group.id,
+    title: group.title,
+    blurb: group.blurb,
+    settings: group.settings.map((setting) => {
+      const present = config.doc !== null && readAt(config.doc, resolvePath(config.doc, setting.path)) !== undefined;
+      return {
+        id: setting.id,
+        label: setting.label,
+        help: setting.help,
+        kind: setting.kind ?? 'choice',
+        choices: setting.choices ?? null,
+        min: setting.min ?? null,
+        max: setting.max ?? null,
+        unit: setting.unit ?? null,
+        placeholder: setting.placeholder ?? null,
+        present,
+        value: present ? readAt(config.doc, resolvePath(config.doc, setting.path)) : null,
+      };
+    }),
+  }));
+
+  const rules = Array.isArray(policy.doc?.rules)
+    ? policy.doc.rules
+        .filter((rule) => rule !== null && typeof rule === 'object' && typeof rule.path === 'string')
+        .map((rule) => ({
+          path: rule.path,
+          class: rule.class ?? null,
+          reason: typeof rule.reason === 'string' ? rule.reason : '',
+          locked: ruleLocked(rule.path),
+        }))
+    : [];
+
+  return {
+    schema: SETTINGS_SCHEMA,
+    files: {
+      config: { path: join(tyranDir, CONFIG_FILE), present: config.present, error: config.error },
+      policy: { path: join(tyranDir, POLICY_FILE), present: policy.present, error: policy.error },
+    },
+    groups,
+    policy: {
+      classes: [...ARTIFACT_CLASSES],
+      describe: {
+        AUTO: 'Agents write it themselves. Rollback is a git revert.',
+        GATED: 'Agents propose, you approve. Denied outright to a subagent.',
+        KERNEL: 'Humans only, by hand. Never autonomously, ever.',
+      },
+      default: policy.doc?.default ?? null,
+      rules,
+    },
+  };
+}
+
+/** Reject a value that the catalogue's own type says is wrong. */
+function coerce(setting, raw) {
+  const kind = setting.kind ?? 'choice';
+  if (kind === 'choice') {
+    const legal = setting.choices.map((c) => c.value);
+    if (!legal.includes(raw)) throw new SettingsError(`${setting.id}: must be one of ${legal.join(' | ')}`);
+    return raw;
+  }
+  if (kind === 'boolean') {
+    if (typeof raw !== 'boolean') throw new SettingsError(`${setting.id}: must be true or false`);
+    return raw;
+  }
+  if (kind === 'number') {
+    if (typeof raw !== 'number' || !Number.isFinite(raw)) throw new SettingsError(`${setting.id}: must be a number`);
+    if (raw < setting.min || raw > setting.max) {
+      throw new SettingsError(`${setting.id}: must be between ${setting.min} and ${setting.max}`);
+    }
+    return raw;
+  }
+  if (kind === 'text') {
+    if (typeof raw !== 'string' || raw.trim() === '') throw new SettingsError(`${setting.id}: must not be empty`);
+    return raw.trim();
+  }
+  if (kind === 'list') {
+    if (!Array.isArray(raw)) throw new SettingsError(`${setting.id}: must be a list`);
+    const items = raw.map((item) => (typeof item === 'string' ? item.trim() : item)).filter((item) => item !== '');
+    for (const item of items) {
+      if (typeof item !== 'string') throw new SettingsError(`${setting.id}: every entry must be text`);
+    }
+    return items;
+  }
+  throw new SettingsError(`${setting.id}: no editor for this kind of value`);
+}
+
+/**
+ * Write one config setting, or refuse and change nothing.
+ *
+ * The order is the point: patch the TEXT, re-validate the RESULT with the same
+ * validator `schema.mjs validate` runs, and only then hand the caller
+ * something to write. A value that would produce a config the validator
+ * rejects never reaches the disk, so the board cannot leave a repo in a state
+ * its own tooling refuses to load.
+ */
+export function applySetting(tyranDir, id, value, confirm = null) {
+  const setting = BY_ID.get(id);
+  if (!setting) throw new SettingsError(`unknown setting "${id}"`);
+  const file = join(tyranDir, CONFIG_FILE);
+  const loaded = loadFile(file);
+  if (!loaded.present) throw new SettingsError(`${file} does not exist — run /tyran:setup first`);
+  if (loaded.doc === null) throw new SettingsError(`${file} does not parse, so it cannot be edited safely: ${loaded.error}`);
+
+  const path = resolvePath(loaded.doc, setting.path);
+  const before = readAt(loaded.doc, path);
+  if (before === undefined) {
+    throw new SettingsError(
+      `"${setting.path.join('.')}" is not in ${file}. This screen edits values that are already there; ` +
+        'add the key by hand once and it becomes editable here.',
+    );
+  }
+  const next = coerce(setting, value);
+  if (id === 'autonomy') {
+    requireConfirm('autonomy', before, next, confirm,
+      'A higher deployment class lets finished work travel further without you — P2 reaches staging, P3 merges to the default branch.');
+  }
+
+  let text;
+  try {
+    text = patch(loaded.text, path, next);
+  } catch (err) {
+    if (err instanceof YamlPatchError) throw new SettingsError(err.message);
+    throw err;
+  }
+
+  const errors = validateConfig(parse(text));
+  if (errors.length > 0) {
+    throw new SettingsError(`that change makes the config invalid, so nothing was written:\n  ${errors.join('\n  ')}`);
+  }
+  return { file, path, before, after: next, text };
+}
+
+/**
+ * Change one policy rule's class, or the default class, and refuse anything
+ * that would weaken the boundary protecting the gate.
+ *
+ * The rule is addressed by its path GLOB, not by its position, and re-resolved
+ * against the file as it is right now. An index captured when the page loaded
+ * would point at a different rule if the file moved underneath it, and the
+ * write would land on the wrong boundary with no error at all.
+ */
+export function applyPolicyClass(tyranDir, rulePath, klass, confirm = null) {
+  if (!ARTIFACT_CLASSES.includes(klass)) {
+    throw new SettingsError(`class must be one of ${ARTIFACT_CLASSES.join(' | ')}`);
+  }
+  const file = join(tyranDir, POLICY_FILE);
+  const loaded = loadFile(file);
+  if (!loaded.present) throw new SettingsError(`${file} does not exist — run /tyran:setup first`);
+  if (loaded.doc === null) throw new SettingsError(`${file} does not parse, so it cannot be edited safely: ${loaded.error}`);
+
+  let path;
+  let before;
+  let consequence;
+  if (rulePath === null) {
+    path = ['default'];
+    before = loaded.doc.default;
+    if (before === undefined) throw new SettingsError(`${file} has no "default" — add one by hand once and it becomes editable here`);
+    consequence = 'This is the class every path no rule matches gets, so it is the widest change available on this screen.';
+  } else {
+    if (ruleLocked(rulePath)) {
+      throw new SettingsError(
+        `"${rulePath}" is one of the paths that protect the gate itself, and it stays KERNEL. ` +
+          'A system that can lower the class of its own enforcement has no boundary at all.',
+      );
+    }
+    const rules = Array.isArray(loaded.doc.rules) ? loaded.doc.rules : [];
+    const index = rules.findIndex((rule) => rule !== null && typeof rule === 'object' && rule.path === rulePath);
+    if (index === -1) throw new SettingsError(`no rule for "${rulePath}" in ${file}`);
+    path = ['rules', index, 'class'];
+    before = rules[index].class;
+    // The rule's own `reason:` is the consequence, verbatim. Every boundary in
+    // this file is required to say why it exists; that sentence was written by
+    // whoever put the boundary there, and it is a better warning than anything
+    // this module could compose about a path it has never seen.
+    consequence = typeof rules[index].reason === 'string' && rules[index].reason !== ''
+      ? `This rule exists because: ${rules[index].reason}`
+      : 'This rule records no reason, which is itself worth looking at before loosening it.';
+  }
+  requireConfirm('class', before, klass, confirm, consequence);
+
+  let text;
+  try {
+    text = patch(loaded.text, path, klass);
+  } catch (err) {
+    if (err instanceof YamlPatchError) throw new SettingsError(err.message);
+    throw err;
+  }
+
+  // The same validator `schema.mjs validate policy` runs — including the check
+  // that no rule, however spelled, can claim a kernel path at a lower class.
+  const errors = validatePolicy(parse(text));
+  if (errors.length > 0) {
+    throw new SettingsError(`that change makes the policy invalid, so nothing was written:\n  ${errors.join('\n  ')}`);
+  }
+  return { file, path, before, after: klass, text };
+}

--- a/scripts/yaml-lite.mjs
+++ b/scripts/yaml-lite.mjs
@@ -115,7 +115,16 @@ function parseScalar(raw, lineNo, { allowFlow = true } = {}) {
   return value;
 }
 
-function stripComment(line, lineNo) {
+/**
+ * Split a line into its code and its trailing comment.
+ *
+ * Exported because an EDITOR needs the half a parser throws away. Patching one
+ * value in a hand-written config means putting the operator's comment back
+ * afterwards, and a second `#`-finder written elsewhere would disagree with
+ * this one about `url: 'http://x/#frag'` on exactly the files where being
+ * wrong costs a comment.
+ */
+export function splitInlineComment(line, lineNo) {
   // Comments start at ` #` outside quotes; a leading `#` is a full-line comment.
   let inSingle = false;
   let inDouble = false;
@@ -156,7 +165,11 @@ function stripComment(line, lineNo) {
       lineNo,
     );
   }
-  return cut === -1 ? line : line.slice(0, cut);
+  return cut === -1 ? { code: line, comment: '' } : { code: line.slice(0, cut), comment: line.slice(cut) };
+}
+
+function stripComment(line, lineNo) {
+  return splitInlineComment(line, lineNo).code;
 }
 
 /** Parse a YAML-subset document into a plain JS object. */
@@ -377,7 +390,17 @@ function formatKey(key) {
   return s;
 }
 
-function formatScalar(value) {
+/**
+ * Render one scalar as this subset spells it — quoting whenever an unquoted
+ * spelling would read back as something else.
+ *
+ * Exported for the same reason as `splitInlineComment`: an editor that writes
+ * a single value into an existing file must quote it by exactly the rules
+ * `parse` reads by. `mode: off` is the standing proof — bare `off` is the
+ * boolean false in YAML, so the string "off" has to come back quoted or the
+ * overnight gate silently changes meaning.
+ */
+export function formatScalar(value) {
   if (value === null || value === undefined) return 'null';
   if (typeof value === 'boolean' || typeof value === 'number') return String(value);
   const s = String(value);

--- a/scripts/yaml-patch.mjs
+++ b/scripts/yaml-patch.mjs
@@ -1,0 +1,263 @@
+#!/usr/bin/env node
+/**
+ * yaml-patch — change ONE value in a YAML-subset file and keep the file.
+ *
+ * `yaml-lite.stringify` can serialize a whole document, and using it here
+ * would be the obvious move and the wrong one. `templates/config.yaml` is 91
+ * lines of which 60 are comments, and those comments are the only place an
+ * operator is told that bare `off` is the boolean false, or why `autonomy:`
+ * being AUTO is a trade rather than an oversight. Round-tripping the document
+ * through a serializer deletes all of it, silently, the first time anyone
+ * moves a slider in a web page.
+ *
+ * So this module edits TEXT, not data: it finds the line that owns a path and
+ * rewrites the value on it, leaving every other byte — comments, blank lines,
+ * key order, the operator's own spacing — exactly where it was.
+ *
+ * ## Why a text edit is safe here
+ *
+ * Because it is verified rather than trusted. Every patch is applied and then
+ * PROVED, by parsing the result and comparing it to the document we meant to
+ * produce: the target path holds the new value, and every other path is
+ * byte-for-byte the value it held before. A locator bug cannot ship a wrong
+ * file; it can only fail loudly. That inverts the usual risk of hand-editing
+ * structured text, where the damage is silent and found later.
+ *
+ * The guarantee, stated exactly: if `patch()` returns, the returned text
+ * parses to the intended document. If it cannot prove that, it throws and the
+ * caller writes nothing.
+ *
+ * ## What it deliberately will not do
+ *
+ * - **Create keys.** A path that does not already exist is refused. Adding a
+ *   key means choosing where it goes and what comment explains it, which is
+ *   authoring, not editing.
+ * - **Eat comments inside a list it replaces.** Replacing a block sequence
+ *   rewrites its lines, so a comment among the items would vanish. That is
+ *   refused instead, with the line number, because the alternative is the
+ *   silent loss this whole module exists to prevent.
+ */
+import { YamlLiteError, formatScalar, parse, splitInlineComment } from './yaml-lite.mjs';
+
+export class YamlPatchError extends Error {}
+
+/** Lines with their code half, comment half and indentation, once. */
+function scan(text) {
+  return text.split('\n').map((raw, i) => {
+    const { code, comment } = splitInlineComment(raw, i + 1);
+    const trimmed = code.trim();
+    return {
+      i,
+      raw,
+      code,
+      comment,
+      trimmed,
+      blank: trimmed === '',
+      indent: code.length - code.trimStart().length,
+    };
+  });
+}
+
+/**
+ * A sequence item carries its first key on the dash line (`- path: x`), so the
+ * dash line is presented to the locator as an ordinary key line indented two
+ * further. Without this the first key of every rule would be unreachable by
+ * the same code that reaches the rest.
+ */
+function asKeyLine(line, seqIndent) {
+  if (line.indent === seqIndent && line.trimmed.startsWith('- ')) {
+    return { ...line, indent: seqIndent + 2, trimmed: line.trimmed.slice(2).trim(), dash: true };
+  }
+  return line;
+}
+
+/**
+ * One past the last line belonging to the block that starts at `from`.
+ *
+ * The last CONTENT line, not the last line before the next key: a blank line
+ * and the comment introducing the following section sit between the two, and
+ * counting them as part of this block is how a list replacement would eat the
+ * next section's heading.
+ */
+function blockEnd(lines, from, indent) {
+  let end = from;
+  for (let i = from; i < lines.length; i += 1) {
+    if (lines[i].blank) continue;
+    if (lines[i].indent <= indent) break;
+    end = i + 1;
+  }
+  return end;
+}
+
+/**
+ * Find the line that owns `path`, and where on it the value sits.
+ *
+ * `path` segments are keys, or integers for a position in a block sequence.
+ */
+function locate(lines, path) {
+  let from = 0;
+  let to = lines.length;
+  let indent = 0;
+  let found = null;
+
+  for (let depth = 0; depth < path.length; depth += 1) {
+    const segment = path[depth];
+    const where = `${path.slice(0, depth + 1).join('.')}`;
+
+    if (typeof segment === 'number') {
+      let seen = -1;
+      let hit = -1;
+      for (let i = from; i < to; i += 1) {
+        const line = lines[i];
+        if (line.blank || line.indent !== indent || !line.trimmed.startsWith('- ')) continue;
+        seen += 1;
+        if (seen === segment) {
+          hit = i;
+          break;
+        }
+      }
+      if (hit === -1) throw new YamlPatchError(`no item ${segment} in the list at "${path.slice(0, depth).join('.')}"`);
+      found = { line: hit, key: null };
+      from = hit;
+      to = blockEnd(lines, hit + 1, indent);
+      // The item's keys sit two columns in from the dash, and the FIRST of
+      // them shares the dash line — `- path: x`. Both facts are needed: the
+      // search indent moves to the keys, and the dash line is presented as a
+      // key line at that same indent by `asKeyLine`.
+      indent = lines[hit].indent + 2;
+      continue;
+    }
+
+    let hit = -1;
+    for (let i = from; i < to; i += 1) {
+      const line = asKeyLine(lines[i], indent - 2);
+      if (line.blank || line.indent !== indent) continue;
+      const colon = line.trimmed.indexOf(':');
+      if (colon === -1) continue;
+      if (line.trimmed.slice(0, colon).trim().replace(/^['"]|['"]$/g, '') !== segment) continue;
+      hit = i;
+      break;
+    }
+    if (hit === -1) throw new YamlPatchError(`"${where}" is not in this file — yaml-patch edits existing keys, it does not add them`);
+    found = { line: hit, key: segment };
+    from = hit + 1;
+    to = blockEnd(lines, hit + 1, lines[hit].indent);
+    indent = lines[hit].indent + 2;
+  }
+
+  if (found === null) throw new YamlPatchError('an empty path addresses nothing');
+  return found;
+}
+
+/** Deep structural equality over the plain data yaml-lite produces. */
+function sameValue(a, b) {
+  if (a === b) return true;
+  if (Array.isArray(a) || Array.isArray(b)) {
+    if (!Array.isArray(a) || !Array.isArray(b) || a.length !== b.length) return false;
+    return a.every((item, i) => sameValue(item, b[i]));
+  }
+  if (a === null || b === null || typeof a !== 'object' || typeof b !== 'object') return false;
+  const ka = Object.keys(a);
+  const kb = Object.keys(b);
+  if (ka.length !== kb.length) return false;
+  return ka.every((k) => Object.hasOwn(b, k) && sameValue(a[k], b[k]));
+}
+
+function readAt(doc, path) {
+  let node = doc;
+  for (const segment of path) {
+    if (node === null || typeof node !== 'object') return undefined;
+    node = node[segment];
+  }
+  return node;
+}
+
+function writeAt(doc, path, value) {
+  let node = doc;
+  for (const segment of path.slice(0, -1)) node = node[segment];
+  node[path.at(-1)] = value;
+}
+
+/** Rewrite the value on a `key: value` line, keeping indent and comment. */
+function scalarLine(line, seqIndent, value) {
+  const view = asKeyLine(line, seqIndent);
+  const colon = view.trimmed.indexOf(':');
+  const head = view.dash
+    ? `${' '.repeat(line.indent)}- ${view.trimmed.slice(0, colon + 1)}`
+    : `${' '.repeat(line.indent)}${view.trimmed.slice(0, colon + 1)}`;
+  const tail = line.comment === '' ? '' : ` ${line.comment}`;
+  return `${head} ${formatScalar(value)}${tail}`;
+}
+
+/**
+ * Set `path` to `value` in `text`, returning the new text.
+ *
+ * Throws `YamlPatchError` if the path is absent, if the change cannot be made
+ * without losing a comment, or — the one that matters — if the result does not
+ * parse back to exactly the document intended.
+ */
+export function patch(text, path, value) {
+  let before;
+  try {
+    before = parse(text);
+  } catch (err) {
+    if (err instanceof YamlLiteError) throw new YamlPatchError(`this file does not parse, so it cannot be edited safely: ${err.message}`);
+    throw err;
+  }
+  if (readAt(before, path) === undefined) {
+    throw new YamlPatchError(`"${path.join('.')}" is not in this file — yaml-patch edits existing keys, it does not add them`);
+  }
+
+  const lines = scan(text);
+  const seqIndent = typeof path.at(-2) === 'number' ? lines[locate(lines, path.slice(0, -1)).line].indent : -2;
+  const target = locate(lines, path);
+  const line = lines[target.line];
+
+  const out = text.split('\n');
+  if (Array.isArray(value)) {
+    const view = asKeyLine(line, seqIndent);
+    const colon = view.trimmed.indexOf(':');
+    const inlineValue = view.trimmed.slice(colon + 1).trim();
+    const childIndent = line.indent + 2;
+    const end = inlineValue === '' ? blockEnd(lines, target.line + 1, line.indent) : target.line + 1;
+    // Rewriting the block rewrites its lines, so a comment living among the
+    // items would disappear. Refusing keeps the promise this module is for.
+    for (let i = target.line + 1; i < end; i += 1) {
+      if (lines[i].comment !== '') {
+        throw new YamlPatchError(
+          `line ${i + 1} of this list is a comment, and replacing the list would delete it — ` +
+            `edit ${path.join('.')} in the file by hand instead`,
+        );
+      }
+    }
+    const head = `${' '.repeat(line.indent)}${view.trimmed.slice(0, colon + 1)}`;
+    const tail = line.comment === '' ? '' : ` ${line.comment}`;
+    const body = value.length === 0
+      ? [`${head} []${tail}`]
+      : [`${head}${tail}`, ...value.map((item) => `${' '.repeat(childIndent)}- ${formatScalar(item)}`)];
+    out.splice(target.line, end - target.line, ...body);
+  } else {
+    out[target.line] = scalarLine(line, seqIndent, value);
+  }
+  const next = out.join('\n');
+
+  // The proof. A locator that picked the wrong line, a quoting rule that read
+  // back as a different type, a list block whose extent was misjudged — each
+  // shows up here as a mismatch, before anything reaches the disk.
+  const expected = structuredClone(before);
+  writeAt(expected, path, value);
+  let after;
+  try {
+    after = parse(next);
+  } catch (err) {
+    throw new YamlPatchError(`the edit produced a file that no longer parses (${err.message}) — nothing was written`);
+  }
+  if (!sameValue(after, expected)) {
+    throw new YamlPatchError(
+      `the edit did not produce the intended document — nothing was written. ` +
+        `Wanted ${path.join('.')} = ${JSON.stringify(value)}, got ${JSON.stringify(readAt(after, path))}` +
+        (sameValue(readAt(after, path), value) ? ', and something else in the file changed too' : ''),
+    );
+  }
+  return next;
+}

--- a/scripts/yaml-patch.mjs
+++ b/scripts/yaml-patch.mjs
@@ -3,8 +3,8 @@
  * yaml-patch — change ONE value in a YAML-subset file and keep the file.
  *
  * `yaml-lite.stringify` can serialize a whole document, and using it here
- * would be the obvious move and the wrong one. `templates/config.yaml` is 91
- * lines of which 60 are comments, and those comments are the only place an
+ * would be the obvious move and the wrong one. `templates/config.yaml` is 90
+ * lines of which 63 are comments, and those comments are the only place an
  * operator is told that bare `off` is the boolean false, or why `autonomy:`
  * being AUTO is a trade rather than an oversight. Round-tripping the document
  * through a serializer deletes all of it, silently, the first time anyone
@@ -41,14 +41,23 @@ import { YamlLiteError, formatScalar, parse, splitInlineComment } from './yaml-l
 
 export class YamlPatchError extends Error {}
 
-/** Lines with their code half, comment half and indentation, once. */
+/**
+ * Lines with their code half, comment half, indentation and line ending.
+ *
+ * The `\r` is carried separately so a rewritten line in a CRLF file keeps the
+ * ending every other line has. Dropping it produced a file with mixed endings
+ * — correct data, and a diff that looks like the whole file moved.
+ */
 function scan(text) {
-  return text.split('\n').map((raw, i) => {
+  return text.split('\n').map((line, i) => {
+    const eol = line.endsWith('\r') ? '\r' : '';
+    const raw = eol === '' ? line : line.slice(0, -1);
     const { code, comment } = splitInlineComment(raw, i + 1);
     const trimmed = code.trim();
     return {
       i,
       raw,
+      eol,
       code,
       comment,
       trimmed,
@@ -60,15 +69,49 @@ function scan(text) {
 
 /**
  * A sequence item carries its first key on the dash line (`- path: x`), so the
- * dash line is presented to the locator as an ordinary key line indented two
- * further. Without this the first key of every rule would be unreachable by
- * the same code that reaches the rest.
+ * dash line is presented to the locator as an ordinary key line at the indent
+ * its siblings use. Without this the first key of every rule would be
+ * unreachable by the same code that reaches the rest.
  */
-function asKeyLine(line, seqIndent) {
-  if (line.indent === seqIndent && line.trimmed.startsWith('- ')) {
-    return { ...line, indent: seqIndent + 2, trimmed: line.trimmed.slice(2).trim(), dash: true };
+function asKeyLine(line, dashIndent, keyIndent) {
+  if (dashIndent >= 0 && line.indent === dashIndent && line.trimmed.startsWith('- ')) {
+    return { ...line, indent: keyIndent, trimmed: line.trimmed.slice(2).trim(), dash: true };
   }
   return line;
+}
+
+/**
+ * How far in the block under `from` is indented, or -1 if there is no block.
+ *
+ * DISCOVERED, never assumed. `yaml-lite` recurses with `parseBlock(next.indent)`
+ * — whatever the next line happens to be indented by, as long as it is deeper
+ * and even — so a config indented four spaces is as legal as one indented two,
+ * and `validateConfig` accepts it. A hardcoded step here made every nested key
+ * in such a file report "is not in this file" while the page, which reads the
+ * PARSED document, rendered all fifteen controls enabled. The operator got a
+ * false error under a live control telling them to add a key that was already
+ * there.
+ *
+ * The one step that genuinely is fixed is a sequence item's siblings, at
+ * exactly dash + 2 — that is `yaml-lite.parseBlock`'s `indent + 2`, and it
+ * follows from `- ` being two characters wide.
+ */
+function childIndentOf(lines, from, to, parentIndent) {
+  for (let i = from; i < to; i += 1) {
+    if (lines[i].blank) continue;
+    return lines[i].indent > parentIndent ? lines[i].indent : -1;
+  }
+  return -1;
+}
+
+/** The indent step this document uses, for a block that has no children yet. */
+function documentStep(lines, topIndent) {
+  let step = -1;
+  for (const line of lines) {
+    if (line.blank || line.indent <= topIndent) continue;
+    if (step === -1 || line.indent < step) step = line.indent;
+  }
+  return step === -1 ? 2 : step - topIndent;
 }
 
 /**
@@ -95,9 +138,12 @@ function blockEnd(lines, from, indent) {
  * `path` segments are keys, or integers for a position in a block sequence.
  */
 function locate(lines, path) {
+  const first = lines.find((line) => !line.blank);
+  const topIndent = first === undefined ? 0 : first.indent;
   let from = 0;
   let to = lines.length;
-  let indent = 0;
+  let indent = topIndent;
+  let dashIndent = -1;
   let found = null;
 
   for (let depth = 0; depth < path.length; depth += 1) {
@@ -117,40 +163,55 @@ function locate(lines, path) {
         }
       }
       if (hit === -1) throw new YamlPatchError(`no item ${segment} in the list at "${path.slice(0, depth).join('.')}"`);
-      found = { line: hit, key: null };
+      dashIndent = lines[hit].indent;
+      found = { line: hit, dash: false, keyIndent: dashIndent + 2 };
       from = hit;
-      to = blockEnd(lines, hit + 1, indent);
-      // The item's keys sit two columns in from the dash, and the FIRST of
-      // them shares the dash line — `- path: x`. Both facts are needed: the
-      // search indent moves to the keys, and the dash line is presented as a
-      // key line at that same indent by `asKeyLine`.
-      indent = lines[hit].indent + 2;
+      to = blockEnd(lines, hit + 1, dashIndent);
+      // A sequence item's sibling keys sit at exactly dash + 2, and the FIRST
+      // of them shares the dash line — `- path: x`. This is the one step that
+      // is not discovered, because it is not a style choice: `- ` is two
+      // characters, and yaml-lite reads siblings at `indent + 2` for that
+      // reason.
+      indent = dashIndent + 2;
       continue;
     }
 
     let hit = -1;
+    let view = null;
     for (let i = from; i < to; i += 1) {
-      const line = asKeyLine(lines[i], indent - 2);
+      const line = asKeyLine(lines[i], dashIndent, indent);
       if (line.blank || line.indent !== indent) continue;
       const colon = line.trimmed.indexOf(':');
       if (colon === -1) continue;
       if (line.trimmed.slice(0, colon).trim().replace(/^['"]|['"]$/g, '') !== segment) continue;
       hit = i;
+      view = line;
       break;
     }
     if (hit === -1) throw new YamlPatchError(`"${where}" is not in this file — yaml-patch edits existing keys, it does not add them`);
-    found = { line: hit, key: segment };
+    found = { line: hit, dash: view.dash === true, keyIndent: indent };
+    const parentIndent = lines[hit].indent;
     from = hit + 1;
-    to = blockEnd(lines, hit + 1, lines[hit].indent);
-    indent = lines[hit].indent + 2;
+    to = blockEnd(lines, from, parentIndent);
+    indent = childIndentOf(lines, from, to, parentIndent);
+    if (indent === -1) indent = parentIndent + documentStep(lines, topIndent);
+    dashIndent = -1;
   }
 
   if (found === null) throw new YamlPatchError('an empty path addresses nothing');
   return found;
 }
 
-/** Deep structural equality over the plain data yaml-lite produces. */
-function sameValue(a, b) {
+/**
+ * Deep structural equality over the plain data yaml-lite produces.
+ *
+ * Exported so the proof at the end of `patch()` can be tested directly. It is
+ * defence in depth with no input known to reach it — every wrong case found so
+ * far is refused earlier, by the locator, by the comment guard, or by
+ * `formatScalar` — so a test that goes through `patch()` cannot make it fire,
+ * and this is the mutable logic the guarantee actually rests on.
+ */
+export function sameValue(a, b) {
   if (a === b) return true;
   if (Array.isArray(a) || Array.isArray(b)) {
     if (!Array.isArray(a) || !Array.isArray(b) || a.length !== b.length) return false;
@@ -178,15 +239,13 @@ function writeAt(doc, path, value) {
   node[path.at(-1)] = value;
 }
 
-/** Rewrite the value on a `key: value` line, keeping indent and comment. */
-function scalarLine(line, seqIndent, value) {
-  const view = asKeyLine(line, seqIndent);
-  const colon = view.trimmed.indexOf(':');
-  const head = view.dash
-    ? `${' '.repeat(line.indent)}- ${view.trimmed.slice(0, colon + 1)}`
-    : `${' '.repeat(line.indent)}${view.trimmed.slice(0, colon + 1)}`;
+/** Rewrite the value on a `key: value` line, keeping indent, comment and ending. */
+function scalarLine(line, target, value) {
+  const body = target.dash ? line.trimmed.slice(2).trim() : line.trimmed;
+  const colon = body.indexOf(':');
+  const head = `${' '.repeat(line.indent)}${target.dash ? '- ' : ''}${body.slice(0, colon + 1)}`;
   const tail = line.comment === '' ? '' : ` ${line.comment}`;
-  return `${head} ${formatScalar(value)}${tail}`;
+  return `${head} ${formatScalar(value)}${tail}${line.eol}`;
 }
 
 /**
@@ -208,18 +267,46 @@ export function patch(text, path, value) {
     throw new YamlPatchError(`"${path.join('.')}" is not in this file — yaml-patch edits existing keys, it does not add them`);
   }
 
+  return build(text, path, value, before);
+}
+
+/**
+ * The edit itself, with every refusal this module makes reported as one error
+ * type.
+ *
+ * `formatScalar` throws `YamlLiteError` for a value the subset cannot spell —
+ * a newline, an invisible codepoint — and that is ordinary rejected input, not
+ * a fault. Letting it escape made the caller classify it as a server error:
+ * HTTP 500 and a line in the terminal the docs designate as the audit trail,
+ * for someone pasting a model name with a stray newline in it.
+ */
+function build(text, path, value, before) {
+  try {
+    return edit(text, path, value, before);
+  } catch (err) {
+    if (err instanceof YamlLiteError) throw new YamlPatchError(err.message);
+    throw err;
+  }
+}
+
+function edit(text, path, value, before) {
   const lines = scan(text);
-  const seqIndent = typeof path.at(-2) === 'number' ? lines[locate(lines, path.slice(0, -1)).line].indent : -2;
+  const first = lines.find((l) => !l.blank);
   const target = locate(lines, path);
   const line = lines[target.line];
 
   const out = text.split('\n');
   if (Array.isArray(value)) {
-    const view = asKeyLine(line, seqIndent);
-    const colon = view.trimmed.indexOf(':');
-    const inlineValue = view.trimmed.slice(colon + 1).trim();
-    const childIndent = line.indent + 2;
+    const body = target.dash ? line.trimmed.slice(2).trim() : line.trimmed;
+    const colon = body.indexOf(':');
+    const inlineValue = body.slice(colon + 1).trim();
     const end = inlineValue === '' ? blockEnd(lines, target.line + 1, line.indent) : target.line + 1;
+    // The items' indent is the one they already have; a list with none yet
+    // (`shared_zones: []`) takes the step the rest of the document uses.
+    const discovered = childIndentOf(lines, target.line + 1, end, line.indent);
+    const childIndent = discovered === -1
+      ? line.indent + documentStep(lines, first === undefined ? 0 : first.indent)
+      : discovered;
     // Rewriting the block rewrites its lines, so a comment living among the
     // items would disappear. Refusing keeps the promise this module is for.
     for (let i = target.line + 1; i < end; i += 1) {
@@ -230,14 +317,14 @@ export function patch(text, path, value) {
         );
       }
     }
-    const head = `${' '.repeat(line.indent)}${view.trimmed.slice(0, colon + 1)}`;
+    const head = `${' '.repeat(line.indent)}${target.dash ? '- ' : ''}${body.slice(0, colon + 1)}`;
     const tail = line.comment === '' ? '' : ` ${line.comment}`;
-    const body = value.length === 0
-      ? [`${head} []${tail}`]
-      : [`${head}${tail}`, ...value.map((item) => `${' '.repeat(childIndent)}- ${formatScalar(item)}`)];
-    out.splice(target.line, end - target.line, ...body);
+    const rendered = value.length === 0
+      ? [`${head} []${tail}${line.eol}`]
+      : [`${head}${tail}${line.eol}`, ...value.map((item) => `${' '.repeat(childIndent)}- ${formatScalar(item)}${line.eol}`)];
+    out.splice(target.line, end - target.line, ...rendered);
   } else {
-    out[target.line] = scalarLine(line, seqIndent, value);
+    out[target.line] = scalarLine(line, target, value);
   }
   const next = out.join('\n');
 

--- a/site/scripts/build-sandbox.mjs
+++ b/site/scripts/build-sandbox.mjs
@@ -34,6 +34,7 @@ import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { renderAll, BOARD_HTML_FILE } from '../../scripts/board.mjs';
 import { costJson, rollup } from '../../scripts/cost.mjs';
+import { readSettings } from '../../scripts/settings.mjs';
 
 /**
  * Spend for the sandbox, built through the REAL rollup.
@@ -92,8 +93,39 @@ function sandboxCostJson() {
   return costJson(report);
 }
 
+/**
+ * Settings for the sandbox, read out of the SHIPPED TEMPLATES.
+ *
+ * Same argument as spend: run the real reader over the real files, so the tab
+ * a reader clicks is laid out by the code their own board runs and shows the
+ * defaults they will actually get. `writable` is false because a static page
+ * has no server behind it — every control renders disabled, and the banner
+ * says which flag turns them on, which is exactly the true answer here.
+ *
+ * The absolute paths `readSettings` reports are replaced with the ones an
+ * operator would see: the build machine's temp directory is not a fact about
+ * anyone else's repository, and it has no business in a published file.
+ */
+function sandboxSettingsJson(templatesDir) {
+  const work = mkdtempSync(join(tmpdir(), 'tyran-sandbox-settings-'));
+  try {
+    const tyran = join(work, '.tyran');
+    mkdirSync(join(tyran, 'policies'), { recursive: true });
+    writeFileSync(join(tyran, 'config.yaml'), readFileSync(join(templatesDir, 'config.yaml'), 'utf8'));
+    writeFileSync(join(tyran, 'policies', 'autonomy.yaml'), readFileSync(join(templatesDir, 'policies', 'autonomy.yaml'), 'utf8'));
+    const payload = readSettings(tyran);
+    payload.files.config.path = join('.tyran', 'config.yaml');
+    payload.files.policy.path = join('.tyran', 'policies', 'autonomy.yaml');
+    payload.writable = false;
+    return JSON.stringify(payload, null, 2) + '\n';
+  } finally {
+    rmSync(work, { recursive: true, force: true });
+  }
+}
+
 const HERE = dirname(fileURLToPath(import.meta.url));
 const SANDBOX_SRC = join(HERE, '..', 'sandbox');
+const TEMPLATES = join(HERE, '..', '..', 'templates');
 const OUT_DIR = join(HERE, '..', 'public', 'sandbox');
 
 /** Newest event lands here, in minutes before the build. */
@@ -173,6 +205,7 @@ try {
   // path the client already fetches — so the sandbox exercises the same code
   // path a real board does, rather than a special case for the demo.
   writeFileSync(join(OUT_DIR, 'cost.json'), sandboxCostJson());
+  writeFileSync(join(OUT_DIR, 'settings.json'), sandboxSettingsJson(TEMPLATES));
   const t = payload.totals;
   console.log(
     `sandbox: ${t.initiatives} initiative(s), ${t.tickets} ticket(s), ${t.agents} agent(s), ` +

--- a/site/src/content/docs/board.mdx
+++ b/site/src/content/docs/board.mdx
@@ -120,8 +120,9 @@ It prints `board: serving http://127.0.0.1:4173/`. Open that. The board
 re-renders on every request, so a reload is always current, and the page
 reloads itself every 30 seconds anyway. `--port <n>` if 4173 is taken.
 `Ctrl-C` stops it. It binds loopback only and pins the `Host` header, so
-nothing outside your machine can reach it — and it is read-only: the server
-answers three URLs and derives a filesystem path from none of them.
+nothing outside your machine can reach it, and it derives a filesystem path
+from no URL at all. It is read-only unless you add `--write`, which turns on
+the [Settings](#settings) tab and nothing else.
 
 **Open the file** — no server, no spend:
 
@@ -132,17 +133,18 @@ start .tyran\state\board.html         # Windows
 ```
 
 That file is regenerated after every agent and at every merge, so it is a
-real answer, not a stale one. It carries everything except the Spend tab,
-which is fetched rather than embedded — see [Spend](#spend) for why. Over
-`file://` the tab is empty and says nothing is wrong; over the server, a
-spend failure now says which failure it was.
+real answer, not a stale one. It carries everything except **Spend** and
+**Settings**, which are fetched rather than embedded — see [Spend](#spend)
+for why, and the same reasoning covers config. Over `file://` both tabs say
+where their data comes from rather than rendering an empty panel; over the
+server, a failure says which failure it was.
 
 Inside a session you never type either command: **`/tyran:status` regenerates
 the board and tells you where it is.** The three commands are the same board
 from three directions — `--serve` for a browser you keep open, the file for a
 quick look, `BOARD.md` for reading in the terminal or in a diff.
 
-## board.html, in four tabs
+## board.html, in five tabs
 
 The page an operator leaves open overnight: self-contained (inline CSS/JS,
 zero external hosts and zero CDNs, complete over `file://`; the one
@@ -161,6 +163,7 @@ and the page opens on Overview:
 | **Board** | where every ticket is — the lanes, and the detail of whichever card you select |
 | **Waiting on you** | what is blocked on a decision, and the commands that unblock it |
 | **Spend** | what the work has cost |
+| **Settings** | what Tyran is configured to do, and — with `--write` — how to change it |
 
 The queue's tab label carries its open count, because the operator is usually
 looking at one of the other three, and a question they cannot see is a
@@ -197,10 +200,13 @@ client builds DOM with `createElement`/`textContent` only.
 node scripts/board.mjs --dir .tyran            # render all three artefacts
 node scripts/board.mjs --dir .tyran --check    # byte-exact drift check, exit 1
 node scripts/board.mjs --dir .tyran --serve    # localhost viewer, always fresh
+node scripts/board.mjs --dir .tyran --serve --write   # ... and Settings can edit
 ```
 
 `--serve` binds `127.0.0.1` only, re-renders per request, and never derives a
-filesystem path from a URL. The initiative ceiling is 64, refused loudly —
+filesystem path from a URL; `--write` adds the [Settings](#settings) routes and
+nothing else, and refuses on its own (`--write` without `--serve` is a usage
+error, not a silent no-op). The initiative ceiling is 64, refused loudly —
 archive closed initiatives rather than boarding them. An unreadable journal
 renders as a visible **UNREADABLE** entry: a board that omits a broken
 initiative would read as "all is well" exactly when it is not.
@@ -234,6 +240,92 @@ one same-origin request to loopback, and the same defences cover it: the
 `--serve` (a foreign `Host` gets 403, verified), and a cost read that fails
 returns 503 rather than taking the board down — the board answers "what is
 going on", and that answer does not depend on knowing what it cost.
+
+## Settings
+
+The **Settings** tab is the only thing on this page that writes. Everything
+else is a projection of the journal, where hand-editing is drift; config and
+the autonomy policy are the opposite — operator-owned files that nothing
+generates, and until this tab existed the only way to change them was an
+editor and a memory of what each key meant.
+
+```bash
+npx @jjanczur/tyran board --dir .tyran --serve --write
+```
+
+Without `--write` the tab still renders, every control disabled, with the
+command that turns it on. **Writes are off by default and per-invocation**:
+a board left running is reachable by anything on the machine, and the
+difference between reading that and editing the autonomy policy through it is
+the difference this flag exists to make.
+
+What it edits, with a sentence of prose on every knob:
+
+| | |
+|---|---|
+| `.tyran/config.yaml` | cost profile · deployment autonomy · the four model tiers · validation commands · shared zones · the whole `limits:` block |
+| `.tyran/policies/autonomy.yaml` | the `default` class, and the class of any existing rule |
+
+**One line moves.** The file is not round-tripped through a serializer —
+`scripts/yaml-patch.mjs` finds the line that owns the value and rewrites that
+line, keeping its trailing comment, the blank lines, the key order and your
+own spacing. `templates/config.yaml` is 60 lines of comment out of 91, and
+those comments are the only place anyone is told that bare `off` is the YAML
+boolean false; a serializer round-trip would delete all of it silently the
+first time someone moved a control.
+
+**The edit is proved, not trusted.** Every patch is applied and then parsed
+back and compared to the document that was intended: the target holds the new
+value, and every other path holds exactly what it held before. Then the result
+goes through the same `validateConfig` / `validatePolicy` that
+`node scripts/schema.mjs validate` runs. If either check fails, nothing is
+written and the page says why. A refused change leaves the file byte-identical.
+
+**The boundary still protects itself.** `hooks/**` and `.tyran/policies/**`
+are rendered as locked KERNEL rows with no control at all, and the write route
+refuses them twice over — once by name, and once because `validatePolicy`
+rejects any policy in which a kernel path resolves below KERNEL, however the
+rule is spelled. A screen that could lower the class of its own enforcement
+would be the way around the gate rather than the way to configure it.
+
+**Loosening takes a second, deliberate act. Tightening does not.** Those two
+protected globs are the only ones the validator defends, and the shipped
+policy carries several more whose own stated reason is that they must not
+move — `.claude/settings.json` ("anything that can edit it can switch every
+gate off"), `.tyran/STOP` ("a loop that can clear its own stop signal has
+none"). A dropdown treats those like any other choice, so:
+
+- **moving a class toward AUTO**, or **raising `autonomy`** (P1 → P2 → P3), is
+  refused on the first request. The refusal quotes the rule's own `reason:`
+  and names a confirmation token; the page turns that into one extra
+  **Yes — loosen it** press, and the second request carries the token.
+- the token is the **new value itself**, not a boolean, so nothing can widen a
+  boundary by sending a truthy flag beside whatever value it liked.
+- **tightening applies on the first click**, exactly like every other setting.
+  Friction on making a boundary stricter is how you teach someone to stop
+  making boundaries stricter.
+
+`validation:` is not in that set, deliberately. It is a list of shell commands
+and it looks like it belongs — but `.tyran/config.yaml` is class AUTO in the
+shipped policy, so an agent can already edit it directly. A confirmation on
+the page would add friction without adding a boundary; tighten that rule
+instead, on the same screen, if the trade is wrong for your repo.
+
+**What it deliberately will not do**: create a key that is not already in the
+file (absent knobs render as "add it by hand once"), author or delete a policy
+rule (a boundary's written `reason` is load-bearing, and a one-line reason
+typed into a form is how a policy turns into a list of unexplained globs), or
+edit `pricing:` (a rate card is a table copied from a vendor's price list).
+
+**What guards the route, stated exactly.** The `Host` pin that covers the whole
+server, plus an `Origin` check and a required `application/json` content type —
+together those close the browser paths: a page on another origin cannot read
+the board, and its POST is preflighted and refused. What they do **not** do is
+stop another process on your machine that can already reach loopback; nothing
+served on localhost can. The flag is the control that matters there, and the
+KERNEL invariant is what holds even if the flag is on. Every write also prints
+a line to the terminal running the server, and lands in `git diff` — those two
+are the audit trail.
 
 ## board.json, schema 1
 

--- a/site/src/content/docs/board.mdx
+++ b/site/src/content/docs/board.mdx
@@ -269,9 +269,9 @@ What it edits, with a sentence of prose on every knob:
 **One line moves.** The file is not round-tripped through a serializer —
 `scripts/yaml-patch.mjs` finds the line that owns the value and rewrites that
 line, keeping its trailing comment, the blank lines, the key order and your
-own spacing. `templates/config.yaml` is 60 lines of comment out of 91, and
-those comments are the only place anyone is told that bare `off` is the YAML
-boolean false; a serializer round-trip would delete all of it silently the
+own spacing. `templates/config.yaml` is 63 comment lines out of 90, and those
+comments are the only place anyone is told that bare `off` is the YAML boolean
+false; a serializer round-trip would delete all of it silently the
 first time someone moved a control.
 
 **The edit is proved, not trusted.** Every patch is applied and then parsed

--- a/site/src/content/docs/configuration.mdx
+++ b/site/src/content/docs/configuration.mdx
@@ -13,6 +13,12 @@ written by `scripts/scan-repo.mjs` · validated by `scripts/schema.mjs`
 All per-repo configuration lives in `.tyran/config.yaml` — committed, human
 reviewable, written by `/tyran:setup` and editable by hand.
 
+**Or from the board.** `npx @jjanczur/tyran board --serve --write` puts every
+key below on a screen with a sentence explaining what it does, and writes your
+change back into this file one line at a time, comments intact — including the
+autonomy policy. See [the Settings tab](../board/#settings) for what it will and
+will not touch, and for why loosening a boundary there takes a second press.
+
 ## `.tyran/config.yaml`
 
 ```yaml

--- a/site/src/content/docs/projections.mdx
+++ b/site/src/content/docs/projections.mdx
@@ -5,7 +5,7 @@ description: 'How STATE.md and PROGRESS.md are generated from the journal, the d
 import Provenance from '../../components/Provenance.astro';
 
 <Provenance>
-`scripts/project.mjs` · 68 unit tests, including byte-exact golden files
+`scripts/project.mjs` · 69 unit tests, including byte-exact golden files
 </Provenance>
 
 The journal stays the only source of truth; everything on this page is a

--- a/tests/unit/board-write.test.mjs
+++ b/tests/unit/board-write.test.mjs
@@ -217,10 +217,38 @@ test('a hostile body is refused rather than interpreted', async () => {
   }
 });
 
-test('loosening a boundary over HTTP takes two requests, and the first one says which token', async () => {
+test('a value the YAML subset cannot spell is a 400, not a 500 in the audit trail', async () => {
+  // Ordinary rejected input — somebody pasted a model name with a newline in
+  // it — was being classified as a server fault, which meant HTTP 500 plus a
+  // `board: settings write failed` line in the terminal the docs designate as
+  // the record of what this screen changed. MUTANT: let YamlLiteError escape
+  // `patch()` again.
+  const f = fixture();
+  const s = await serve(f.tyran, ['--write']);
+  try {
+    for (const bad of ['a\nb', `a${String.fromCodePoint(0x202e)}b`]) {
+      const res = await post(s.base, '/settings/config', { id: 'tiers.cheap', value: bad });
+      assert.equal(res.status, 400, `${JSON.stringify(bad)} should be a refusal, not a fault`);
+      assert.equal((await res.json()).ok, false);
+    }
+    assert.doesNotMatch(s.log(), /settings write failed/, 'a rejected value is not a server fault');
+    assert.equal(parse(readFileSync(join(f.tyran, 'config.yaml'), 'utf8')).tiers.cheap, 'haiku');
+  } finally {
+    await s.stop();
+    f.cleanup();
+  }
+});
+
+test('loosening a boundary is refused unless the request names the change', async () => {
   // MUTANT: stop threading `confirm` through handleSettingsWrite. The first
   // request succeeds and `.tyran/STOP` — the brake an operator uses to halt a
   // running initiative — goes to AUTO in one POST.
+  //
+  // What this does NOT claim: that two round trips are required. The token is
+  // the new value, which is deterministic and not a server-issued nonce, so a
+  // caller that already knows the change can send it in one request. That is
+  // the design — this guard is against a click, not against a script, and
+  // `docs/board.md` says which of those it defends.
   const f = fixture();
   const s = await serve(f.tyran, ['--write']);
   try {

--- a/tests/unit/board-write.test.mjs
+++ b/tests/unit/board-write.test.mjs
@@ -1,0 +1,326 @@
+/**
+ * The board's write channel, exercised against a REAL running server.
+ *
+ * Every other assertion about `--serve` in this repository matches strings in
+ * a rendered page or calls a pure function. Neither would notice a route that
+ * is never reached, a flag that is never consulted, or a 403 that is actually
+ * a 200 — and this is the one surface where being wrong means a web page can
+ * edit the file that decides what agents may write. So this file starts the
+ * process the operator starts, and talks to it over HTTP.
+ */
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { spawn } from 'node:child_process';
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { parse } from '../../scripts/yaml-lite.mjs';
+import { validateConfig, validatePolicy } from '../../scripts/schema.mjs';
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..', '..');
+const SCRIPT = join(ROOT, 'scripts', 'board.mjs');
+const FIXTURE = join(ROOT, 'tests', 'fixtures', 'journal-demo.jsonl');
+
+/** A .tyran directory with one initiative and the shipped config + policy. */
+function fixture() {
+  const dir = mkdtempSync(join(tmpdir(), 'tyran-board-write-'));
+  const tyran = join(dir, '.tyran');
+  mkdirSync(join(tyran, 'policies'), { recursive: true });
+  mkdirSync(join(tyran, 'state', 'demo'), { recursive: true });
+  writeFileSync(join(tyran, 'config.yaml'), readFileSync(join(ROOT, 'templates', 'config.yaml'), 'utf8'));
+  writeFileSync(join(tyran, 'policies', 'autonomy.yaml'), readFileSync(join(ROOT, 'templates', 'policies', 'autonomy.yaml'), 'utf8'));
+  writeFileSync(join(tyran, 'state', 'demo', 'journal.jsonl'), readFileSync(FIXTURE, 'utf8'));
+  return { dir, tyran, cleanup: () => rmSync(dir, { recursive: true, force: true }) };
+}
+
+/**
+ * Start the server and wait for the line it prints.
+ *
+ * The port comes from the OS rather than a constant: two of these run
+ * concurrently under the suite's default parallelism, and a fixed port makes
+ * the second one fail with EADDRINUSE on a machine that is doing nothing
+ * wrong.
+ */
+async function serve(tyran, extraArgs = []) {
+  const { createServer } = await import('node:http');
+  const port = await new Promise((done, fail) => {
+    const probe = createServer();
+    probe.on('error', fail);
+    probe.listen(0, '127.0.0.1', () => {
+      const { port: p } = probe.address();
+      probe.close(() => done(p));
+    });
+  });
+  const child = spawn(process.execPath, [SCRIPT, '--dir', tyran, '--serve', '--port', String(port), ...extraArgs], {
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+  let log = '';
+  child.stdout.on('data', (d) => { log += String(d); });
+  child.stderr.on('data', (d) => { log += String(d); });
+  const base = `http://127.0.0.1:${port}`;
+  for (let i = 0; i < 100; i += 1) {
+    if (log.includes('board: serving')) break;
+    await new Promise((r) => setTimeout(r, 50));
+  }
+  assert.match(log, /board: serving/, `the server did not start: ${log}`);
+  return {
+    base,
+    log: () => log,
+    stop: () => new Promise((done) => { child.once('exit', () => done()); child.kill(); }),
+  };
+}
+
+const post = (base, route, body, headers = {}) =>
+  fetch(`${base}${route}`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json', ...headers },
+    body: typeof body === 'string' ? body : JSON.stringify(body),
+  });
+
+test('a board served without --write refuses every write and names the flag', async () => {
+  // MUTANT: default `write` to true in parseArgs. Every assertion about the
+  // catalogue still passes; a board someone left running becomes editable by
+  // anything that can reach loopback.
+  const f = fixture();
+  const s = await serve(f.tyran);
+  try {
+    const settings = await (await fetch(`${s.base}/settings.json`)).json();
+    assert.equal(settings.writable, false, 'the page is told it may not write');
+    assert.equal(settings.schema, 1);
+
+    for (const [route, body] of [['/settings/config', { id: 'profile', value: 'eco' }], ['/settings/policy', { path: null, class: 'AUTO' }]]) {
+      const res = await post(s.base, route, body);
+      assert.equal(res.status, 403);
+      const payload = await res.json();
+      assert.equal(payload.ok, false);
+      assert.match(payload.error, /--write/, 'the refusal names the flag that turns it on');
+    }
+    assert.equal(readFileSync(join(f.tyran, 'config.yaml'), 'utf8'), readFileSync(join(ROOT, 'templates', 'config.yaml'), 'utf8'));
+  } finally {
+    await s.stop();
+    f.cleanup();
+  }
+});
+
+test('--write edits config and policy, one line at a time', async () => {
+  const f = fixture();
+  const s = await serve(f.tyran, ['--write']);
+  try {
+    const ok = await (await post(s.base, '/settings/config', { id: 'limits.mode', value: 'pause' })).json();
+    assert.equal(ok.ok, true);
+    assert.equal(ok.before, 'off');
+    assert.equal(ok.after, 'pause');
+
+    const pol = await (await post(s.base, '/settings/policy', { path: '.tyran/config.yaml', class: 'GATED' })).json();
+    assert.equal(pol.ok, true);
+    assert.deepEqual(pol.path, ['rules', 4, 'class']);
+
+    const config = parse(readFileSync(join(f.tyran, 'config.yaml'), 'utf8'));
+    assert.equal(config.limits.mode, 'pause');
+    assert.deepEqual(validateConfig(config), []);
+    const policy = parse(readFileSync(join(f.tyran, 'policies', 'autonomy.yaml'), 'utf8'));
+    assert.equal(policy.rules.find((r) => r.path === '.tyran/config.yaml').class, 'GATED');
+    assert.deepEqual(validatePolicy(policy), []);
+
+    // The operator's terminal is the audit trail for a change made from a
+    // web page. MUTANT: drop the console.log and a settings screen becomes a
+    // thing that edits your repo leaving no trace where a person looks.
+    assert.match(s.log(), /board: wrote .*config\.yaml — limits\.mode: "off" -> "pause"/);
+  } finally {
+    await s.stop();
+    f.cleanup();
+  }
+});
+
+test('the kernel paths survive the write route', async () => {
+  // The route must not be the way around the gate it configures.
+  const f = fixture();
+  const s = await serve(f.tyran, ['--write']);
+  try {
+    for (const glob of ['hooks/**', '.tyran/policies/**']) {
+      const res = await post(s.base, '/settings/policy', { path: glob, class: 'AUTO' });
+      assert.equal(res.status, 400);
+      assert.match((await res.json()).error, /KERNEL/);
+    }
+    assert.deepEqual(validatePolicy(parse(readFileSync(join(f.tyran, 'policies', 'autonomy.yaml'), 'utf8'))), []);
+  } finally {
+    await s.stop();
+    f.cleanup();
+  }
+});
+
+test('a cross-origin POST is refused even though the Host pin lets it through', async () => {
+  // The Host pin answers "which name did you dial", which a page on another
+  // origin satisfies by dialling 127.0.0.1 directly. Origin answers "who is
+  // asking", and it is the only header that separates the board's own fetch
+  // from some other tab's. MUTANT: delete originAllowed — the Host pin passes
+  // and this write lands.
+  const f = fixture();
+  const s = await serve(f.tyran, ['--write']);
+  try {
+    const res = await post(s.base, '/settings/config', { id: 'profile', value: 'eco' }, { origin: 'https://evil.example' });
+    assert.equal(res.status, 403);
+    assert.equal(parse(readFileSync(join(f.tyran, 'config.yaml'), 'utf8')).profile, 'balanced');
+
+    // The board's own page, which is what must keep working.
+    const own = await post(s.base, '/settings/config', { id: 'profile', value: 'eco' }, { origin: s.base });
+    assert.equal((await own.json()).ok, true);
+  } finally {
+    await s.stop();
+    f.cleanup();
+  }
+});
+
+test('only application/json is accepted, because that is what forces a preflight', async () => {
+  // A form POST (text/plain, or a urlencoded form) is a "simple request": a
+  // browser sends it cross-origin without asking permission first. Requiring
+  // a JSON content type is what makes the browser preflight and be refused.
+  // MUTANT: accept any content type.
+  const f = fixture();
+  const s = await serve(f.tyran, ['--write']);
+  try {
+    const res = await post(s.base, '/settings/config', { id: 'profile', value: 'eco' }, { 'content-type': 'text/plain' });
+    assert.equal(res.status, 400);
+    assert.match((await res.json()).error, /application\/json/);
+    assert.equal(parse(readFileSync(join(f.tyran, 'config.yaml'), 'utf8')).profile, 'balanced');
+  } finally {
+    await s.stop();
+    f.cleanup();
+  }
+});
+
+test('a hostile body is refused rather than interpreted', async () => {
+  const f = fixture();
+  const s = await serve(f.tyran, ['--write']);
+  try {
+    const cases = [
+      ['not json at all', 400],
+      [JSON.stringify(['profile', 'eco']), 400],
+      [JSON.stringify({ id: '__proto__', value: 'x' }), 400],
+      [JSON.stringify({ id: 'profile', value: { toString: 'x' } }), 400],
+      [JSON.stringify({ id: 'validation', value: 'rm -rf /' }), 400],
+    ];
+    for (const [body, status] of cases) {
+      const res = await post(s.base, '/settings/config', body);
+      assert.equal(res.status, status, `body ${body} should be refused`);
+      assert.equal((await res.json()).ok, false);
+    }
+    // A body over the cap is dropped rather than buffered.
+    const huge = await post(s.base, '/settings/config', JSON.stringify({ id: 'tiers.work', value: 'x'.repeat(200_000) }))
+      .catch(() => ({ status: 400 }));
+    assert.notEqual(huge.status, 200);
+    assert.deepEqual(validateConfig(parse(readFileSync(join(f.tyran, 'config.yaml'), 'utf8'))), []);
+  } finally {
+    await s.stop();
+    f.cleanup();
+  }
+});
+
+test('loosening a boundary over HTTP takes two requests, and the first one says which token', async () => {
+  // MUTANT: stop threading `confirm` through handleSettingsWrite. The first
+  // request succeeds and `.tyran/STOP` — the brake an operator uses to halt a
+  // running initiative — goes to AUTO in one POST.
+  const f = fixture();
+  const s = await serve(f.tyran, ['--write']);
+  try {
+    const first = await post(s.base, '/settings/policy', { path: '.tyran/STOP', class: 'AUTO' });
+    assert.equal(first.status, 400);
+    const refusal = await first.json();
+    assert.equal(refusal.widens, true);
+    assert.equal(refusal.confirm_with, 'AUTO');
+    assert.match(refusal.error, /clear its own stop signal/, 'the rule states its own consequence');
+    assert.equal(parse(readFileSync(join(f.tyran, 'policies', 'autonomy.yaml'), 'utf8')).rules.find((r) => r.path === '.tyran/STOP').class, 'KERNEL');
+
+    const second = await post(s.base, '/settings/policy', { path: '.tyran/STOP', class: 'AUTO', confirm: refusal.confirm_with });
+    assert.equal((await second.json()).ok, true);
+    assert.equal(parse(readFileSync(join(f.tyran, 'policies', 'autonomy.yaml'), 'utf8')).rules.find((r) => r.path === '.tyran/STOP').class, 'AUTO');
+  } finally {
+    await s.stop();
+    f.cleanup();
+  }
+});
+
+test('a board renders on a repo that has been set up and never run', async () => {
+  // The command the README leads with, on the state every install passes
+  // through. It used to die with an ENOENT naming a temp file, because
+  // `.tyran/state/` is created by the first initiative and setup does not
+  // create it. MUTANT: remove the mkdirSync from writeAllAtomic.
+  const { execFileSync } = await import('node:child_process');
+  const dir = mkdtempSync(join(tmpdir(), 'tyran-fresh-'));
+  try {
+    mkdirSync(join(dir, '.tyran', 'policies'), { recursive: true });
+    const out = execFileSync(process.execPath, [SCRIPT, '--dir', join(dir, '.tyran')], { stdio: 'pipe', encoding: 'utf8' });
+    assert.match(out, /board\.html/);
+    for (const name of ['BOARD.md', 'board.json', 'board.html']) {
+      assert.ok(readFileSync(join(dir, '.tyran', 'state', name), 'utf8').length > 0, `${name} was written`);
+    }
+    // And the render is stable, so --check on a journal-less repo is not
+    // permanently red.
+    execFileSync(process.execPath, [SCRIPT, '--dir', join(dir, '.tyran'), '--check'], { stdio: 'pipe' });
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('the write routes take POST only', async () => {
+  const f = fixture();
+  const s = await serve(f.tyran, ['--write']);
+  try {
+    for (const route of ['/settings/config', '/settings/policy']) {
+      const res = await fetch(`${s.base}${route}`);
+      assert.equal(res.status, 405);
+    }
+  } finally {
+    await s.stop();
+    f.cleanup();
+  }
+});
+
+test('a foreign Host is refused before any route is considered', async () => {
+  // Raw http, not fetch: `Host` is a forbidden header in undici, so a fetch
+  // cannot express the DNS-rebinding request this pin exists to refuse.
+  // MUTANT: delete the Host pin — any page the operator visits can resolve
+  // its own hostname to 127.0.0.1 and POST to this board.
+  const { request } = await import('node:http');
+  const f = fixture();
+  const s = await serve(f.tyran, ['--write']);
+  try {
+    const { port } = new URL(s.base);
+    const answer = await new Promise((done, fail) => {
+      const req = request(
+        { host: '127.0.0.1', port, path: '/settings/config', method: 'POST', headers: { host: 'evil.example', 'content-type': 'application/json' } },
+        (res) => {
+          let body = '';
+          res.on('data', (d) => { body += String(d); });
+          res.on('end', () => done({ status: res.statusCode, body }));
+        },
+      );
+      req.on('error', fail);
+      req.end(JSON.stringify({ id: 'profile', value: 'eco' }));
+    });
+    assert.equal(answer.status, 403);
+    assert.match(answer.body, /127\.0\.0\.1 only/);
+    assert.equal(parse(readFileSync(join(f.tyran, 'config.yaml'), 'utf8')).profile, 'balanced');
+  } finally {
+    await s.stop();
+    f.cleanup();
+  }
+});
+
+test('--write without --serve is a usage error, not a silent no-op', async () => {
+  const { execFileSync } = await import('node:child_process');
+  const f = fixture();
+  try {
+    assert.throws(
+      () => execFileSync(process.execPath, [SCRIPT, '--dir', f.tyran, '--write'], { stdio: 'pipe' }),
+      (err) => {
+        assert.equal(err.status, 2);
+        assert.match(String(err.stderr), /--write only means anything with --serve/);
+        return true;
+      },
+    );
+  } finally {
+    f.cleanup();
+  }
+});

--- a/tests/unit/project.test.mjs
+++ b/tests/unit/project.test.mjs
@@ -1243,15 +1243,22 @@ test('writeAllAtomic: an unwritable directory fails before touching anything', (
 });
 
 test('writeAllAtomic stages EVERY file before renaming any of them', () => {
-  // The first entry stages fine; the second cannot even be staged (its
-  // directory does not exist). A rename-as-you-go implementation would have
-  // already swapped STATE.md by then — this is what pins the ordering.
+  // The first entry stages fine; the second cannot even be staged. A
+  // rename-as-you-go implementation would have already swapped STATE.md by
+  // then — this is what pins the ordering.
+  //
+  // The unstageable entry is one whose PARENT is a regular file, not one
+  // whose parent is merely absent: an absent directory is now created, so
+  // that a board can be rendered on a repo that has been set up and never
+  // run. A parent that exists and is not a directory still cannot be made
+  // into one, which is the same failure at the same point.
   const out = dir();
   writeFileSync(join(out, STATE_FILE), 'OLD STATE\n');
+  writeFileSync(join(out, 'not-a-dir'), 'I am a file\n');
   assert.throws(() =>
     writeAllAtomic([
       [join(out, STATE_FILE), 'NEW STATE\n'],
-      [join(out, 'no-such-dir', PROGRESS_FILE), 'NEW PROGRESS\n'],
+      [join(out, 'not-a-dir', PROGRESS_FILE), 'NEW PROGRESS\n'],
     ]),
   );
   assert.equal(
@@ -1259,7 +1266,18 @@ test('writeAllAtomic stages EVERY file before renaming any of them', () => {
     'OLD STATE\n',
     'STATE.md was swapped before the whole set could be staged',
   );
-  assert.deepEqual(readdirSync(out), [STATE_FILE], 'a temp file was left behind');
+  assert.deepEqual(readdirSync(out).sort(), [STATE_FILE, 'not-a-dir'].sort(), 'a temp file was left behind');
+});
+
+test('writeAllAtomic creates a directory that is merely absent', () => {
+  // `.tyran/state/` is created by the first initiative, so `board.mjs` on a
+  // repo that has been set up and never run had nowhere to stage and died
+  // with an ENOENT naming a temp file nobody had heard of — on the one
+  // command the README leads with. MUTANT: drop the mkdirSync.
+  const out = dir();
+  writeAllAtomic([[join(out, 'state', STATE_FILE), 'NEW STATE\n']]);
+  assert.equal(readFileSync(join(out, 'state', STATE_FILE), 'utf8'), 'NEW STATE\n');
+  assert.deepEqual(readdirSync(join(out, 'state')), [STATE_FILE], 'no temp file left behind');
 });
 
 test('writeAllAtomic leaves no orphaned .tmp when a RENAME fails', () => {

--- a/tests/unit/scan-control-chars.test.mjs
+++ b/tests/unit/scan-control-chars.test.mjs
@@ -910,10 +910,12 @@ test('THIS repository scans clean end to end', () => {
     'scripts/scan-control-chars.mjs',
     'scripts/scan-repo.mjs',
     'scripts/schema.mjs',
+    'scripts/settings.mjs',
     'scripts/statusline.mjs',
     'scripts/stop-check.mjs',
     'scripts/tiers.mjs',
     'scripts/yaml-lite.mjs',
+    'scripts/yaml-patch.mjs',
     'site/.gitignore',
     'site/astro.config.mjs',
     'site/package-lock.json',
@@ -995,6 +997,7 @@ test('THIS repository scans clean end to end', () => {
     'tests/pressure/.gitkeep',
     'tests/unit/agents.test.mjs',
     'tests/unit/answer.test.mjs',
+    'tests/unit/board-write.test.mjs',
     'tests/unit/board.test.mjs',
     'tests/unit/cli.test.mjs',
     'tests/unit/cost.test.mjs',
@@ -1026,10 +1029,12 @@ test('THIS repository scans clean end to end', () => {
     'tests/unit/scan-control-chars.test.mjs',
     'tests/unit/scan-repo.test.mjs',
     'tests/unit/schema.test.mjs',
+    'tests/unit/settings.test.mjs',
     'tests/unit/statusline.test.mjs',
     'tests/unit/stop-check.test.mjs',
     'tests/unit/tiers.test.mjs',
     'tests/unit/yaml-lite.test.mjs',
+    'tests/unit/yaml-patch.test.mjs',
   ], 'the set of scanned files changed — confirm nothing left the scan by accident');
 
   // The count stays asserted too, derived from the list rather than typed

--- a/tests/unit/settings.test.mjs
+++ b/tests/unit/settings.test.mjs
@@ -1,0 +1,374 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { AUTONOMY_CLASSES, LIMITS_MODES, PROFILES, TIER_KEYS, validateConfig, validatePolicy } from '../../scripts/schema.mjs';
+import { parse } from '../../scripts/yaml-lite.mjs';
+import { renderConfig, scanRepo } from '../../scripts/scan-repo.mjs';
+import { GROUPS, SettingsError, allSettings, applyPolicyClass, applySetting, readSettings } from '../../scripts/settings.mjs';
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..', '..');
+
+/** A .tyran directory seeded from the shipped templates. */
+function fixture() {
+  const dir = mkdtempSync(join(tmpdir(), 'tyran-settings-'));
+  const tyran = join(dir, '.tyran');
+  mkdirSync(join(tyran, 'policies'), { recursive: true });
+  writeFileSync(join(tyran, 'config.yaml'), readFileSync(join(ROOT, 'templates', 'config.yaml'), 'utf8'));
+  writeFileSync(join(tyran, 'policies', 'autonomy.yaml'), readFileSync(join(ROOT, 'templates', 'policies', 'autonomy.yaml'), 'utf8'));
+  return { dir, tyran, cleanup: () => rmSync(dir, { recursive: true, force: true }) };
+}
+
+/** applySetting returns the text; the server writes it. Do both here. */
+function write(tyran, applied) {
+  writeFileSync(applied.file, applied.text);
+  return applied;
+}
+
+test('reads every knob out of the shipped template with its value', () => {
+  const f = fixture();
+  try {
+    const s = readSettings(f.tyran);
+    const flat = s.groups.flatMap((g) => g.settings);
+    assert.equal(flat.length, allSettings().length);
+    assert.ok(flat.every((x) => x.present === true), 'the template sets every knob the catalogue offers');
+    const byId = new Map(flat.map((x) => [x.id, x.value]));
+    assert.equal(byId.get('profile'), 'balanced');
+    assert.equal(byId.get('autonomy'), 'P1');
+    assert.equal(byId.get('limits.mode'), 'off');
+    assert.equal(byId.get('limits.keep_awake'), false);
+    assert.deepEqual(byId.get('shared_zones'), []);
+  } finally {
+    f.cleanup();
+  }
+});
+
+test('the choices offered are the ones the validator accepts', () => {
+  // ADR-21: a second list of legal values here would drift from the one that
+  // enforces it, and the page would offer a choice the file rejects.
+  // MUTANT: hard-code ['eco','balanced'] in the catalogue.
+  const byId = new Map(allSettings().map((s) => [s.id, s]));
+  assert.deepEqual(byId.get('profile').choices.map((c) => c.value), [...PROFILES]);
+  assert.deepEqual(byId.get('autonomy').choices.map((c) => c.value), [...AUTONOMY_CLASSES]);
+  assert.deepEqual(byId.get('limits.mode').choices.map((c) => c.value), [...LIMITS_MODES]);
+  for (const key of TIER_KEYS) assert.ok(byId.has(`tiers.${key}`), `tiers.${key} is editable`);
+});
+
+test('every knob carries prose, because a control nobody understands is not a setting', () => {
+  // MUTANT: ship a setting with no help string. The page renders a bare
+  // dropdown and the operator is back to reading the YAML to find out what it
+  // does, which is the problem this whole screen exists to solve.
+  for (const setting of allSettings()) {
+    assert.ok(setting.help && setting.help.length > 30, `${setting.id} needs a real explanation`);
+    assert.ok(setting.label, `${setting.id} needs a label`);
+    if ((setting.kind ?? 'choice') === 'choice') {
+      for (const choice of setting.choices) {
+        assert.ok(choice.describe && choice.describe.length > 15, `${setting.id}=${choice.value} needs a description`);
+      }
+    }
+  }
+  for (const group of GROUPS) assert.ok(group.blurb && group.title, `${group.id} needs a title and a blurb`);
+});
+
+test('a freshly scanned config exposes every knob this screen offers', () => {
+  // The two spellings of one document: `templates/config.yaml` is what the
+  // docs show, `renderConfig(scanRepo(...))` is what an operator actually
+  // gets, and they had drifted — no `limits:` key at all, so the entire
+  // Overnight group rendered as seven lines of dead text on every fresh
+  // install, and doctor's limit-telemetry-missing could never fire either.
+  // MUTANT: drop the `limits` block from scanRepo's config.
+  const dir = mkdtempSync(join(tmpdir(), 'tyran-scan-'));
+  try {
+    const tyran = join(dir, '.tyran');
+    mkdirSync(tyran, { recursive: true });
+    writeFileSync(join(tyran, 'config.yaml'), renderConfig(scanRepo(dir).config));
+    assert.deepEqual(validateConfig(parse(readFileSync(join(tyran, 'config.yaml'), 'utf8'))), []);
+    const missing = readSettings(tyran).groups
+      .flatMap((g) => g.settings)
+      .filter((s) => s.present !== true)
+      .map((s) => s.id);
+    assert.deepEqual(missing, [], 'every catalogued setting must resolve in a scanned config');
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('a write lands as one line and the file stays valid', () => {
+  const f = fixture();
+  try {
+    const before = readFileSync(join(f.tyran, 'config.yaml'), 'utf8');
+    write(f.tyran, applySetting(f.tyran, 'limits.mode', 'pause'));
+    const after = readFileSync(join(f.tyran, 'config.yaml'), 'utf8');
+    assert.equal(before.split('\n').filter((l, i) => l !== after.split('\n')[i]).length, 1);
+    assert.deepEqual(validateConfig(parse(after)), []);
+    assert.equal(parse(after).limits.mode, 'pause');
+  } finally {
+    f.cleanup();
+  }
+});
+
+test('rejects a value the validator would reject, and writes nothing', () => {
+  const f = fixture();
+  try {
+    const before = readFileSync(join(f.tyran, 'config.yaml'), 'utf8');
+    assert.throws(() => applySetting(f.tyran, 'profile', 'turbo'), SettingsError);
+    // 0.97 where 97 belongs: the classic fraction-for-percent footgun, which
+    // would otherwise pause on the first tool call of every session.
+    assert.throws(() => applySetting(f.tyran, 'limits.pause_at_percent', 0.97), SettingsError);
+    assert.throws(() => applySetting(f.tyran, 'limits.keep_awake', 'yes'), SettingsError);
+    assert.throws(() => applySetting(f.tyran, 'tiers.work', '   '), SettingsError);
+    assert.throws(() => applySetting(f.tyran, 'nonesuch', 1), SettingsError);
+    assert.equal(readFileSync(join(f.tyran, 'config.yaml'), 'utf8'), before, 'a refused write changes nothing');
+  } finally {
+    f.cleanup();
+  }
+});
+
+test('the kernel paths cannot be lowered through this screen', () => {
+  // The boundary has to protect itself through the write route too, or the
+  // route IS the way around the gate. MUTANT: delete the ruleLocked check —
+  // and note that validatePolicy still catches it, which is the point of
+  // having both.
+  const f = fixture();
+  try {
+    for (const glob of ['hooks/**', '.tyran/policies/**']) {
+      assert.throws(() => applyPolicyClass(f.tyran, glob, 'AUTO'), (err) => {
+        assert.ok(err instanceof SettingsError);
+        assert.match(err.message, /KERNEL/);
+        return true;
+      });
+    }
+    const s = readSettings(f.tyran);
+    const locked = s.policy.rules.filter((r) => r.locked).map((r) => r.path);
+    assert.deepEqual(locked.sort(), ['.tyran/policies/**', 'hooks/**']);
+  } finally {
+    f.cleanup();
+  }
+});
+
+test('a rule that would claim a kernel path is refused by the validator itself', () => {
+  // The lock list is an exact-path check; this is the case it does not cover
+  // and validatePolicy does — a DIFFERENT, more specific glob reaching into
+  // the protected namespace. MUTANT: skip the validatePolicy call after the
+  // patch and this write lands.
+  const f = fixture();
+  try {
+    const file = join(f.tyran, 'policies', 'autonomy.yaml');
+    const text = readFileSync(file, 'utf8').replace(
+      '  - path: .tyran/knowledge/**',
+      '  - path: hooks/scripts/**\n    class: KERNEL\n    reason: placeholder\n\n  - path: .tyran/knowledge/**',
+    );
+    writeFileSync(file, text);
+    assert.throws(() => applyPolicyClass(f.tyran, 'hooks/scripts/**', 'AUTO'), (err) => {
+      assert.ok(err instanceof SettingsError);
+      assert.match(err.message, /invalid|KERNEL/);
+      return true;
+    });
+    assert.equal(readFileSync(file, 'utf8'), text, 'nothing was written');
+  } finally {
+    f.cleanup();
+  }
+});
+
+test('a rule is addressed by its glob, so a moved file cannot misdirect the write', () => {
+  // MUTANT: address rules by the index the page was rendered with. Reorder
+  // the file between read and write and the class lands on a neighbour.
+  const f = fixture();
+  try {
+    const file = join(f.tyran, 'policies', 'autonomy.yaml');
+    const original = parse(readFileSync(file, 'utf8'));
+    const target = '.claude/agents/**';
+    const wasAt = original.rules.findIndex((r) => r.path === target);
+    // Move the target rule by inserting one ahead of it.
+    writeFileSync(file, readFileSync(file, 'utf8').replace(
+      '  - path: .tyran/knowledge/**',
+      '  - path: docs/**\n    class: AUTO\n    reason: inserted to shift every later index\n\n  - path: .tyran/knowledge/**',
+    ));
+    write(f.tyran, applyPolicyClass(f.tyran, target, 'AUTO', 'AUTO'));
+    const after = parse(readFileSync(file, 'utf8'));
+    assert.equal(after.rules.find((r) => r.path === target).class, 'AUTO');
+    assert.equal(after.rules[wasAt].path, '.tyran/config.yaml', 'the old index now holds a different rule');
+    assert.equal(after.rules[wasAt].class, 'AUTO', 'and it was not the one that changed');
+    assert.deepEqual(validatePolicy(after), []);
+  } finally {
+    f.cleanup();
+  }
+});
+
+test('the policy default is editable and is addressed by null', () => {
+  const f = fixture();
+  try {
+    write(f.tyran, applyPolicyClass(f.tyran, null, 'AUTO', 'AUTO'));
+    assert.equal(parse(readFileSync(join(f.tyran, 'policies', 'autonomy.yaml'), 'utf8')).default, 'AUTO');
+  } finally {
+    f.cleanup();
+  }
+});
+
+test('a provenanced value is written into .value, not over the wrapper', () => {
+  // setup writes `profile: {value, source, confidence}` when it inferred the
+  // answer. MUTANT: always patch the bare path — the wrapper is replaced by a
+  // scalar and the provenance an operator uses to audit the value is gone.
+  const f = fixture();
+  try {
+    const file = join(f.tyran, 'config.yaml');
+    writeFileSync(file, readFileSync(file, 'utf8').replace(
+      'profile: balanced',
+      "profile:\n  value: balanced\n  source: 'git log: inferred'\n  confidence: 0.9",
+    ));
+    write(f.tyran, applySetting(f.tyran, 'profile', 'eco'));
+    const doc = parse(readFileSync(file, 'utf8'));
+    assert.deepEqual(doc.profile, { value: 'eco', source: 'git log: inferred', confidence: 0.9 });
+    assert.deepEqual(validateConfig(doc), []);
+    assert.equal(readSettings(f.tyran).groups[0].settings[0].value, 'eco', 'and it reads back through the wrapper');
+  } finally {
+    f.cleanup();
+  }
+});
+
+test('a config that does not parse is reported, not thrown', () => {
+  // This screen is exactly where an operator wants to be when the file is
+  // broken. MUTANT: let the YamlLiteError escape — the whole tab 500s and the
+  // one thing that could have named the broken file shows nothing.
+  const f = fixture();
+  try {
+    writeFileSync(join(f.tyran, 'config.yaml'), 'profile: >-\n  balanced\n');
+    const s = readSettings(f.tyran);
+    assert.equal(s.files.config.present, true);
+    assert.match(s.files.config.error, /block scalar/);
+    assert.ok(s.groups.flatMap((g) => g.settings).every((x) => x.present === false));
+    assert.throws(() => applySetting(f.tyran, 'profile', 'eco'), SettingsError);
+  } finally {
+    f.cleanup();
+  }
+});
+
+test('a missing key is offered as absent rather than as an empty control', () => {
+  const f = fixture();
+  try {
+    const file = join(f.tyran, 'config.yaml');
+    writeFileSync(file, readFileSync(file, 'utf8').replace(/^ {2}keep_awake:.*$/m, ''));
+    const setting = readSettings(f.tyran).groups.flatMap((g) => g.settings).find((x) => x.id === 'limits.keep_awake');
+    assert.equal(setting.present, false);
+    assert.throws(() => applySetting(f.tyran, 'limits.keep_awake', true), /is not in/);
+  } finally {
+    f.cleanup();
+  }
+});
+
+test('a missing file says so instead of creating one', () => {
+  const dir = mkdtempSync(join(tmpdir(), 'tyran-settings-empty-'));
+  try {
+    mkdirSync(join(dir, '.tyran'), { recursive: true });
+    const s = readSettings(join(dir, '.tyran'));
+    assert.equal(s.files.config.present, false);
+    assert.equal(s.policy.rules.length, 0);
+    assert.throws(() => applySetting(join(dir, '.tyran'), 'profile', 'eco'), /does not exist/);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('loosening a boundary needs a second, deliberate confirmation', () => {
+  // The hole this closes: MANDATORY_KERNEL_PATHS covers `hooks/**` and
+  // `.tyran/policies/**` and nothing else, so `.claude/settings.json` ("anything
+  // that can edit it can switch every gate off") and `.tyran/STOP` ("a loop
+  // that can clear its own stop signal has none") were one click from AUTO.
+  // MUTANT: delete the requireConfirm call in applyPolicyClass.
+  const f = fixture();
+  try {
+    for (const glob of ['.claude/settings.json', '.claude/settings.local.json', '.tyran/STOP']) {
+      assert.throws(() => applyPolicyClass(f.tyran, glob, 'AUTO'), (err) => {
+        assert.ok(err instanceof SettingsError);
+        assert.equal(err.widens, true);
+        assert.equal(err.confirm_with, 'AUTO');
+        // The rule's own reason is the warning: whoever put the boundary
+        // there wrote a better one than this module could compose.
+        assert.match(err.message, /This rule exists because:/);
+        return true;
+      });
+    }
+    // Same for the default, and for raising the deployment class.
+    assert.throws(() => applyPolicyClass(f.tyran, null, 'AUTO'), (err) => err.widens === true);
+    assert.throws(() => applySetting(f.tyran, 'autonomy', 'P3'), (err) => {
+      assert.equal(err.widens, true);
+      assert.match(err.message, /merges to the default branch/);
+      return true;
+    });
+  } finally {
+    f.cleanup();
+  }
+});
+
+test('the confirmation must name the change, so a truthy flag does not satisfy it', () => {
+  // MUTANT: accept any non-null `confirm`. A caller that sends
+  // `{confirm: true}` alongside whatever value it liked would then widen
+  // anything, which is not a confirmation, it is a formality.
+  const f = fixture();
+  try {
+    assert.throws(() => applyPolicyClass(f.tyran, '.tyran/STOP', 'AUTO', 'yes'), (err) => err.widens === true);
+    assert.throws(() => applyPolicyClass(f.tyran, '.tyran/STOP', 'AUTO', 'GATED'), (err) => err.widens === true);
+    const ok = write(f.tyran, applyPolicyClass(f.tyran, '.tyran/STOP', 'AUTO', 'AUTO'));
+    assert.equal(ok.after, 'AUTO');
+    assert.deepEqual(validatePolicy(parse(readFileSync(join(f.tyran, 'policies', 'autonomy.yaml'), 'utf8'))), []);
+  } finally {
+    f.cleanup();
+  }
+});
+
+test('tightening applies on one click, because friction there teaches the wrong lesson', () => {
+  // MUTANT: make requireConfirm symmetric. Every step toward a stricter
+  // boundary then costs an extra confirmation, which is how you train an
+  // operator to stop tightening things.
+  const f = fixture();
+  try {
+    write(f.tyran, applyPolicyClass(f.tyran, '.tyran/config.yaml', 'GATED'));
+    write(f.tyran, applyPolicyClass(f.tyran, '.claude/agents/**', 'KERNEL'));
+    write(f.tyran, applySetting(f.tyran, 'autonomy', 'P1'));
+    const doc = parse(readFileSync(join(f.tyran, 'policies', 'autonomy.yaml'), 'utf8'));
+    assert.equal(doc.rules.find((r) => r.path === '.tyran/config.yaml').class, 'GATED');
+    assert.equal(doc.rules.find((r) => r.path === '.claude/agents/**').class, 'KERNEL');
+  } finally {
+    f.cleanup();
+  }
+});
+
+test('P2 is a widening of P1 and P1 is a tightening of P2', () => {
+  const f = fixture();
+  try {
+    assert.throws(() => applySetting(f.tyran, 'autonomy', 'P2'), (err) => err.widens === true);
+    write(f.tyran, applySetting(f.tyran, 'autonomy', 'P2', 'P2'));
+    write(f.tyran, applySetting(f.tyran, 'autonomy', 'P1'));
+    assert.equal(parse(readFileSync(join(f.tyran, 'config.yaml'), 'utf8')).autonomy, 'P1');
+  } finally {
+    f.cleanup();
+  }
+});
+
+test('an ordinary setting is not dragged into the confirmation flow', () => {
+  // The guard is for boundaries, not for every control. MUTANT: apply
+  // requireConfirm to every setting — the whole screen becomes two clicks.
+  const f = fixture();
+  try {
+    write(f.tyran, applySetting(f.tyran, 'profile', 'eco'));
+    write(f.tyran, applySetting(f.tyran, 'limits.mode', 'pause'));
+    write(f.tyran, applySetting(f.tyran, 'limits.keep_awake', true));
+    assert.equal(parse(readFileSync(join(f.tyran, 'config.yaml'), 'utf8')).profile, 'eco');
+  } finally {
+    f.cleanup();
+  }
+});
+
+test('list edits keep the comments around them', () => {
+  const f = fixture();
+  try {
+    write(f.tyran, applySetting(f.tyran, 'validation', ['npm test', '', '  npm run build  ']));
+    const text = readFileSync(join(f.tyran, 'config.yaml'), 'utf8');
+    assert.deepEqual(parse(text).validation, ['npm test', 'npm run build'], 'blanks dropped, entries trimmed');
+    assert.ok(text.includes('# Repo validation commands, run before anything is called done.'));
+  } finally {
+    f.cleanup();
+  }
+});

--- a/tests/unit/yaml-patch.test.mjs
+++ b/tests/unit/yaml-patch.test.mjs
@@ -4,7 +4,25 @@ import { readFileSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
 import { parse } from '../../scripts/yaml-lite.mjs';
-import { patch, YamlPatchError } from '../../scripts/yaml-patch.mjs';
+import { patch, sameValue, YamlPatchError } from '../../scripts/yaml-patch.mjs';
+
+/** A config indented four spaces, which yaml-lite and validateConfig both accept. */
+const FOUR_SPACE = [
+  'tiers:',
+  '    cheap: haiku # scout',
+  '    work: sonnet',
+  'limits:',
+  "    mode: 'off'",
+  '    keep_awake: false',
+  'rules:',
+  '    - path: a/**',
+  '      class: AUTO',
+  '    - path: b/**',
+  '      class: GATED',
+  'validation:',
+  '    - npm test',
+  '',
+].join('\n');
 
 const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..', '..');
 const template = (name) => readFileSync(join(ROOT, 'templates', name), 'utf8');
@@ -129,12 +147,95 @@ test('a repeated patch is idempotent', () => {
   assert.equal(patch(once, ['profile'], 'eco'), once);
 });
 
+test('the indent step is read from the file, not assumed to be two', () => {
+  // `yaml-lite.parseBlock` recurses with `next.indent` — whatever the next
+  // line happens to be indented by — so a four-space config is as legal as a
+  // two-space one and `validateConfig` accepts it. MUTANT: go back to
+  // `parentIndent + 2`. Every nested key here then reports "is not in this
+  // file", while a UI reading the PARSED document renders all of them as
+  // present and editable, so the operator gets a false error under a live
+  // control telling them to add a key that is already there.
+  const cases = [
+    [['tiers', 'cheap'], 'newmodel'],
+    [['limits', 'mode'], 'pause'],
+    [['limits', 'keep_awake'], true],
+    [['rules', 1, 'class'], 'KERNEL'],
+    [['rules', 0, 'path'], 'z/**'],
+  ];
+  for (const [path, value] of cases) {
+    const after = patch(FOUR_SPACE, path, value);
+    const walk = (doc, p) => p.reduce((node, key) => node[key], doc);
+    assert.deepEqual(walk(parse(after), path), value, `${path.join('.')} did not take`);
+    const changed = FOUR_SPACE.split('\n').filter((l, i) => l !== after.split('\n')[i]);
+    assert.equal(changed.length, 1, `${path.join('.')} changed ${changed.length} lines`);
+  }
+  // The comment on a four-space line survives too.
+  assert.match(patch(FOUR_SPACE, ['tiers', 'cheap'], 'x'), /^ {4}cheap: x # scout$/m);
+});
+
+test('a list is rewritten at the indent its own items already use', () => {
+  const after = patch(FOUR_SPACE, ['validation'], ['npm run build', 'npm test']);
+  assert.deepEqual(parse(after).validation, ['npm run build', 'npm test']);
+  assert.match(after, /^ {4}- npm run build$/m);
+});
+
+test('an eight-space document works the same way', () => {
+  const wide = 'limits:\n        mode: pause\n        keep_awake: false\n';
+  assert.equal(parse(patch(wide, ['limits', 'keep_awake'], true)).limits.keep_awake, true);
+  assert.match(patch(wide, ['limits', 'mode'], 'warn'), /^ {8}mode: warn$/m);
+});
+
+test('a CRLF file keeps its line endings', () => {
+  // MUTANT: drop `line.eol`. The data is right and every diff of the file
+  // shows one line whose ending no longer matches the other eighty-nine.
+  const crlf = 'profile: balanced\r\nlimits:\r\n  mode: pause\r\n';
+  const after = patch(crlf, ['limits', 'mode'], 'warn');
+  assert.equal(after, 'profile: balanced\r\nlimits:\r\n  mode: warn\r\n');
+  assert.equal(parse(after).limits.mode, 'warn');
+});
+
+test('a value the subset cannot spell is a refusal, not a crash', () => {
+  // `formatScalar` throws YamlLiteError, which is ordinary rejected input —
+  // somebody pasted a model name with a newline in it. Letting it escape made
+  // the caller classify it as a server fault: HTTP 500, plus a line in the
+  // terminal the docs designate as the audit trail. MUTANT: re-throw anything
+  // that is not already a YamlPatchError.
+  for (const bad of ['a\nb', `a${String.fromCodePoint(0x202e)}b`, `a${String.fromCodePoint(0x200b)}b`]) {
+    assert.throws(() => patch(FOUR_SPACE, ['tiers', 'cheap'], bad), YamlPatchError);
+  }
+  assert.throws(() => patch(FOUR_SPACE, ['validation'], ['ok', 'bad\nvalue']), YamlPatchError);
+});
+
+test('sameValue is the proof, and it is strict about every way two documents differ', () => {
+  // The guarantee at the end of `patch()` rests on this comparison, and no
+  // input is known to reach it — every wrong case is refused earlier by the
+  // locator, the comment guard or formatScalar (2772 fuzzed triples, zero
+  // firings). So it is tested directly: a comparison that has quietly become
+  // permissive is the one way the proof stops being one.
+  assert.ok(sameValue({ a: 1, b: 'x' }, { a: 1, b: 'x' }));
+  assert.ok(sameValue([1, [2, 3]], [1, [2, 3]]));
+  assert.ok(sameValue(null, null));
+  assert.ok(!sameValue({ a: 1 }, { a: 1, b: 2 }), 'an extra key is a difference');
+  assert.ok(!sameValue({ a: 1, b: 2 }, { a: 1 }), 'a missing key is a difference');
+  assert.ok(!sameValue({ a: { b: 1 } }, { a: { b: 2 } }), 'a nested change is a difference');
+  assert.ok(!sameValue([1, 2], [1, 2, 3]), 'a longer list is a difference');
+  assert.ok(!sameValue([1, 2], [2, 1]), 'order is a difference');
+  assert.ok(!sameValue(1, '1'), 'a type change is a difference — the whole point of the quoting rules');
+  assert.ok(!sameValue(false, 'false'));
+  assert.ok(!sameValue(null, undefined));
+  assert.ok(!sameValue({ a: 1 }, [1]));
+});
+
 test('refuses a value this subset cannot spell back', () => {
   // yaml-lite.formatScalar throws on a newline and on invisible codepoints;
   // the patcher lets that through rather than writing a file that reads back
   // as different data. The bidi override is BUILT here, never typed: a raw
   // one in a tracked file is what ADR-19 and the write guard exist to stop.
+  //
+  // Named error class, not a bare `assert.throws`: an unqualified throws()
+  // passes on ANY exception, including the wrong class, which is exactly how
+  // a rejected value came to be reported as a server fault.
   const bidi = `a${String.fromCodePoint(0x202e)}b`;
-  assert.throws(() => patch(template('config.yaml'), ['profile'], 'a\nb'));
-  assert.throws(() => patch(template('config.yaml'), ['profile'], bidi));
+  assert.throws(() => patch(template('config.yaml'), ['profile'], 'a\nb'), YamlPatchError);
+  assert.throws(() => patch(template('config.yaml'), ['profile'], bidi), YamlPatchError);
 });

--- a/tests/unit/yaml-patch.test.mjs
+++ b/tests/unit/yaml-patch.test.mjs
@@ -1,0 +1,140 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+import { parse } from '../../scripts/yaml-lite.mjs';
+import { patch, YamlPatchError } from '../../scripts/yaml-patch.mjs';
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..', '..');
+const template = (name) => readFileSync(join(ROOT, 'templates', name), 'utf8');
+
+test('changes one value and leaves every other byte alone', () => {
+  // The whole reason this module exists rather than a stringify round-trip.
+  // MUTANT: rebuild the file with yaml-lite.stringify — the value is still
+  // right and all 60 comment lines are gone.
+  const before = template('config.yaml');
+  const after = patch(before, ['profile'], 'eco');
+  const changed = before.split('\n').map((line, i) => [line, after.split('\n')[i]]).filter(([a, b]) => a !== b);
+  assert.equal(changed.length, 1, 'exactly one line may differ');
+  assert.deepEqual(changed[0], ['profile: balanced', 'profile: eco']);
+});
+
+test('keeps the trailing comment on the line it edits', () => {
+  // MUTANT: build the replacement line from indent + key + value only. The
+  // parse still succeeds and the operator loses the note explaining the key.
+  const after = patch(template('config.yaml'), ['limits', 'mode'], 'pause');
+  const line = after.split('\n').find((l) => l.trim().startsWith('mode:'));
+  assert.match(line, /^ {2}mode: pause # quoted/);
+});
+
+test('quotes a value that would read back as a different type', () => {
+  // Bare `off` is the YAML boolean false. Writing it unquoted turns
+  // limits.mode from the string "off" into `false` and the overnight gate
+  // silently changes meaning. MUTANT: emit String(value), not formatScalar.
+  const after = patch(patch(template('config.yaml'), ['limits', 'mode'], 'pause'), ['limits', 'mode'], 'off');
+  assert.match(after, /^ {2}mode: 'off'/m);
+  assert.equal(parse(after).limits.mode, 'off');
+});
+
+test('writes a boolean as a boolean, not as a string', () => {
+  const after = patch(template('config.yaml'), ['limits', 'keep_awake'], true);
+  assert.equal(parse(after).limits.keep_awake, true);
+  assert.match(after, /^ {2}keep_awake: true/m);
+});
+
+test('reaches a key inside a block sequence item', () => {
+  // The first key of an item shares the dash line and the rest are indented
+  // two further. MUTANT: drop the indent advance after a numeric segment and
+  // every rules[n].class becomes unreachable.
+  const before = template(join('policies', 'autonomy.yaml'));
+  const index = parse(before).rules.findIndex((r) => r.path === '.tyran/config.yaml');
+  const after = patch(before, ['rules', index, 'class'], 'GATED');
+  assert.equal(parse(after).rules[index].class, 'GATED');
+  assert.equal(parse(after).rules[index].path, '.tyran/config.yaml', 'the neighbouring key is untouched');
+  const changed = before.split('\n').filter((line, i) => line !== after.split('\n')[i]);
+  assert.equal(changed.length, 1);
+});
+
+test('reaches the key that shares the dash line', () => {
+  const before = template(join('policies', 'autonomy.yaml'));
+  const after = patch(before, ['rules', 0, 'path'], '.tyran/knowledge/scoped/**');
+  assert.equal(parse(after).rules[0].path, '.tyran/knowledge/scoped/**');
+  assert.match(after, /^ {2}- path: \.tyran\/knowledge\/scoped\/\*\*$/m);
+});
+
+test('replaces a list without swallowing the next section', () => {
+  // blockEnd must stop at the last CONTENT line. MUTANT: return the index of
+  // the next line at or below the parent indent, and the blank line plus the
+  // comment introducing `shared_zones` are counted as part of `validation`
+  // and deleted.
+  const before = template('config.yaml');
+  const after = patch(before, ['validation'], ['npm test']);
+  assert.deepEqual(parse(after).validation, ['npm test']);
+  assert.ok(
+    after.includes('# Files multiple agents may touch: append-only, serialized by the conductor.'),
+    'the comment heading the next section survived',
+  );
+  assert.deepEqual(parse(after).shared_zones, []);
+});
+
+test('an empty list collapses to the inline spelling', () => {
+  const after = patch(template('config.yaml'), ['validation'], []);
+  assert.match(after, /^validation: \[\]$/m);
+  assert.deepEqual(parse(after).validation, []);
+});
+
+test('an inline empty list expands into a block', () => {
+  const after = patch(template('config.yaml'), ['shared_zones'], ['src/registry.ts', 'src/index.ts']);
+  assert.deepEqual(parse(after).shared_zones, ['src/registry.ts', 'src/index.ts']);
+});
+
+test('refuses to replace a list that has a comment among its items', () => {
+  // Rewriting the block rewrites its lines, so this comment would vanish.
+  // MUTANT: delete the refusal loop — the patch succeeds and eats the note.
+  const text = 'validation:\n  # the slow one first\n  - npm test\n';
+  assert.throws(() => patch(text, ['validation'], ['npm run lint']), (err) => {
+    assert.ok(err instanceof YamlPatchError);
+    assert.match(err.message, /line 2 .*comment/);
+    return true;
+  });
+});
+
+test('refuses a key that is not already in the file', () => {
+  // Adding a key means choosing where it goes and what comment explains it.
+  assert.throws(() => patch(template('config.yaml'), ['pricing', 'rate_card'], 'list-2026-08'), YamlPatchError);
+  assert.throws(() => patch(template('config.yaml'), ['nope'], 1), YamlPatchError);
+});
+
+test('refuses a file that does not parse rather than guessing', () => {
+  assert.throws(() => patch('profile: >-\n  balanced\n', ['profile'], 'eco'), (err) => {
+    assert.ok(err instanceof YamlPatchError);
+    assert.match(err.message, /does not parse/);
+    return true;
+  });
+});
+
+test('the round-trip proof is what makes the text edit safe', () => {
+  // Two keys with the same name at different depths: the locator must pick
+  // the nested one. MUTANT: search the whole file for the last path segment
+  // instead of walking the path — the wrong `mode` is rewritten, and THIS
+  // assertion notices, because the proof compares the whole document.
+  const text = 'mode: outer\nlimits:\n  mode: inner\n';
+  const after = patch(text, ['limits', 'mode'], 'changed');
+  assert.deepEqual(parse(after), { mode: 'outer', limits: { mode: 'changed' } });
+});
+
+test('a repeated patch is idempotent', () => {
+  const once = patch(template('config.yaml'), ['profile'], 'eco');
+  assert.equal(patch(once, ['profile'], 'eco'), once);
+});
+
+test('refuses a value this subset cannot spell back', () => {
+  // yaml-lite.formatScalar throws on a newline and on invisible codepoints;
+  // the patcher lets that through rather than writing a file that reads back
+  // as different data. The bidi override is BUILT here, never typed: a raw
+  // one in a tracked file is what ADR-19 and the write guard exist to stop.
+  const bidi = `a${String.fromCodePoint(0x202e)}b`;
+  assert.throws(() => patch(template('config.yaml'), ['profile'], 'a\nb'));
+  assert.throws(() => patch(template('config.yaml'), ['profile'], bidi));
+});


### PR DESCRIPTION
## Settings: the board can change what Tyran does

`npx @jjanczur/tyran board --dir .tyran --serve --write` → a fifth tab that
edits `.tyran/config.yaml` and `.tyran/policies/autonomy.yaml`. Every knob gets
a sentence of prose; every policy rule shows its own recorded reason. Writes are
**off** without the flag — the tab still renders, disabled, with the command
that turns it on.

### One line moves, and the comments stay

The plan of record accepted losing the comments, on the grounds that the screen
could carry the explanations instead. It turned out not to be necessary.
`scripts/yaml-patch.mjs` rewrites the line that owns a value rather than
round-tripping the document through a serializer, so `templates/config.yaml`
keeps all 60 of its comment lines — including the one that says bare `off` is
the YAML boolean false, which is also the value that would have silently
changed meaning had this been done the obvious way.

**The edit is proved, not trusted.** Every patch is applied, parsed back, and
deep-compared against the document that was intended: the target holds the new
value and every other path holds what it held before. Then the result goes
through the same `validateConfig` / `validatePolicy` that `schema.mjs validate`
runs. A locator bug cannot ship a wrong file — only fail loudly — and a refused
write leaves the file byte-identical.

### Loosening a boundary is not the same click as tightening one

Found by an independent study of a competing harness, before this shipped, and
worse than the study guessed. `validatePolicy` defends exactly two globs, so
the first version of this screen would take `.claude/settings.json` from KERNEL
to AUTO in **one press** — on a rule whose own stated reason is *"anything that
can edit it can switch every gate off"*. So would `.tyran/STOP` (*"a loop that
can clear its own stop signal has none"*) and the policy `default`, and
`autonomy: P1 → P3` sat in an ordinary dropdown beside the cost profile.

Loosening now takes a second, deliberate request. The first is refused with the
rule's own reason quoted back plus a confirmation token, and the token is **the
new value itself**, not a boolean — nothing widens a boundary by sending a
truthy flag beside whatever value it liked. Tightening still applies on the
first click, because friction there teaches people to stop tightening things.

### Two things a fresh install could not do

Both found by the same study, both reproduced before being believed:

- **`board --dir .tyran` crashed** with `ENOENT` naming a temp file, on a repo
  that had been set up and never run — the one command the README leads with.
  `.tyran/state/` is created by the first initiative; `writeAllAtomic` staged
  into it and never made it.
- **A scanned config carried no `limits:` block**, so the whole Overnight
  section of the new tab was seven lines of dead text on every fresh install
  (the editor deliberately refuses to invent keys). Doctor's
  `limit-telemetry-missing` could never fire before this either.

### What guards the write route, stated exactly

The `Host` pin, an `Origin` check and a required `application/json` content
type close the browser paths. They do **not** stop another process on the
machine that can already reach loopback; nothing served on localhost does. The
`--write` flag is the control that matters there, and the kernel invariant is
what holds even when the flag is on. `docs/board.md` says this in those words
rather than claiming a sandbox.

### Deliberately not done

Creating keys that are not already in the file · authoring or deleting a policy
rule (a boundary's written `reason` is load-bearing) · `pricing:` · a journal
event per write (config is repo-wide, journals are per-initiative — the record
is the terminal line plus `git diff`).

### Verification

- `node --test "tests/**/*.test.mjs"` → **1361 pass, 0 fail** (38 new)
- `desc-budget` 4352/5000 · `scan-control-chars` clean (200 files) ·
  `claude plugin validate` ✔ · site build + `check-base-prefix` OK
- Driven in a real browser: both writes land as one line, the refusal writes
  nothing, and the two-step confirmation completes.

`NOTES-REQUESTS.md §7` records the rest of the study: six ranked features still
to build, and thirteen ideas killed with the reason, so nobody re-proposes them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
