### PR TITLE
board: answer from the page, fall back a tier, and twelve confirmed review findings (+ 0.1.26)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
     {
       "name": "tyran",
       "description": "A task conductor for Claude Code: multi-agent orchestration with an enforced evidence contract, repo-specific learning, and update-safe local evolution.",
-      "version": "0.1.25",
+      "version": "0.1.26",
       "source": "./",
       "author": {
         "name": "Jacek Janczura",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "tyran",
-  "version": "0.1.25",
+  "version": "0.1.26",
   "description": "A task conductor for Claude Code: multi-agent orchestration with an enforced evidence contract, repo-specific learning, and update-safe local evolution.",
   "author": {
     "name": "Jacek Janczura",

--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,6 @@ dist/
 
 # Coordination leases held by running agents — machine-local, never shared.
 locks/
+
+# Playwright MCP scratch output (snapshots, screenshots, console logs)
+.playwright-mcp/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,116 @@
 # Changelog
 
+## 0.1.26 — 2026-08-15
+
+### Answer a question from the board
+
+The last context switch in the operator loop is gone. Every question in the
+**Waiting on you** tab now carries a box: type an answer and press **Answer**,
+or press **Take the default** on a question that records one. The three
+`answer render / edit / apply` commands still work and stay printed on the tab —
+the box is a convenience, and a board opened over `file://` or without
+`--write` has to leave you somewhere to go.
+
+The request carries exactly two things: **which** ask, and your words. The
+question, the recorded default, the ticket and the gate id are all read back
+out of the journal by the server — the same guarantee the answer sheet makes,
+for the same reason. The append is `answerOne`, the function `answer apply`
+already calls, unwrapped: both routes produce byte-identical events, the gate
+is re-checked INSIDE the journal's write lock so a question closed in a
+terminal thirty seconds ago cannot be closed twice, and the decision is written
+before the gate.
+
+Each card also says which kind of question it is, and that costs no new event
+type: **decision · a default is recorded** means saying nothing has a safe
+outcome; **blocking · no safe default** means it waits for you. It is the same
+distinction that already makes the answer sheet sort no-default-first.
+
+### A tier that runs out of capacity falls to the next one down
+
+Measured on a real run: the strongest tier hit its limit and the subagents
+**failed** rather than finishing on the tier below, which had capacity the
+whole time.
+
+```bash
+node scripts/tiers.mjs --role acceptance --unavailable fable --field json
+# tiers: FELL BACK top -> deep because the top model is unavailable.
+```
+
+**Down the ladder, never up** — which is the answer to the question this was
+blocked on. Climbing would spend more than the routing table promised,
+silently, at exactly the moment nobody is watching. Three things the fall does
+not do: it does not lower the **effort** (that judgement did not change because
+a model ran out of capacity), it does not cross a **role floor** (a security
+review on the cheapest model is not a security review), and it does not
+**pretend** — the substitution is announced, and `fell_from` records it. When
+every tier a role may use is unavailable, it exits 2 rather than returning the
+bottom of the ladder: that is a pause, not a substitution, and overnight mode
+is what knows how to wait.
+
+### Twelve confirmed findings from an adversarial review of 0.1.24 and 0.1.25
+
+Five lenses attacked the shipped code and each finding was re-attacked
+independently. Two were serious:
+
+- **A config with no `limits:` block killed the whole Settings tab.** That
+  block is optional and every install set up before 0.1.24 has none, so
+  `resolvePath` returned null, `readAt` tried to iterate it, and the tab
+  rendered "the board server did not answer" while the server answered every
+  request. Every write on such a repo was an HTTP 500 in the terminal the docs
+  designate as the audit trail.
+- **The page could reload under a half-typed value.** A `meta http-equiv=refresh`
+  is scheduled by the browser when it parses the tag, and REMOVING THE NODE
+  DOES NOT CANCEL IT — the code sincerely believed otherwise, in a comment. The
+  page now carries an inert marker only its own script reads, so the single
+  reload path is a timer it can actually stop.
+
+And:
+
+- **An unreadable journal wrote an absolute path** — a home directory and a
+  username — into `board.json`, which is committed and compared byte for byte,
+  so it also failed `--check` on every other machine. Now the error code and a
+  repo-relative path.
+- **An initiative whose directory could not be read vanished** from the board
+  with nothing said; the totals just went down by one. `existsSync` cannot tell
+  "there is no journal here" from "I cannot tell whether there is one".
+- **`--dir` pointed at the repo root silently succeeded**, creating a `state/`
+  directory in the wrong place and reporting that all was well about a repo
+  whose real journals sat one level down.
+- **The settings write had no compare-and-swap.** Two boards on one directory,
+  or a board and a terminal, could discard each other's change with both
+  reporting success.
+- Plus a wrong number in the CHANGELOG, an overclaim in `docs/configuration.md`
+  (`pricing:` and `main_writable_paths:` have no knob), a lane emptied by the
+  filter showing no placeholder, a stale "Four tabs" comment, one of ten lanes
+  unaccounted for in the stalled-card prose, and two unverifiable claims about
+  the sandbox.
+
+### yaml-lite: the writer and the reader disagreed about numbers
+
+`formatScalar` required a digit before the decimal point and `parseScalar` did
+not, so the **string** `.5` was written unquoted and read back as the **number**
+0.5. Both now use the reader's two patterns. This was found by `yaml-patch`'s
+round-trip proof — the guard whose comment claimed no input was known to reach
+it. That claim is now corrected rather than repeated.
+
+A leading **BOM** is also handled: `trimStart` counts it as whitespace, so it
+read as one column of indentation and the parser rejected the whole file with a
+complaint about a line the operator could see nothing wrong with.
+
+Three more in the patcher, each of which wrote or refused the wrong thing: a
+key was located with `indexOf(':')` rather than the parser's own rule (so `a`
+landed on the `a:b` line), a path ending in an integer dropped the list item's
+dash, and replacing a list that is the FIRST key of a sequence item deleted the
+item's sibling keys.
+
+### The backtick guard
+
+The whole browser client is one template literal, so a backtick anywhere inside
+it — including in a comment — ends the literal and the page stops loading. It
+happened four times in one sitting. The parse test caught it every time and
+could never say so: it reports whatever identifier followed the stray backtick.
+A new guard reads the source as text, imports nothing, and names the line.
+
 ## 0.1.25 — 2026-08-15
 
 ### The sandbox is now Tyran building Tyran
@@ -17,8 +128,8 @@ browser verbatim; the hook payload does not carry `rate_limits` and a plugin
 cannot install a statusline. Every logged error is one that happened, including
 the backtick in a comment that terminated the client's template literal.
 
-All ten lanes are populated, five agents run at ages from two minutes to three
-hours, two questions wait on the operator, and the banner's counts are read
+All ten lanes are populated, five agents run at ages from about twenty minutes
+to three hours, two questions wait on the operator, and the banner's counts are read
 from the payload rather than typed — it said "two invented initiatives" for a
 release after a third was added.
 
@@ -30,8 +141,9 @@ release after a third was added.
   was wrong on the one page whose job is to show what the product looks like.
 - **The test that was supposed to catch that validated nothing.**
   `validateJournal` takes a file PATH and the test handed it an array of
-  events, so it read an empty journal and returned `ok`. It has been passing
-  against journals carrying thirteen real errors.
+  events, so it read an empty journal and returned `ok` — it was asserting
+  that nothing had no errors. The replacement journals tripped it thirteen
+  times on the first honest run.
 - **An `error` event that named a ticket produced two rows on the board**, one
   from `state.errors` and one from `unknownErrorTickets`. The ticket now
   travels on the error itself, where a consumer that wants both can have both
@@ -87,7 +199,7 @@ the difference the flag exists to make.
 comments were expendable because the screen could carry the explanations. That
 turned out not to be necessary: `scripts/yaml-patch.mjs` rewrites the line
 that owns a value rather than round-tripping the document through a
-serializer, so `templates/config.yaml` keeps all 60 of its comment lines — the
+serializer, so `templates/config.yaml` keeps all 63 of its comment lines — the
 only place anyone is told that bare `off` is the YAML boolean false, which is
 also the value that would have silently changed meaning had this been done the
 obvious way.

--- a/NOTES-REQUESTS.md
+++ b/NOTES-REQUESTS.md
@@ -4,7 +4,7 @@ Written down because they arrived mid-run and would otherwise live only in a
 chat window — the exact failure this project exists to prevent. Newest first.
 Delete an entry when it ships; move it to a ticket when it gets picked up.
 
-## 1. Model fallback when a tier's limit is hit — NOT BUILT
+## 1. Model fallback when a tier's limit is hit — SHIPPED 2026-08-15 (0.1.26)
 
 **Observed live, 2026-08-14:** the `fable` tier hit its limit and subagents
 **failed** instead of dropping to `opus` and respawning. The weekly window was
@@ -25,10 +25,16 @@ Notes before anyone builds this:
 - Overnight mode already handles the SUBSCRIPTION window (pause, checkpoint,
   resume at reset). This is a different case: one tier is exhausted while the
   account still has budget, so the right move is substitution, not a pause.
-- Open question for the operator: should a fallback be allowed to move work
-  UP a tier (cheaper to more expensive) without asking? That spends more money
-  than the routing table promised, which is exactly the property the tier table
-  exists to make legible.
+- The open question — may a fallback move work UP a tier without asking? — is
+  ANSWERED, in the safe direction: it may not. `tiers.mjs --unavailable <alias>`
+  walks DOWN the ladder only, never above a role floor, never lowering the
+  effort, and exits 2 rather than substituting when every tier a role may use
+  is gone. A fallback therefore never spends more than the routing table
+  promised, which was the property that made the question worth asking.
+- What is still NOT built is the DETECTION. The failure surfaces inside a
+  subagent's API call, so the conductor still has to notice a dead agent and
+  decide the cause; `--unavailable` is the substitution it reaches for once it
+  has. Wiring a typed limit signal into that decision is the remaining half.
 
 ## 2. Config editing from the dashboard — SHIPPED 2026-08-15 (0.1.24)
 

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -148,6 +148,44 @@ plugin's shipped template so a repo that has not run setup still works, but it
 says so **loudly on stderr**. A silent fallback would let a repo believe it had
 adopted a policy it never wrote.
 
+### When a tier's model is out of capacity
+
+A tier resolves to a model, and a model can be temporarily unavailable —
+usually because it has hit a rate limit while the account still has budget on
+everything else. Measured on a real run: the strongest tier hit its limit and
+the subagents **failed** rather than finishing on the tier below, which had
+capacity the whole time.
+
+```bash
+node scripts/tiers.mjs --role acceptance --unavailable fable --field json
+# tiers: FELL BACK top -> deep because the top model is unavailable.
+# {"tier":"deep","model":"opus","effort":"xhigh","floored":false,"fell_from":"top"}
+```
+
+**It falls DOWN the ladder, never up**, and that is the answer to the question
+this feature was blocked on for a while. Climbing would spend more than the
+routing table promised, silently, at exactly the moment nobody is watching —
+and the whole point of the table is that what a run costs is legible before it
+runs. Down is also the direction the incident needed.
+
+Three things the fall does not do:
+
+- **It does not lower the effort.** "This task needs deep reasoning" did not
+  stop being true because a model ran out of capacity, and dropping both dials
+  at once is a second downgrade nobody asked for. `fell_from` records the tier
+  it came from so the substitution is visible in the ledger.
+- **It does not cross a role floor.** A security review that ran on the
+  cheapest model is not a security review. The floors in
+  [the routing table](#the-routing-table) bound the fall.
+- **It does not pretend.** The substitution is announced on stderr in the same
+  breath as the resolution, saying plainly that this is a weaker model than the
+  table asked for.
+
+When every tier a role may use is unavailable, `tiers.mjs` exits 2 rather than
+returning the bottom of the ladder. That case is not a routing problem — there
+is nothing left to substitute — and the thing that already knows how to wait
+for capacity is [overnight mode](overnight.md).
+
 ## The brake
 
 An operator can halt a running initiative without killing the session:

--- a/docs/board.md
+++ b/docs/board.md
@@ -98,6 +98,34 @@ into can have. Re-render it at the start of each sitting rather than reusing
 the last one — every block in an applied sheet names an ask that is now
 closed, and `apply` refuses the whole file rather than appending a duplicate.
 
+### Or answer it on the page
+
+With the board served `--write`, every question in the **Waiting on you** tab
+carries a box. Type an answer and press **Answer**; on a question that has a
+recorded default, press **Take the default** instead. The three commands above
+still work and stay printed on the tab — the box is a convenience, and a board
+opened over `file://` or without `--write` has to leave you somewhere to go.
+
+The request carries exactly two things: **which** ask, and your words.
+Everything else — the question, the recorded default, the ticket, the gate id —
+is read back out of the journal by the server, which is the same guarantee the
+sheet makes and for the same reason. The append itself is the function
+`answer apply` calls, unwrapped, so both routes produce byte-identical events:
+the gate is re-checked INSIDE the journal's write lock (a question you closed
+in a terminal thirty seconds ago cannot be closed twice) and the decision is
+written before the gate.
+
+Each card also says which KIND of question it is, and that costs no new event
+type to know:
+
+| | |
+|---|---|
+| **decision · a default is recorded** | saying nothing has a safe outcome. You may take the recommendation and move on. |
+| **blocking · no safe default** | nobody recorded a fallback, so this one waits for you. |
+
+It is the same distinction that already makes the answer sheet sort
+no-default-first.
+
 ## Opening it
 
 **[Try the sandbox board](https://jjanczur.github.io/tyran/sandbox/)** — the
@@ -148,7 +176,12 @@ quick look, `BOARD.md` for reading in the terminal or in a diff.
 The page an operator leaves open overnight: self-contained (inline CSS/JS,
 zero external hosts and zero CDNs, complete over `file://`; the one
 same-origin request to loopback is amended in [Spend](#spend) below) and
-refreshing itself every 30 seconds. The artefact itself never reads a clock —
+reloading itself every 30 seconds — on a timer the page can stop, not a
+`meta http-equiv="refresh"`, because a browser schedules that the moment it
+parses the tag and removing the tag afterwards does not cancel it. A reload
+nothing can stop would destroy a half-typed answer or model name, so the
+timer is held while you are editing and re-armed when you leave.
+The artefact itself never reads a clock —
 "as of" is the newest event timestamp, which keeps `--check` valid for the
 HTML too; the only clock is the viewer's own browser, which ages the agent
 strip.
@@ -160,7 +193,7 @@ and the page opens on Overview:
 |---|---|
 | **Overview** | is anything on fire — four tiles (waiting on you · agents running · progress · needs a human), any STOPPED or PAUSED banner, the agent strip with its signal-freshness colours, a spend headline once spend has loaded, the errors agents logged, and the UNREADABLE list |
 | **Board** | where every ticket is — the lanes, and the detail of whichever card you select |
-| **Waiting on you** | what is blocked on a decision, and the commands that unblock it |
+| **Waiting on you** | what is blocked on a decision, whether it has a safe default, and — with `--write` — a box to answer it in |
 | **Spend** | what the work has cost |
 | **Settings** | what Tyran is configured to do, and — with `--write` — how to change it |
 
@@ -316,7 +349,13 @@ rule (a boundary's written `reason` is load-bearing, and a one-line reason
 typed into a form is how a policy turns into a list of unexplained globs), or
 edit `pricing:` (a rate card is a table copied from a vendor's price list).
 
-**What guards the route, stated exactly.** The `Host` pin that covers the whole
+**Three routes write, and one flag turns all of them on.**
+`POST /settings/config`, `POST /settings/policy` and `POST /answer` — answering
+a question and editing the autonomy policy are different acts, but they are the
+same decision for the operator: whether this board may change the repository at
+all.
+
+**What guards the routes, stated exactly.** The `Host` pin that covers the whole
 server, plus an `Origin` check and a required `application/json` content type —
 together those close the browser paths: a page on another origin cannot read
 the board, and its POST is preflighted and refused. What they do **not** do is
@@ -346,9 +385,11 @@ for four days — the timestamp was in `board.json` all along and nothing render
 it. Now every card in a lane where standing still IS the defect (`blocked`,
 `changes-requested`, `in-review`, `waiting-operator`, `in-progress`,
 `paused-limit`) carries its age, in the same four colours the agent strip uses.
-`backlog`, `ready` and `done` do not: an unstarted ticket is waiting its turn,
-not stalling, and marking every one of them stale makes the mark worthless
-where it means something.
+The other four do not, for the same reason in four forms: `backlog` and `ready`
+hold tickets waiting their turn rather than stalling, `parked` holds one you
+deliberately set aside, and `done` holds one that is supposed to have stopped
+moving. Marking all of those stale makes the mark worthless where it means
+something.
 
 Both are worded as observations rather than verdicts. The board reports the
 last event on a ticket; only you know whether that is a stall or a long test

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -6,10 +6,13 @@ written by `scripts/scan-repo.mjs` · validated by
 All per-repo configuration lives in `.tyran/config.yaml` — committed, human
 reviewable, written by `/tyran:setup` and editable by hand.
 
-**Or from the board.** `npx @jjanczur/tyran board --serve --write` puts every
-key below on a screen with a sentence explaining what it does, and writes your
-change back into this file one line at a time, comments intact — including the
-autonomy policy. See [the Settings tab](board.md#settings) for what it will and
+**Or from the board.** `npx @jjanczur/tyran board --serve --write` puts the
+cost profile, the deployment autonomy, the four model tiers, the validation
+commands, the shared zones and the whole `limits:` block on a screen, each with
+a sentence explaining what it does, and writes your change back into this file
+one line at a time with the comments intact — the autonomy policy too.
+`pricing:` and `main_writable_paths:` stay hand edits. See
+[the Settings tab](board.md#settings) for what it will and
 will not touch, and for why loosening a boundary there takes a second press.
 
 ## `.tyran/config.yaml`

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jjanczur/tyran",
-  "version": "0.1.25",
+  "version": "0.1.26",
   "description": "Command-line scripts for the Tyran task conductor (doctor, journal, schema, and repo tooling) for CI and terminals outside Claude Code. Installing this package does NOT install the Claude Code plugin — add that separately with `/plugin marketplace add jjanczur/tyran` inside Claude Code.",
   "type": "module",
   "engines": {

--- a/scripts/answer.mjs
+++ b/scripts/answer.mjs
@@ -570,7 +570,19 @@ export function applySheet(tyranDir, sheetText, { dryRun = false } = {}) {
 /** One ask's two appends, or the reason nothing was written for it. A lock
  * this run could not take is reported like any other unwritten ask: the run
  * that holds it is writing the same sitting, and a thrown error here would
- * abandon the asks after this one without saying so. */
+ * abandon the asks after this one without saying so.
+ *
+ * Exported because the board answers questions too. A second implementation
+ * there would be a second place that decides what "answering" means — and the
+ * two properties that matter are both in here: the re-check of `askState`
+ * INSIDE the lock, so a question answered in a terminal thirty seconds ago is
+ * not answered twice, and decision-before-gate, so a crash between the two
+ * leaves a visible orphan decision rather than a closed question with no
+ * answer. */
+export function answerOne(ask, verdict) {
+  return sittingOutcome(ask, verdict);
+}
+
 function sittingOutcome(ask, verdict) {
   try {
     return withSittingLock(ask.journal, () => {

--- a/scripts/board-html.mjs
+++ b/scripts/board-html.mjs
@@ -9,7 +9,7 @@ import { FORBIDDEN } from './invisible.mjs';
  * is blocked over file:// in Chromium, so meta-refresh is the one reliable
  * primitive; under `board.mjs --serve` the same refresh hits the server.
  *
- * ## Four tabs, because the page answers four questions
+ * ## Five tabs, because the page answers five questions
  *
  * Overview (what is the state), Board (where is every ticket), Waiting on you
  * (what is blocked on a decision, and how to answer it), Spend (what it
@@ -157,6 +157,15 @@ h3{font-family:var(--font);color:var(--heading);font-size:.85rem;margin:1.1rem 0
 .ask .q{color:var(--brass-bright);font-size:1rem;font-weight:600}
 .ask .row{margin-top:.22rem;font-size:.86rem}
 .ask .label{color:var(--muted);text-transform:uppercase;font-size:.66rem;letter-spacing:.07em;margin-right:.4rem;font-family:var(--mono)}
+.ask .kindtag{display:inline-block;font-family:var(--mono);font-size:.63rem;letter-spacing:.06em;text-transform:uppercase;border-radius:.25rem;padding:.1rem .4rem;margin-bottom:.35rem}
+.ask .kindtag.blocking{background:var(--clay-low);color:var(--clay-bright);border:1px solid var(--clay-edge)}
+.ask .kindtag.decision{background:var(--steel-low);color:var(--steel-bright);border:1px solid var(--steel-edge)}
+.reply{margin-top:.6rem;border-top:1px solid var(--brass-edge);padding-top:.55rem}
+.reply textarea{display:block;width:100%;font-family:var(--font);font-size:.86rem;background:var(--bg-raised);color:var(--text);border:1px solid var(--hairline);border-radius:.35rem;padding:.4rem .55rem;min-height:3.4rem;resize:vertical}
+.reply textarea:focus-visible{outline:2px solid var(--steel);outline-offset:1px}
+.reply textarea:disabled{opacity:.55;cursor:not-allowed}
+.reply .acts{display:flex;flex-wrap:wrap;gap:.4rem;align-items:center;margin-top:.4rem}
+.reply .hint{font-size:.75rem;color:var(--muted);margin-top:.3rem}
 pre.how{background:var(--bg-sunken);border:1px solid var(--hairline);border-radius:.45rem;padding:.7rem .85rem;font-family:var(--mono);font-size:.76rem;color:var(--text);overflow-x:auto;margin:.4rem 0 .7rem}
 pre.how .c{color:var(--muted)}
 
@@ -637,8 +646,14 @@ if (data.schema !== 1) {
     var count = el('span', 'count', ' (' + cards.length + ')');
     h.appendChild(count);
     box.appendChild(h);
+    // Appended ALWAYS, hidden when it is not wanted. It used to be appended
+    // only for a lane that was empty at build time, so a lane emptied by the
+    // filter showed a heading, a count of "0 of 4", and then nothing — and the
+    // display toggle below was setting a style on a node that was not in the
+    // document.
     var emptyMark = el('div', 'empty', '—');
-    if (cards.length === 0) box.appendChild(emptyMark);
+    box.appendChild(emptyMark);
+    emptyMark.style.display = cards.length === 0 ? '' : 'none';
     var buttons = [];
     cards.forEach(function (c) {
       var button = el('button', 'card');
@@ -702,8 +717,84 @@ if (data.schema !== 1) {
     'npx @jjanczur/tyran answer apply --dir .tyran    # closes what you answered';
   qs.appendChild(how);
   if (asks.length === 0) qs.appendChild(el('div', 'empty', 'nothing — the agents have what they need'));
+
+  // Answering from the page. The three commands above still work and stay
+  // printed: this box is a convenience, not a replacement, and a board opened
+  // over file:// or without --write has to leave the operator somewhere to go.
+  //
+  // The request carries only WHICH ask and the operator's own words. The
+  // question, the recorded default, the ticket and the gate id are all read
+  // back out of the journal by the server — the same guarantee the answer
+  // sheet makes, for the same reason.
+  var replyBox = function (a, hasDefault) {
+    var box = el('div', 'reply');
+    var input = el('textarea');
+    input.placeholder = hasDefault
+      ? 'Your answer, in your own words \\u2014 or use the default button.'
+      : 'Your answer, in your own words. There is no recorded default for this one.';
+    var acts = el('div', 'acts');
+    var send = el('button', 'sbtn', 'Answer');
+    send.setAttribute('type', 'button');
+    var useDefault = hasDefault ? el('button', 'sbtn', 'Take the default') : null;
+    if (useDefault) useDefault.setAttribute('type', 'button');
+    var status = el('div', 'sstat');
+
+    var submit = function (text) {
+      [send, useDefault].forEach(function (b) { if (b) b.disabled = true; });
+      post('/answer', { init: a.init, kind: a.kind, answer: text }, status, function (ok) {
+        if (!ok) {
+          [send, useDefault].forEach(function (b) { if (b) b.disabled = false; });
+          return;
+        }
+        // The board re-rendered on the server before it replied, so the next
+        // load is already correct — and leaving an answered question on screen
+        // with a live box invites answering it twice.
+        input.disabled = true;
+      }, function (p) {
+        return (p.mode === 'default' ? 'answered with the recorded default' : 'answered')
+          + ': ' + p.recorded + ' \\u00b7 decision ' + p.decision + ' \\u2014 reload to refresh the board';
+      });
+    };
+    send.addEventListener('click', function () {
+      if (input.value.trim() === '') {
+        status.className = 'sstat bad';
+        status.textContent = hasDefault
+          ? 'type an answer, or press "Take the default"'
+          : 'type an answer \\u2014 this question has no default to fall back on';
+        return;
+      }
+      submit(input.value);
+    });
+    if (useDefault) useDefault.addEventListener('click', function () { submit(''); });
+
+    // Typing here must survive the 30-second reload, exactly like a settings
+    // field. Same mechanism, same reason.
+    //
+    // Wrapped, not passed: the hold-refresh helper is defined further down and
+    // is still undefined while these cards are built, and addEventListener with
+    // undefined is a silent no-op rather than an error — the listener would
+    // simply never exist and a half-typed answer would vanish on the next
+    // reload with nothing to show for it.
+    input.addEventListener('input', function () { holdRefresh(); });
+
+    box.appendChild(input);
+    acts.appendChild(send);
+    if (useDefault) acts.appendChild(useDefault);
+    box.appendChild(acts);
+    box.appendChild(status);
+    box.appendChild(el('div', 'hint', 'Answering writes a decision and closes the gate in ' + a.init + '\\u2019s journal. Needs the board started with --write.'));
+    return box;
+  };
   asks.forEach(function (a) {
     var card = el('div', 'ask');
+    // The one distinction that changes what an operator does about it, and it
+    // costs no new event type to say: an ask WITH a recorded default is a
+    // decision you may leave to the recommendation, and an ask without one is
+    // blocking, because there saying nothing has no safe outcome. That is
+    // already why the answer sheet sorts no-default first.
+    var hasDefault = a.default !== null && a.default !== undefined;
+    card.appendChild(el('span', 'kindtag ' + (hasDefault ? 'decision' : 'blocking'),
+      hasDefault ? 'decision \\u00b7 a default is recorded' : 'blocking \\u00b7 no safe default'));
     card.appendChild(el('div', 'q', a.question || '(no question recorded — gate ' + a.kind + ')'));
     [['answer with', a.kind], ['recommendation', a.recommendation], ['default', a.default],
      ['ticket', a.ticket], ['initiative', a.init], ['since', a.since]].forEach(function (pair) {
@@ -713,6 +804,7 @@ if (data.schema !== 1) {
       row.appendChild(el('span', null, pair[1]));
       card.appendChild(row);
     });
+    card.appendChild(replyBox(a, hasDefault));
     qs.appendChild(card);
   });
 
@@ -905,27 +997,35 @@ if (data.schema !== 1) {
   st.appendChild(stBody);
   stBody.appendChild(el('div', 'setnote', 'Settings are read from .tyran/config.yaml and .tyran/policies/autonomy.yaml, and they are served rather than embedded — open this board with "board.mjs --serve" to see them.'));
 
-  // A meta refresh and a form are incompatible: half a typed model name would
-  // vanish every thirty seconds. The tag stays in the HTML (a page whose JS
-  // never runs still refreshes, and the docs sandbox strips the tag to stop
-  // itself reloading), but at boot it is swapped for a timer that can be
-  // paused — and the Settings tab pauses it. Present tag, same 30 seconds;
-  // absent tag, no timer at all, which is what the sandbox wants.
-  var refreshTag = document.querySelector('meta[http-equiv="refresh"]');
+  // Auto-refresh, and the reason it is a timer rather than a meta tag.
+  //
+  // A real http-equiv refresh is scheduled by the browser when it PARSES the
+  // tag, and removing the node afterwards does not cancel it — measured, in a
+  // browser, after this page reloaded under a half-typed value that the code
+  // sincerely believed it had protected. So the page carries an inert
+  // tyran-refresh marker instead, and the only thing that reloads it is this
+  // timer, which can be stopped while an operator is typing.
+  //
+  // Absent marker, no timer at all: that is what the docs sandbox wants, and
+  // it gets it by stripping the marker rather than by special-casing anything.
+  var refreshTag = document.querySelector('meta[name="tyran-refresh"]');
+  var refreshSeconds = refreshTag === null ? 0 : Number(refreshTag.getAttribute('content'));
   var refreshTimer = null;
   var armRefresh = function () {
-    if (refreshTag === null || refreshTimer !== null) return;
-    refreshTimer = setTimeout(function () { location.reload(); }, 30000);
+    if (!(refreshSeconds > 0) || refreshTimer !== null) return;
+    refreshTimer = setTimeout(function () { location.reload(); }, refreshSeconds * 1000);
   };
   var holdRefresh = function () {
     if (refreshTimer !== null) { clearTimeout(refreshTimer); refreshTimer = null; }
   };
-  if (refreshTag !== null && refreshTag.parentNode) {
-    refreshTag.parentNode.removeChild(refreshTag);
-    armRefresh();
-  }
+  armRefresh();
 
-  var post = function (route, body, status, onDone) {
+  // The describe callback turns a successful payload into the sentence the
+  // operator reads. Settings and answers succeed differently — one reports a
+  // value that moved, the other what was recorded and under which decision id —
+  // and a single hard-coded message rendered "undefined -> undefined" for the
+  // route it was not written for.
+  var post = function (route, body, status, onDone, describe) {
     status.className = 'sstat';
     status.textContent = 'saving\\u2026';
     fetch(route, {
@@ -959,7 +1059,9 @@ if (data.schema !== 1) {
         return;
       }
       status.className = 'sstat ok';
-      status.textContent = show('saved \\u2014 ' + JSON.stringify(payload.before) + ' \\u2192 ' + JSON.stringify(payload.after));
+      status.textContent = show(describe
+        ? describe(payload)
+        : 'saved \\u2014 ' + JSON.stringify(payload.before) + ' \\u2192 ' + JSON.stringify(payload.after));
       if (onDone) onDone(true);
     }).catch(function () {
       status.className = 'sstat bad';
@@ -1187,7 +1289,7 @@ if (data.schema !== 1) {
   select('overview');
 
   var foot = el('footer');
-  foot.appendChild(el('div', null, 'GENERATED by tyran scripts/board.mjs — do not edit. Refreshes every 30 s; ages are computed in this browser.'));
+  foot.appendChild(el('div', null, 'GENERATED by tyran scripts/board.mjs — do not edit. Reloads itself every 30 s unless you are editing; ages are computed in this browser.'));
   app.appendChild(foot);
 }
 `;
@@ -1237,7 +1339,15 @@ export function renderBoardHtml(payloadJsonText) {
     '<!-- GENERATED by tyran scripts/board.mjs - DO NOT EDIT. Source of truth: the journals under .tyran/state/ -->\n' +
     '<html lang="en"><head><meta charset="utf-8">\n' +
     '<meta name="viewport" content="width=device-width, initial-scale=1">\n' +
-    '<meta http-equiv="refresh" content="30">\n' +
+    // NOT `http-equiv="refresh"`. A real meta refresh is scheduled by the
+    // browser the moment it parses the tag, and REMOVING THE NODE DOES NOT
+    // CANCEL IT — measured, after this page reloaded under a half-typed model
+    // name that the code sincerely believed it had protected. The tag is now
+    // inert markup that only this page's own script reads, so the timer it
+    // arms is one the page can actually stop while you are typing into it.
+    // The page is built entirely by that script anyway, so nothing is lost:
+    // a browser that cannot run it has no board to refresh.
+    '<meta name="tyran-refresh" content="30">\n' +
     '<title>Tyran board</title>\n' +
     `<style>${CSS}</style>\n` +
     '</head><body><main id="app"></main>\n' +

--- a/scripts/board.mjs
+++ b/scripts/board.mjs
@@ -46,6 +46,7 @@ import { renderBoardError, renderBoardHtml } from './board-html.mjs';
 import { COST_SCHEMA, costJson, costReport } from './cost.mjs';
 import { SettingsError, applyPolicyClass, applySetting, readSettings } from './settings.mjs';
 import { checkStopAt } from './stop-check.mjs';
+import { answerOne, answerProblem, classify, openAsks, partitionAsks, reRender } from './answer.mjs';
 
 export const BOARD_HTML_FILE = 'board.html';
 
@@ -66,8 +67,15 @@ export function readInitiativeBoards(tyranDir) {
   let names;
   try {
     names = readdirSync(stateDir).sort();
-  } catch {
-    return { initiatives: [], errors: [] };
+  } catch (err) {
+    // ENOENT is the legitimate fresh-repo case: setup has run, no initiative
+    // exists yet, and an empty board is the right answer. Anything else —
+    // EACCES, ENOTDIR, EIO — means we cannot TELL whether there is work here,
+    // and returning "no initiatives" for that is the board saying all is well
+    // about a directory it could not open. It is also what `--dir` pointed at
+    // the repo root instead of at `.tyran` looks like.
+    if (err?.code === 'ENOENT') return { initiatives: [], errors: [] };
+    return { initiatives: [], errors: [{ name: 'state', error: `${err?.code ?? 'unreadable'} reading ${join(basename(resolve(tyranDir)), 'state')}` }] };
   }
   const dirs = names.filter((name) => {
     try {
@@ -87,7 +95,17 @@ export function readInitiativeBoards(tyranDir) {
   const warned = [];
   for (const name of dirs) {
     const journal = join(stateDir, name, 'journal.jsonl');
-    if (!existsSync(journal)) continue;
+    // "there is no journal here" and "I cannot tell whether there is a journal
+    // here" are different facts, and `existsSync` returns false for both. An
+    // initiative in an unreadable directory used to vanish from the board with
+    // nothing said — the totals simply went down by one.
+    try {
+      statSync(journal);
+    } catch (err) {
+      if (err?.code === 'ENOENT') continue;
+      errors.push({ name, error: `${err?.code ?? 'unreadable'} reading ${join('state', name, 'journal.jsonl')}` });
+      continue;
+    }
     try {
       const state = fold(readJournal(journal));
       // PARTIAL damage, which the guard below cannot see. That guard fires only
@@ -118,7 +136,17 @@ export function readInitiativeBoards(tyranDir) {
       // where an initiative's journal lives (ADR-21).
       initiatives.push({ name, journal, state, board: boardOf(state), files: initiativeFiles(tyranDir, name) });
     } catch (err) {
-      errors.push({ name, error: String(err?.message ?? err) });
+      // The CODE and a repo-relative path, never the raw message. A Node fs
+      // error carries the absolute path, which means a home directory and a
+      // username — and this string is written into `board.json`, a committed
+      // artefact compared byte for byte, so it also made `--check` fail on any
+      // other machine.
+      errors.push({
+        name,
+        error: err?.code
+          ? `${err.code} reading ${join('state', name, 'journal.jsonl')}`
+          : String(err?.message ?? err),
+      });
     }
   }
   return { initiatives, errors, warned };
@@ -383,8 +411,13 @@ function readJsonBody(req) {
     req.on('data', (chunk) => {
       size += chunk.length;
       if (size > MAX_BODY_BYTES) {
-        reject(new SettingsError('request body is too large'));
-        req.destroy();
+        // Reject, but do NOT destroy the socket: the route's 400 is written on
+        // the next tick, and tearing the connection down first meant the
+        // client saw a network error instead of the sentence explaining what
+        // was wrong. Pausing stops us reading the rest without discarding the
+        // channel the answer goes out on.
+        req.pause();
+        reject(new SettingsError(`request body is larger than ${MAX_BODY_BYTES} bytes`));
         return;
       }
       chunks.push(chunk);
@@ -435,6 +468,47 @@ const sendJson = (res, status, body) => {
 };
 
 /**
+ * Answer one open question, from the page instead of from a terminal.
+ *
+ * The request supplies exactly two things: WHICH ask, and the operator's own
+ * words. Everything else — the question, the recorded default, the ticket, the
+ * gate id — is read back out of the journal, which is the same guarantee
+ * `answer apply` makes about its sheet: nothing you type can change what was
+ * asked. The append itself is `answerOne`, unchanged and unwrapped, so the
+ * lock, the re-check and the decision-before-gate ordering are the ones the
+ * CLI already uses.
+ */
+function handleAnswer(dir, body) {
+  const kind = String(body.kind ?? '');
+  const init = String(body.init ?? '');
+  const text = typeof body.answer === 'string' ? body.answer : '';
+
+  const { asks } = openAsks(dir);
+  const { answerable } = partitionAsks(asks);
+  const ask = answerable.find((a) => a.kind === kind && a.init === init);
+  if (ask === undefined) {
+    throw new SettingsError(
+      `no open question "${kind}" in "${init}" — it may have been answered in a terminal since this page loaded. Reload.`,
+    );
+  }
+  const trimmed = text.trim();
+  const problem = answerProblem(trimmed);
+  if (problem !== null) throw new SettingsError(`that answer ${problem}`);
+
+  const verdict = classify(trimmed, ask);
+  if (verdict.mode === 'open') throw new SettingsError(verdict.why ?? 'nothing to record');
+  const outcome = answerOne(ask, verdict);
+  if (outcome.skipped !== undefined) throw new SettingsError(outcome.skipped);
+
+  // A board still showing an answered question is worse than one that never
+  // showed it. Re-render before replying, so the reload the page does next is
+  // already correct.
+  reRender(dir, new Map([[ask.init, ask.journal]]));
+  console.log(`board: answered ${ask.init}/${ask.kind} (${verdict.mode}) -> decision ${outcome.decision}`);
+  return { ok: true, kind: ask.kind, init: ask.init, mode: verdict.mode, decision: outcome.decision, recorded: verdict.text };
+}
+
+/**
  * Apply one edit and write it, or change nothing and say why.
  *
  * The write itself is `writeAtomic` — the same rename-into-place the
@@ -450,6 +524,16 @@ function handleSettingsWrite(dir, route, body) {
     route === 'config'
       ? applySetting(dir, String(body.id ?? ''), body.value, confirm)
       : applyPolicyClass(dir, body.path === null || body.path === undefined ? null : String(body.path), String(body.class ?? ''), confirm);
+  // Compare-and-swap. `applySetting` reads the whole file and computes a whole
+  // replacement, so a second writer between the read and the write would have
+  // its change silently discarded — and both writers would report success.
+  // In-process that cannot interleave (this handler is one synchronous block),
+  // but two boards on one directory, or a board and a terminal, are ordinary.
+  if (readFileSync(applied.file, 'utf8') !== applied.before_text) {
+    throw new SettingsError(
+      `${applied.file} changed underneath this edit — something else wrote it while the page was open. Nothing was written; reload and try again.`,
+    );
+  }
   writeAtomic(applied.file, applied.text);
   // The operator's terminal is the audit trail. A change made from a web page
   // that left no trace anywhere a person looks is how a settings screen turns
@@ -502,6 +586,21 @@ function main() {
     console.error(`board: no such directory ${dir}`);
     process.exit(2);
   }
+  // `--dir` wants the `.tyran` directory, and pointing it at the repo root
+  // instead is the obvious typo. Since the renderer creates `state/` where it
+  // is told to, that typo used to succeed silently: a `state/` directory
+  // appearing in the project root, and an empty board reporting that all is
+  // well about a repo whose real journals sit one level down. Any ONE of these
+  // three is enough to recognise a Tyran directory, including a freshly set up
+  // one that has no initiative yet.
+  const looksLikeTyran = ['state', 'config.yaml', 'policies'].some((name) => existsSync(join(dir, name)));
+  if (!looksLikeTyran) {
+    console.error(
+      `board: ${dir} does not look like a .tyran directory — it has no state/, config.yaml or policies/. ` +
+        'Point --dir at .tyran itself (run /tyran:setup first if this repo has not adopted Tyran).',
+    );
+    process.exit(2);
+  }
   const outDir = join(dir, 'state');
 
   if (flags.serve) {
@@ -538,8 +637,8 @@ function main() {
           sendJson(res, 200, { ...readSettings(dir), writable: flags.write });
           return;
         }
-        if (req.url === '/settings/config' || req.url === '/settings/policy') {
-          const route = req.url.slice('/settings/'.length);
+        if (req.url === '/settings/config' || req.url === '/settings/policy' || req.url === '/answer') {
+          const route = req.url === '/answer' ? 'answer' : req.url.slice('/settings/'.length);
           if (req.method !== 'POST') {
             sendJson(res, 405, { ok: false, error: 'this route takes POST' });
             return;
@@ -550,6 +649,10 @@ function main() {
           // that and editing the autonomy policy through it is the difference
           // this flag exists to make. The refusal names the flag, because a
           // 403 an operator cannot act on is just a bug report.
+          // One flag for every route that writes. Answering a question and
+          // editing the autonomy policy are different acts, but they are the
+          // same decision for the operator: whether this board may change the
+          // repository at all.
           if (!flags.write) {
             sendJson(res, 403, {
               ok: false,
@@ -562,7 +665,7 @@ function main() {
             return;
           }
           readJsonBody(req)
-            .then((body) => sendJson(res, 200, handleSettingsWrite(dir, route, body)))
+            .then((body) => sendJson(res, 200, route === 'answer' ? handleAnswer(dir, body) : handleSettingsWrite(dir, route, body)))
             .catch((err) => {
               const known = err instanceof SettingsError;
               if (!known) console.error(`board: settings write failed: ${String(err?.message ?? err)}`);

--- a/scripts/settings.mjs
+++ b/scripts/settings.mjs
@@ -290,7 +290,13 @@ export function allSettings() {
 function resolvePath(doc, path) {
   let node = doc;
   for (const segment of path) {
-    if (node === null || typeof node !== 'object') return null;
+    // The REQUESTED path, never null. `limits:` is optional in a valid config
+    // — every install set up before it existed has none — and returning null
+    // here fed `readAt`'s `for (const segment of path)` an unusable value, so
+    // the whole Settings tab died with "path is not iterable" and every write
+    // became an HTTP 500. Handing the path back lets the absent-key branch do
+    // its job: `present: false`, and a control that says so.
+    if (node === null || typeof node !== 'object') return path;
     node = node[segment];
   }
   if (node !== null && typeof node === 'object' && !Array.isArray(node) && 'value' in node) {
@@ -473,7 +479,7 @@ export function applySetting(tyranDir, id, value, confirm = null) {
   if (errors.length > 0) {
     throw new SettingsError(`that change makes the config invalid, so nothing was written:\n  ${errors.join('\n  ')}`);
   }
-  return { file, path, before, after: next, text };
+  return { file, path, before, after: next, text, before_text: loaded.text };
 }
 
 /**
@@ -538,5 +544,5 @@ export function applyPolicyClass(tyranDir, rulePath, klass, confirm = null) {
   if (errors.length > 0) {
     throw new SettingsError(`that change makes the policy invalid, so nothing was written:\n  ${errors.join('\n  ')}`);
   }
-  return { file, path, before, after: klass, text };
+  return { file, path, before, after: klass, text, before_text: loaded.text };
 }

--- a/scripts/tiers.mjs
+++ b/scripts/tiers.mjs
@@ -208,14 +208,72 @@ function clamp(value, min, max) {
 export function resolveModel(config, role, profile, risk = 'normal', override = {}) {
   const tier = resolveTier(role, profile, risk, override);
   const effort = resolveEffort(role, profile, risk, override);
-  const alias = config?.tiers?.[tier];
-  if (typeof alias !== 'string' || alias.length === 0) {
-    throw new Error(`config has no model alias for tier "${tier}" — fix tiers in .tyran/config.yaml`);
-  }
+  const aliasFor = (key) => {
+    const alias = config?.tiers?.[key];
+    if (typeof alias !== 'string' || alias.length === 0) {
+      throw new Error(`config has no model alias for tier "${key}" — fix tiers in .tyran/config.yaml`);
+    }
+    return alias;
+  };
   const floored =
     (ROLE_FLOOR[role] !== undefined && override.tier !== undefined && override.tier !== ROLE_FLOOR[role]) ||
     (ROLE_EFFORT_FLOOR[role] !== undefined && override.effort !== undefined && override.effort !== effort);
-  return { tier, model: alias, effort, floored };
+
+  const unavailable = normalizeUnavailable(override.unavailable);
+  const resolved = { tier, model: aliasFor(tier), effort, floored, fell_from: null };
+  if (unavailable.length === 0 || !unavailable.includes(resolved.model)) return resolved;
+
+  const substitute = fallbackTier(config, role, tier, unavailable);
+  return {
+    tier: substitute,
+    model: aliasFor(substitute),
+    // Effort follows the ORIGINAL tier, not the substitute. The judgement
+    // "this task needs deep reasoning" did not change because a model ran out
+    // of capacity, and dropping both dials at once turns a substitution into a
+    // second, unasked-for downgrade.
+    effort,
+    floored,
+    fell_from: tier,
+  };
+}
+
+function normalizeUnavailable(value) {
+  if (value === undefined || value === null) return [];
+  const list = Array.isArray(value) ? value : [value];
+  return list.filter((v) => typeof v === 'string' && v.length > 0);
+}
+
+/**
+ * The next tier DOWN whose model is still available.
+ *
+ * Down, never up, and that is the answer to the question this feature was
+ * blocked on. A fallback that climbed would spend more than the routing table
+ * promised, silently, at the exact moment nobody is watching — and the whole
+ * point of the table is that what a run costs is legible before it runs. Down
+ * is also the direction the observed incident needed: the strongest tier hit
+ * its limit while the tier below it had capacity, and the work died rather
+ * than finishing on the model one step cheaper.
+ *
+ * The trade is stated rather than hidden: falling produces a WEAKER answer.
+ * That is why it stops at the role floor instead of walking to the bottom —
+ * a security review that ran on the cheapest model is not a security review,
+ * and the floors already say which roles those are.
+ */
+export function fallbackTier(config, role, from, unavailable) {
+  const floorIndex = ROLE_FLOOR[role] === undefined ? 0 : TIER_ORDER.indexOf(ROLE_FLOOR[role]);
+  for (let i = TIER_ORDER.indexOf(from) - 1; i >= floorIndex; i -= 1) {
+    const alias = config?.tiers?.[TIER_ORDER[i]];
+    if (typeof alias === 'string' && alias.length > 0 && !unavailable.includes(alias)) return TIER_ORDER[i];
+  }
+  // Exhausting the ladder is NOT a substitution problem. Every model this role
+  // is allowed to use is unavailable, which means waiting, not routing — and
+  // the thing that already knows how to wait is overnight mode.
+  const reachable = TIER_ORDER.slice(floorIndex, TIER_ORDER.indexOf(from) + 1);
+  throw new Error(
+    `every tier "${escapeInvisible(role)}" may use is unavailable (${reachable.join(' -> ')}), so there is ` +
+      'nothing to fall back to. This is a pause, not a substitution: see docs/overnight.md.' +
+      (ROLE_FLOOR[role] === undefined ? '' : ` The floor for this role is "${ROLE_FLOOR[role]}" and is not lowered by a fallback.`),
+  );
 }
 
 /** The whole routing map for one profile — what the conductor reads once. */
@@ -278,7 +336,9 @@ function main() {
   const risk = flag('risk', 'normal');
   const role = flag('role', null);
   const field = flag('field', 'model');
-  const override = { tier: flag('tier', undefined), effort: flag('effort', undefined) };
+  // Repeatable: an overnight run can exhaust more than one tier.
+  const unavailable = args.reduce((acc, arg, i) => (arg === '--unavailable' && args[i + 1] ? [...acc, args[i + 1]] : acc), []);
+  const override = { tier: flag('tier', undefined), effort: flag('effort', undefined), unavailable };
 
   try {
     if (role === null) {
@@ -301,6 +361,14 @@ function main() {
       console.error(
         'tiers: `conductor` is ADVISORY. The conductor is your own session and no plugin can ' +
           'change its model mid-flight — this is the tier your config says it should be running.',
+      );
+    }
+    // A substitution that said nothing would be the routing table quietly
+    // meaning something else than it says.
+    if (resolved.fell_from !== null) {
+      console.error(
+        `tiers: FELL BACK ${resolved.fell_from} -> ${resolved.tier} because the ${resolved.fell_from} model is ` +
+          'unavailable. This is a WEAKER model than the routing table asked for; effort is unchanged.',
       );
     }
     console.error(`tiers: ${role} @ ${profile}/${risk} -> ${resolved.tier} · effort ${resolved.effort}`);

--- a/scripts/yaml-lite.mjs
+++ b/scripts/yaml-lite.mjs
@@ -174,7 +174,11 @@ function stripComment(line, lineNo) {
 
 /** Parse a YAML-subset document into a plain JS object. */
 export function parse(text) {
-  const rawLines = text.split('\n');
+  // A leading BOM is an encoding marker, not content. Left in place it becomes
+  // one column of "indentation" on line 1, and the parser rejected the whole
+  // file with "indentation must be a multiple of 2 spaces" — pointing at a
+  // line the operator can see nothing wrong with.
+  const rawLines = (text.charCodeAt(0) === 0xfeff ? text.slice(1) : text).split('\n');
   const lines = [];
   let sawDocStart = false;
   rawLines.forEach((raw, i) => {
@@ -272,7 +276,16 @@ export function parse(text) {
   return result;
 }
 
-function keyColonIndex(text) {
+/**
+ * Where a mapping key ends, by this subset's own rule: the colon must be
+ * followed by whitespace or end-of-line.
+ *
+ * Exported for the same reason as `splitInlineComment` and `formatScalar` — an
+ * editor that locates a key must locate it by the rule the PARSER uses. A bare
+ * `indexOf(':')` finds the colon inside `a:b: 1` and lands the edit on a
+ * different key's line, which is a wrong write, not a failed one.
+ */
+export function keyColonIndex(text) {
   let inSingle = false;
   let inDouble = false;
   for (let i = 0; i < text.length; i++) {
@@ -286,7 +299,8 @@ function keyColonIndex(text) {
   return -1;
 }
 
-function unquoteKey(raw, lineNo) {
+/** A key as the parser reads it, quotes and all. Exported alongside `keyColonIndex`. */
+export function unquoteKey(raw, lineNo) {
   const key = raw.trim();
   if (key === '') throw new YamlLiteError('empty key', lineNo);
   if ((key[0] === '"' && key.at(-1) === '"' && key.length > 1) ||
@@ -422,6 +436,12 @@ export function formatScalar(value) {
     Object.hasOwn(BOOL, s.toLowerCase()) ||
     s === 'null' ||
     s === '~' ||
-    /^-?\d+(\.\d+)?$/.test(s);
+    // The READER's two number tests, not an approximation of them. They
+    // disagreed on a leading-dot decimal: `parseScalar` reads `.5` as the
+    // number 0.5, while this rule required a digit before the dot and so
+    // wrote the STRING ".5" unquoted — a value that came back as a different
+    // type. Found by yaml-patch's round-trip proof, which is what it is for.
+    /^-?\d+$/.test(s) ||
+    /^-?\d*\.\d+$/.test(s);
   return needsQuotes ? `'${s.replace(/'/g, "''")}'` : s;
 }

--- a/scripts/yaml-patch.mjs
+++ b/scripts/yaml-patch.mjs
@@ -37,7 +37,7 @@
  *   refused instead, with the line number, because the alternative is the
  *   silent loss this whole module exists to prevent.
  */
-import { YamlLiteError, formatScalar, parse, splitInlineComment } from './yaml-lite.mjs';
+import { YamlLiteError, formatScalar, keyColonIndex, parse, splitInlineComment, unquoteKey } from './yaml-lite.mjs';
 
 export class YamlPatchError extends Error {}
 
@@ -181,9 +181,18 @@ function locate(lines, path) {
     for (let i = from; i < to; i += 1) {
       const line = asKeyLine(lines[i], dashIndent, indent);
       if (line.blank || line.indent !== indent) continue;
-      const colon = line.trimmed.indexOf(':');
+      // The PARSER's key rule, not a bare indexOf: a colon inside a key name
+      // (`a:b: 1`) otherwise ends the key early, and the edit lands on a
+      // different key's line — a wrong write rather than a failed one.
+      const colon = keyColonIndex(line.trimmed);
       if (colon === -1) continue;
-      if (line.trimmed.slice(0, colon).trim().replace(/^['"]|['"]$/g, '') !== segment) continue;
+      let key;
+      try {
+        key = unquoteKey(line.trimmed.slice(0, colon), line.i + 1);
+      } catch {
+        continue;
+      }
+      if (key !== segment) continue;
       hit = i;
       view = line;
       break;
@@ -205,11 +214,15 @@ function locate(lines, path) {
 /**
  * Deep structural equality over the plain data yaml-lite produces.
  *
- * Exported so the proof at the end of `patch()` can be tested directly. It is
- * defence in depth with no input known to reach it — every wrong case found so
- * far is refused earlier, by the locator, by the comment guard, or by
- * `formatScalar` — so a test that goes through `patch()` cannot make it fire,
- * and this is the mutable logic the guarantee actually rests on.
+ * Exported so the proof at the end of `patch()` can be tested directly, and
+ * because it is the mutable logic the guarantee rests on.
+ *
+ * It is NOT unreachable, and an earlier version of this comment said it was.
+ * A review found the case: `formatScalar` used a stricter number pattern than
+ * `parseScalar`, so the string ".5" was written unquoted and read back as the
+ * number 0.5 — a changed type, caught here and nowhere else. That specific
+ * disagreement is fixed in yaml-lite, which is the right place for it; this
+ * check is what noticed.
  */
 export function sameValue(a, b) {
   if (a === b) return true;
@@ -242,9 +255,16 @@ function writeAt(doc, path, value) {
 /** Rewrite the value on a `key: value` line, keeping indent, comment and ending. */
 function scalarLine(line, target, value) {
   const body = target.dash ? line.trimmed.slice(2).trim() : line.trimmed;
-  const colon = body.indexOf(':');
-  const head = `${' '.repeat(line.indent)}${target.dash ? '- ' : ''}${body.slice(0, colon + 1)}`;
+  const colon = keyColonIndex(body);
   const tail = line.comment === '' ? '' : ` ${line.comment}`;
+  // A plain sequence item (`- npm test`) is a value with no key at all, which
+  // an address ending in an integer reaches. Treating it like a mapping line
+  // dropped the dash and shifted the indent by one, and the round-trip proof
+  // then blamed a NEIGHBOURING line for the indentation it had broken.
+  if (colon === -1) {
+    return `${' '.repeat(line.indent)}- ${formatScalar(value)}${tail}${line.eol}`;
+  }
+  const head = `${' '.repeat(line.indent)}${target.dash ? '- ' : ''}${body.slice(0, colon + 1)}`;
   return `${head} ${formatScalar(value)}${tail}${line.eol}`;
 }
 
@@ -256,6 +276,14 @@ function scalarLine(line, target, value) {
  * parse back to exactly the document intended.
  */
 export function patch(text, path, value) {
+  // A BOM is an encoding marker, not content — and `trimStart` counts it as
+  // whitespace, so it read as one column of indentation and the rebuilt line
+  // replaced it with a SPACE, producing an odd indent the parser then refused.
+  // Split it off here and put it back on the result, so the file keeps the
+  // marker it came with and nothing downstream has to know about it.
+  const bom = text.charCodeAt(0) === 0xfeff ? text.slice(0, 1) : '';
+  if (bom !== '') return bom + patch(text.slice(1), path, value);
+
   let before;
   try {
     before = parse(text);
@@ -300,12 +328,17 @@ function edit(text, path, value, before) {
     const body = target.dash ? line.trimmed.slice(2).trim() : line.trimmed;
     const colon = body.indexOf(':');
     const inlineValue = body.slice(colon + 1).trim();
-    const end = inlineValue === '' ? blockEnd(lines, target.line + 1, line.indent) : target.line + 1;
+    // The block boundary is the KEY's indent, not the line's. On the first key
+    // of a sequence item (`- tags:`) the line is indented at the DASH, so
+    // using it ran the block to the end of the whole item and the splice took
+    // the item's sibling keys out with the list.
+    const ownIndent = target.dash ? target.keyIndent : line.indent;
+    const end = inlineValue === '' ? blockEnd(lines, target.line + 1, ownIndent) : target.line + 1;
     // The items' indent is the one they already have; a list with none yet
     // (`shared_zones: []`) takes the step the rest of the document uses.
-    const discovered = childIndentOf(lines, target.line + 1, end, line.indent);
+    const discovered = childIndentOf(lines, target.line + 1, end, ownIndent);
     const childIndent = discovered === -1
-      ? line.indent + documentStep(lines, first === undefined ? 0 : first.indent)
+      ? ownIndent + documentStep(lines, first === undefined ? 0 : first.indent)
       : discovered;
     // Rewriting the block rewrites its lines, so a comment living among the
     // items would disappear. Refusing keeps the promise this module is for.

--- a/site/scripts/build-sandbox.mjs
+++ b/site/scripts/build-sandbox.mjs
@@ -23,9 +23,11 @@
  *    before the build. The journals keep their real spacing — an agent that
  *    was quiet for 40 minutes still is.
  *
- * 2. **It must not pretend to be live.** The 30-second meta refresh is
- *    stripped (it would also snap a reader back to the first tab mid-click)
- *    and a banner says what the page is.
+ * 2. **It must not pretend to be live.** The 30-second refresh marker is
+ *    stripped, which is all it takes: the page arms its reload timer only if
+ *    that marker is present, so a stripped marker means no timer and no
+ *    reader snapped back to the first tab mid-click. A banner says what the
+ *    page is.
  *
  * Spend ships beside it as a plain `cost.json`, which is exactly the relative
  * path the client already fetches — so the sandbox exercises the same code a
@@ -185,7 +187,7 @@ try {
   // Both replacements are asserted rather than assumed: a silent no-op here
   // would publish a page that reloads itself every 30 seconds and claims to
   // be someone's live board.
-  const refresh = '<meta http-equiv="refresh" content="30">\n';
+  const refresh = '<meta name="tyran-refresh" content="30">\n';
   if (!html.includes(refresh)) throw new Error('the refresh tag moved — the sandbox would publish a self-reloading page');
   html = html.replace(refresh, '');
 

--- a/site/src/content/docs/agents.mdx
+++ b/site/src/content/docs/agents.mdx
@@ -158,6 +158,44 @@ plugin's shipped template so a repo that has not run setup still works, but it
 says so **loudly on stderr**. A silent fallback would let a repo believe it had
 adopted a policy it never wrote.
 
+### When a tier's model is out of capacity
+
+A tier resolves to a model, and a model can be temporarily unavailable —
+usually because it has hit a rate limit while the account still has budget on
+everything else. Measured on a real run: the strongest tier hit its limit and
+the subagents **failed** rather than finishing on the tier below, which had
+capacity the whole time.
+
+```bash
+node scripts/tiers.mjs --role acceptance --unavailable fable --field json
+# tiers: FELL BACK top -> deep because the top model is unavailable.
+# {"tier":"deep","model":"opus","effort":"xhigh","floored":false,"fell_from":"top"}
+```
+
+**It falls DOWN the ladder, never up**, and that is the answer to the question
+this feature was blocked on for a while. Climbing would spend more than the
+routing table promised, silently, at exactly the moment nobody is watching —
+and the whole point of the table is that what a run costs is legible before it
+runs. Down is also the direction the incident needed.
+
+Three things the fall does not do:
+
+- **It does not lower the effort.** "This task needs deep reasoning" did not
+  stop being true because a model ran out of capacity, and dropping both dials
+  at once is a second downgrade nobody asked for. `fell_from` records the tier
+  it came from so the substitution is visible in the ledger.
+- **It does not cross a role floor.** A security review that ran on the
+  cheapest model is not a security review. The floors in
+  [the routing table](#the-routing-table) bound the fall.
+- **It does not pretend.** The substitution is announced on stderr in the same
+  breath as the resolution, saying plainly that this is a weaker model than the
+  table asked for.
+
+When every tier a role may use is unavailable, `tiers.mjs` exits 2 rather than
+returning the bottom of the ladder. That case is not a routing problem — there
+is nothing left to substitute — and the thing that already knows how to wait
+for capacity is [overnight mode](../overnight/).
+
 ## The brake
 
 An operator can halt a running initiative without killing the session:

--- a/site/src/content/docs/board.mdx
+++ b/site/src/content/docs/board.mdx
@@ -101,6 +101,34 @@ into can have. Re-render it at the start of each sitting rather than reusing
 the last one — every block in an applied sheet names an ask that is now
 closed, and `apply` refuses the whole file rather than appending a duplicate.
 
+### Or answer it on the page
+
+With the board served `--write`, every question in the **Waiting on you** tab
+carries a box. Type an answer and press **Answer**; on a question that has a
+recorded default, press **Take the default** instead. The three commands above
+still work and stay printed on the tab — the box is a convenience, and a board
+opened over `file://` or without `--write` has to leave you somewhere to go.
+
+The request carries exactly two things: **which** ask, and your words.
+Everything else — the question, the recorded default, the ticket, the gate id —
+is read back out of the journal by the server, which is the same guarantee the
+sheet makes and for the same reason. The append itself is the function
+`answer apply` calls, unwrapped, so both routes produce byte-identical events:
+the gate is re-checked INSIDE the journal's write lock (a question you closed
+in a terminal thirty seconds ago cannot be closed twice) and the decision is
+written before the gate.
+
+Each card also says which KIND of question it is, and that costs no new event
+type to know:
+
+| | |
+|---|---|
+| **decision · a default is recorded** | saying nothing has a safe outcome. You may take the recommendation and move on. |
+| **blocking · no safe default** | nobody recorded a fallback, so this one waits for you. |
+
+It is the same distinction that already makes the answer sheet sort
+no-default-first.
+
 ## Opening it
 
 **[Try the sandbox board](../sandbox/)** — the
@@ -151,7 +179,12 @@ quick look, `BOARD.md` for reading in the terminal or in a diff.
 The page an operator leaves open overnight: self-contained (inline CSS/JS,
 zero external hosts and zero CDNs, complete over `file://`; the one
 same-origin request to loopback is amended in [Spend](#spend) below) and
-refreshing itself every 30 seconds. The artefact itself never reads a clock —
+reloading itself every 30 seconds — on a timer the page can stop, not a
+`meta http-equiv="refresh"`, because a browser schedules that the moment it
+parses the tag and removing the tag afterwards does not cancel it. A reload
+nothing can stop would destroy a half-typed answer or model name, so the
+timer is held while you are editing and re-armed when you leave.
+The artefact itself never reads a clock —
 "as of" is the newest event timestamp, which keeps `--check` valid for the
 HTML too; the only clock is the viewer's own browser, which ages the agent
 strip.
@@ -163,7 +196,7 @@ and the page opens on Overview:
 |---|---|
 | **Overview** | is anything on fire — four tiles (waiting on you · agents running · progress · needs a human), any STOPPED or PAUSED banner, the agent strip with its signal-freshness colours, a spend headline once spend has loaded, the errors agents logged, and the UNREADABLE list |
 | **Board** | where every ticket is — the lanes, and the detail of whichever card you select |
-| **Waiting on you** | what is blocked on a decision, and the commands that unblock it |
+| **Waiting on you** | what is blocked on a decision, whether it has a safe default, and — with `--write` — a box to answer it in |
 | **Spend** | what the work has cost |
 | **Settings** | what Tyran is configured to do, and — with `--write` — how to change it |
 
@@ -319,7 +352,13 @@ rule (a boundary's written `reason` is load-bearing, and a one-line reason
 typed into a form is how a policy turns into a list of unexplained globs), or
 edit `pricing:` (a rate card is a table copied from a vendor's price list).
 
-**What guards the route, stated exactly.** The `Host` pin that covers the whole
+**Three routes write, and one flag turns all of them on.**
+`POST /settings/config`, `POST /settings/policy` and `POST /answer` — answering
+a question and editing the autonomy policy are different acts, but they are the
+same decision for the operator: whether this board may change the repository at
+all.
+
+**What guards the routes, stated exactly.** The `Host` pin that covers the whole
 server, plus an `Origin` check and a required `application/json` content type —
 together those close the browser paths: a page on another origin cannot read
 the board, and its POST is preflighted and refused. What they do **not** do is
@@ -349,9 +388,11 @@ for four days — the timestamp was in `board.json` all along and nothing render
 it. Now every card in a lane where standing still IS the defect (`blocked`,
 `changes-requested`, `in-review`, `waiting-operator`, `in-progress`,
 `paused-limit`) carries its age, in the same four colours the agent strip uses.
-`backlog`, `ready` and `done` do not: an unstarted ticket is waiting its turn,
-not stalling, and marking every one of them stale makes the mark worthless
-where it means something.
+The other four do not, for the same reason in four forms: `backlog` and `ready`
+hold tickets waiting their turn rather than stalling, `parked` holds one you
+deliberately set aside, and `done` holds one that is supposed to have stopped
+moving. Marking all of those stale makes the mark worthless where it means
+something.
 
 Both are worded as observations rather than verdicts. The board reports the
 last event on a ticket; only you know whether that is a stall or a long test

--- a/site/src/content/docs/configuration.mdx
+++ b/site/src/content/docs/configuration.mdx
@@ -13,10 +13,13 @@ written by `scripts/scan-repo.mjs` · validated by `scripts/schema.mjs`
 All per-repo configuration lives in `.tyran/config.yaml` — committed, human
 reviewable, written by `/tyran:setup` and editable by hand.
 
-**Or from the board.** `npx @jjanczur/tyran board --serve --write` puts every
-key below on a screen with a sentence explaining what it does, and writes your
-change back into this file one line at a time, comments intact — including the
-autonomy policy. See [the Settings tab](../board/#settings) for what it will and
+**Or from the board.** `npx @jjanczur/tyran board --serve --write` puts the
+cost profile, the deployment autonomy, the four model tiers, the validation
+commands, the shared zones and the whole `limits:` block on a screen, each with
+a sentence explaining what it does, and writes your change back into this file
+one line at a time with the comments intact — the autonomy policy too.
+`pricing:` and `main_writable_paths:` stay hand edits. See
+[the Settings tab](../board/#settings) for what it will and
 will not touch, and for why loosening a boundary there takes a second press.
 
 ## `.tyran/config.yaml`

--- a/tests/unit/board-client-literal.test.mjs
+++ b/tests/unit/board-client-literal.test.mjs
@@ -1,0 +1,42 @@
+/**
+ * One guard, on the SOURCE TEXT of board-html.mjs, in its own file.
+ *
+ * The whole browser client is a single template literal, so a backtick
+ * anywhere inside it — including inside a comment — ends the literal and the
+ * module stops loading. `board.test.mjs` already compiles the emitted script
+ * and would catch it, but it cannot REPORT it: that file imports the module,
+ * so a stray backtick makes the import throw before any test runs, and the
+ * whole file fails with "Unexpected identifier 'describe'" — the name of the
+ * innocent word that happened to follow.
+ *
+ * This file therefore reads the source as TEXT and imports nothing from it.
+ * Four comments in one sitting quoted an identifier in backticks and cost a
+ * debugging round each; the message below is what those rounds were for.
+ */
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+
+const SOURCE = fileURLToPath(new URL('../../scripts/board-html.mjs', import.meta.url));
+
+test('no backtick reaches the client template literal', () => {
+  // MUTANT: put a backtick in any comment inside CLIENT_JS.
+  const src = readFileSync(SOURCE, 'utf8');
+  const marker = 'const CLIENT_JS = ';
+  const open = src.indexOf(marker);
+  assert.notEqual(open, -1, 'CLIENT_JS is gone — this guard needs rewriting');
+  const body = open + marker.length + 1;
+  const close = src.indexOf('\n`;', body);
+  assert.ok(close > body, 'CLIENT_JS is no longer one template literal — this guard needs rewriting');
+
+  const offenders = src.slice(body, close).split('\n')
+    .map((line, i) => `line ${i + 1}: ${line.trim()}`)
+    .filter((line) => line.includes('`'));
+  assert.deepEqual(
+    offenders,
+    [],
+    'A backtick inside CLIENT_JS ends the template literal and the whole page stops loading. ' +
+      'Reword the comment: name identifiers in prose, never in backticks.',
+  );
+});

--- a/tests/unit/board-write.test.mjs
+++ b/tests/unit/board-write.test.mjs
@@ -11,7 +11,7 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 import { spawn } from 'node:child_process';
-import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -351,4 +351,178 @@ test('--write without --serve is a usage error, not a silent no-op', async () =>
   } finally {
     f.cleanup();
   }
+});
+
+test('a question can be answered from the page, and the answer lands as two events', () => {
+  // The one context switch left in the operator loop: the queue showed the
+  // question and the three commands, and closing it meant a terminal.
+  //
+  // MUTANT: reimplement the append here instead of calling `answerOne`. The
+  // two properties that would silently go missing are the re-check of the
+  // gate INSIDE the lock (so a question answered in a terminal seconds ago is
+  // not answered twice) and decision-before-gate ordering.
+  return (async () => {
+    const { execFileSync } = await import('node:child_process');
+    const f = fixture();
+    const s = await serve(f.tyran, ['--write']);
+    try {
+      // Render first: board.json does not exist until something writes it.
+      execFileSync(process.execPath, [SCRIPT, '--dir', f.tyran], { stdio: 'pipe' });
+      const open = JSON.parse(readFileSync(join(f.tyran, 'state', 'board.json'), 'utf8')).asks;
+      assert.ok(open.length > 0, 'the fixture must carry an open question');
+      const ask = open[0];
+
+      const res = await post(s.base, '/answer', { init: ask.init, kind: ask.kind, answer: 'yes, on staging only' });
+      const payload = await res.json();
+      assert.equal(payload.ok, true, JSON.stringify(payload));
+      assert.equal(payload.mode, 'answered');
+      assert.match(String(payload.decision), /^D-\d+$/);
+
+      const lines = readFileSync(join(f.tyran, 'state', ask.init, 'journal.jsonl'), 'utf8')
+        .split('\n').filter(Boolean).map((l) => JSON.parse(l));
+      const decision = lines.filter((e) => e.ev === 'decision').at(-1);
+      const gate = lines.at(-1);
+      // The decision text is composed by `eventsFor`, shared with the CLI, so
+      // an answer given on the page is byte-identical to one given in a
+      // terminal — including the gate id it is filed under.
+      assert.equal(decision.data.text, `${ask.kind}: yes, on staging only`);
+      assert.equal(gate.ev, 'gate', 'the gate must be the LAST of the two');
+      assert.equal(gate.data.kind, ask.kind);
+      assert.equal(gate.data.result, 'answered');
+
+      // Answering twice must not append twice.
+      const again = await post(s.base, '/answer', { init: ask.init, kind: ask.kind, answer: 'again' });
+      assert.equal(again.status, 400);
+      assert.match((await again.json()).error, /no open question|already/i);
+      assert.equal(lines.filter((e) => e.ev === 'gate' && e.data.kind === ask.kind && e.data.result === 'answered').length, 1);
+    } finally {
+      await s.stop();
+      f.cleanup();
+    }
+  })();
+});
+
+test('answering is refused without --write, like every other route that writes', () => {
+  return (async () => {
+    const f = fixture();
+    const s = await serve(f.tyran);
+    try {
+      const res = await post(s.base, '/answer', { init: 'demo', kind: 'Q-1', answer: 'x' });
+      assert.equal(res.status, 403);
+      assert.match((await res.json()).error, /--write/);
+    } finally {
+      await s.stop();
+      f.cleanup();
+    }
+  })();
+});
+
+test('an answer is validated, and a bad one writes nothing', () => {
+  return (async () => {
+    const { execFileSync } = await import('node:child_process');
+    const f = fixture();
+    const s = await serve(f.tyran, ['--write']);
+    try {
+      execFileSync(process.execPath, [SCRIPT, '--dir', f.tyran], { stdio: 'pipe' });
+      const ask = JSON.parse(readFileSync(join(f.tyran, 'state', 'board.json'), 'utf8')).asks[0];
+      const journal = join(f.tyran, 'state', ask.init, 'journal.jsonl');
+      const before = readFileSync(journal, 'utf8');
+
+      // An unknown ask, an invisible codepoint, and a dash (which means
+      // "leave it open" and therefore records nothing).
+      const cases = [
+        { init: ask.init, kind: 'Q-999', answer: 'x' },
+        { init: 'nosuch', kind: ask.kind, answer: 'x' },
+        { init: ask.init, kind: ask.kind, answer: `a${String.fromCodePoint(0x202e)}b` },
+        { init: ask.init, kind: ask.kind, answer: '-' },
+      ];
+      for (const body of cases) {
+        const res = await post(s.base, '/answer', body);
+        assert.equal(res.status, 400, JSON.stringify(body));
+        assert.equal((await res.json()).ok, false);
+      }
+      assert.equal(readFileSync(journal, 'utf8'), before, 'a refused answer appends nothing');
+    } finally {
+      await s.stop();
+      f.cleanup();
+    }
+  })();
+});
+
+test('a blank answer takes the recorded default and still records it as a decision', () => {
+  // A default accepted is a decision, and the ledger must say which it was.
+  return (async () => {
+    const { execFileSync } = await import('node:child_process');
+    const f = fixture();
+    const s = await serve(f.tyran, ['--write']);
+    try {
+      execFileSync(process.execPath, [SCRIPT, '--dir', f.tyran], { stdio: 'pipe' });
+      const withDefault = JSON.parse(readFileSync(join(f.tyran, 'state', 'board.json'), 'utf8'))
+        .asks.find((a) => a.default !== null && a.default !== undefined);
+      assert.ok(withDefault, 'the fixture must carry an ask with a default');
+      const res = await post(s.base, '/answer', { init: withDefault.init, kind: withDefault.kind, answer: '' });
+      const payload = await res.json();
+      assert.equal(payload.mode, 'default');
+      assert.equal(payload.recorded, withDefault.default, 'the default is taken VERBATIM from the journal');
+    } finally {
+      await s.stop();
+      f.cleanup();
+    }
+  })();
+});
+
+test('a concurrent writer is refused, not silently overwritten', () => {
+  // The write is a whole-file read-modify-write, so a second writer between
+  // the read and the write used to have its change discarded with both
+  // writers reporting success. In-process cannot interleave; two boards on
+  // one directory, or a board and a terminal, are ordinary.
+  // MUTANT: drop the compare-and-swap in handleSettingsWrite.
+  return (async () => {
+    const f = fixture();
+    const s = await serve(f.tyran, ['--write']);
+    try {
+      const file = join(f.tyran, 'config.yaml');
+      // Simulate the other writer landing between this server's read and its
+      // write by changing the file out of band first, then posting a value
+      // computed from what the page loaded.
+      const stale = readFileSync(file, 'utf8');
+      writeFileSync(file, stale.replace('profile: balanced', 'profile: full'));
+      const res = await post(s.base, '/settings/config', { id: 'tiers.work', value: 'newmodel' });
+      assert.equal((await res.json()).ok, true, 'a normal write still works after an out-of-band change');
+      // Both changes must survive: the out-of-band one and this one.
+      const now = parse(readFileSync(file, 'utf8'));
+      assert.equal(now.profile, 'full', 'the other writer was not clobbered');
+      assert.equal(now.tiers.work, 'newmodel');
+    } finally {
+      await s.stop();
+      f.cleanup();
+    }
+  })();
+});
+
+test('board.mjs refuses a --dir that is not a .tyran directory', () => {
+  // `--dir <repo-root>` is the obvious typo, and since the renderer creates
+  // state/ where it is told to, it used to succeed silently: a state/ folder
+  // in the project root and an empty board reporting all is well about a repo
+  // whose real journals sit one level down.
+  // MUTANT: delete the looksLikeTyran check.
+  return (async () => {
+    const { execFileSync } = await import('node:child_process');
+    const f = fixture();
+    try {
+      assert.throws(
+        () => execFileSync(process.execPath, [SCRIPT, '--dir', f.dir], { stdio: 'pipe' }),
+        (err) => {
+          assert.equal(err.status, 2);
+          assert.match(String(err.stderr), /does not look like a \.tyran directory/);
+          return true;
+        },
+      );
+      assert.ok(!existsSync(join(f.dir, 'state')), 'and it created nothing where it was pointed');
+      // The real directory still renders, including a fresh one with no state/.
+      execFileSync(process.execPath, [SCRIPT, '--dir', f.tyran], { stdio: 'pipe' });
+    } finally {
+      f.cleanup();
+    }
+  })();
 });

--- a/tests/unit/board.test.mjs
+++ b/tests/unit/board.test.mjs
@@ -445,6 +445,32 @@ test('board.json carries no absolute path, so two clones of one journal agree', 
   }
 });
 
+test('the page reloads on a timer it can stop, never on a meta refresh', () => {
+  // A real http-equiv refresh is scheduled by the browser when it PARSES the
+  // tag, and removing the node afterwards does not cancel it. The page has a
+  // Settings tab and an answer box now, so a reload it cannot stop destroys a
+  // half-typed value — and the code used to claim, in a comment, that removing
+  // the tag was enough.
+  //
+  // MUTANT: put `http-equiv="refresh"` back. Every other assertion about the
+  // page still passes, and the one thing that breaks is invisible from here:
+  // a value someone was typing.
+  const html = demoHtml();
+  assert.doesNotMatch(html, /http-equiv=["']refresh/i, 'the browser must schedule no navigation of its own');
+  assert.match(html, /<meta name="tyran-refresh" content="30">/, 'the interval is declared as inert markup');
+  assert.match(html, /meta\[name="tyran-refresh"\]/, 'and the client is what reads it');
+  assert.match(html, /clearTimeout\(refreshTimer\)/, 'the timer must be cancellable');
+});
+
+test('the sandbox strips the marker, and stripping it is all it takes', () => {
+  // MUTANT: leave the marker in. The published docs page would then reload
+  // every 30 seconds and snap a reader back to the first tab mid-click, which
+  // is exactly what the generator exists to prevent.
+  const src = readFileSync(fileURLToPath(new URL('../../site/scripts/build-sandbox.mjs', import.meta.url)), 'utf8');
+  assert.match(src, /const refresh = '<meta name="tyran-refresh" content="30">/);
+  assert.match(src, /throw new Error\('the refresh tag moved/, 'a silent no-op here publishes a self-reloading page');
+});
+
 test('the client script actually parses, which nothing else in this suite proves', () => {
   // MUTANT: any stray backtick in CLIENT_JS. The whole client is one template
   // literal in board-html.mjs, so a backtick inside a COMMENT terminates it

--- a/tests/unit/scan-control-chars.test.mjs
+++ b/tests/unit/scan-control-chars.test.mjs
@@ -998,6 +998,7 @@ test('THIS repository scans clean end to end', () => {
     'tests/pressure/.gitkeep',
     'tests/unit/agents.test.mjs',
     'tests/unit/answer.test.mjs',
+    'tests/unit/board-client-literal.test.mjs',
     'tests/unit/board-write.test.mjs',
     'tests/unit/board.test.mjs',
     'tests/unit/cli.test.mjs',

--- a/tests/unit/settings.test.mjs
+++ b/tests/unit/settings.test.mjs
@@ -372,3 +372,47 @@ test('list edits keep the comments around them', () => {
     f.cleanup();
   }
 });
+
+test('a config with no limits: block is editable, not fatal', () => {
+  // `limits:` is OPTIONAL in a valid config — every install set up before it
+  // existed has none — and resolvePath returned null for an absent parent,
+  // which readAt then tried to iterate. The whole Settings tab died with
+  // "path is not iterable" and every write became an HTTP 500.
+  // MUTANT: return null from resolvePath again.
+  const f = fixture();
+  try {
+    const file = join(f.tyran, 'config.yaml');
+    writeFileSync(file, [
+      'profile: balanced', 'autonomy: P1',
+      'tiers:', '  cheap: haiku', '  work: sonnet', '  deep: opus', '  top: fable',
+      'validation:', '  - npm test', 'shared_zones: []', '',
+    ].join('\n'));
+    assert.deepEqual(validateConfig(parse(readFileSync(file, 'utf8'))), [], 'the fixture must be a VALID config');
+
+    const s = readSettings(f.tyran);
+    const overnight = s.groups.find((g) => g.id === 'overnight');
+    assert.ok(overnight.settings.every((x) => x.present === false), 'absent, and rendered as absent');
+    assert.ok(s.groups.flatMap((g) => g.settings).some((x) => x.present === true), 'the rest still reads');
+
+    // And the two writes behave: the absent one refuses by NAME, the present
+    // one still lands.
+    assert.throws(() => applySetting(f.tyran, 'limits.mode', 'pause'), SettingsError);
+    write(f.tyran, applySetting(f.tyran, 'profile', 'eco'));
+    assert.equal(parse(readFileSync(file, 'utf8')).profile, 'eco');
+  } finally {
+    f.cleanup();
+  }
+});
+
+test('an apply hands back the text it read, so a caller can compare and swap', () => {
+  // MUTANT: drop before_text. The board then writes a whole-file replacement
+  // over whatever arrived in the meantime, and both writers report success.
+  const f = fixture();
+  try {
+    const applied = applySetting(f.tyran, 'profile', 'eco');
+    assert.equal(applied.before_text, readFileSync(join(f.tyran, 'config.yaml'), 'utf8'));
+    assert.notEqual(applied.text, applied.before_text);
+  } finally {
+    f.cleanup();
+  }
+});

--- a/tests/unit/tiers.test.mjs
+++ b/tests/unit/tiers.test.mjs
@@ -135,9 +135,13 @@ test('resolveAll covers every role and reports tier, model and effort', () => {
   const doc = { tiers: { cheap: 'haiku', work: 'sonnet', deep: 'opus', top: 'fable' } };
   const all = resolveAll(doc, 'balanced');
   assert.deepEqual(Object.keys(all).sort(), [...ROLES].sort());
-  assert.deepEqual(all.scout, { tier: 'cheap', model: 'haiku', effort: 'low', floored: false });
-  assert.deepEqual(all['security-review'], { tier: 'top', model: 'fable', effort: 'max', floored: false });
-  assert.deepEqual(all.implementer, { tier: 'work', model: 'sonnet', effort: 'medium', floored: false });
+  // `fell_from` is null on every ordinary resolution and names the tier a
+  // fallback came down FROM. Pinned in the shape rather than tested only
+  // where it fires: a consumer that reads it must be able to rely on it
+  // always being present.
+  assert.deepEqual(all.scout, { tier: 'cheap', model: 'haiku', effort: 'low', floored: false, fell_from: null });
+  assert.deepEqual(all['security-review'], { tier: 'top', model: 'fable', effort: 'max', floored: false, fell_from: null });
+  assert.deepEqual(all.implementer, { tier: 'work', model: 'sonnet', effort: 'medium', floored: false, fell_from: null });
 });
 
 // --- dynamic overrides: the conductor adjusting a single subtask -----------
@@ -209,6 +213,7 @@ test('CLI --field selects what lands on stdout', () => {
     model: 'haiku',
     effort: 'low',
     floored: false,
+    fell_from: null,
   });
 });
 
@@ -285,4 +290,86 @@ test('the shipped template resolves for every role — CI would otherwise ship a
     const all = resolveAll(doc, profile);
     for (const role of ROLES) assert.ok(all[role].model.length > 0, `${role}/${profile}`);
   }
+});
+
+// --- fallback: a tier whose model is unavailable ---------------------------
+
+test('a fallback walks DOWN the ladder, never up', () => {
+  // The direction is the whole answer to the question this was blocked on.
+  // Up would spend more than the routing table promised, silently, at the
+  // moment nobody is watching — and the incident that asked for this was the
+  // strongest tier hitting its limit while the one below it had capacity.
+  // MUTANT: search upward. `acceptance` then resolves to nothing at all,
+  // because `top` is the last tier — the failure is silent in the other
+  // direction, where a role in the middle quietly gets a costlier model.
+  const doc = { tiers: { cheap: 'haiku', work: 'sonnet', deep: 'opus', top: 'fable' } };
+  const fell = resolveModel(doc, 'acceptance', 'balanced', 'normal', { unavailable: ['fable'] });
+  assert.equal(fell.tier, 'deep');
+  assert.equal(fell.model, 'opus');
+  assert.equal(fell.fell_from, 'top');
+  // Effort follows the ORIGINAL tier: "this needs deep reasoning" did not stop
+  // being true because a model ran out of capacity, and dropping both dials is
+  // a second downgrade nobody asked for.
+  assert.equal(fell.effort, 'xhigh');
+});
+
+test('a fallback skips every unavailable tier and stops at the first that is not', () => {
+  const doc = { tiers: { cheap: 'haiku', work: 'sonnet', deep: 'opus', top: 'fable' } };
+  const fell = resolveModel(doc, 'acceptance', 'balanced', 'normal', { unavailable: ['fable', 'opus'] });
+  assert.equal(fell.tier, 'work');
+  assert.equal(fell.model, 'sonnet');
+  assert.equal(fell.fell_from, 'top');
+});
+
+test('a role floor is not lowered by a fallback', () => {
+  // A security review that ran on the cheapest model is not a security review.
+  // MUTANT: start the walk at index 0 instead of the floor — the most
+  // consequential judgement in the system silently drops three tiers.
+  const doc = { tiers: { cheap: 'haiku', work: 'sonnet', deep: 'opus', top: 'fable' } };
+  assert.throws(
+    () => resolveModel(doc, 'security-review', 'balanced', 'normal', { unavailable: ['fable'] }),
+    /every tier "security-review" may use is unavailable/,
+  );
+  assert.throws(
+    () => resolveModel(doc, 'security-review', 'balanced', 'normal', { unavailable: ['fable'] }),
+    /floor for this role is "top"/,
+  );
+});
+
+test('exhausting the ladder is a pause, not a substitution', () => {
+  // MUTANT: return the bottom tier anyway. Work then runs on a model the
+  // caller has just been told is unavailable, and fails again for the same
+  // reason, having spent another spawn to find out.
+  const doc = { tiers: { cheap: 'haiku', work: 'sonnet', deep: 'opus', top: 'fable' } };
+  assert.throws(
+    () => resolveModel(doc, 'implementer', 'balanced', 'normal', { unavailable: ['sonnet', 'haiku'] }),
+    /nothing to fall back to.*pause, not a substitution/s,
+  );
+});
+
+test('an unavailable model that is not the resolved one changes nothing', () => {
+  const doc = { tiers: { cheap: 'haiku', work: 'sonnet', deep: 'opus', top: 'fable' } };
+  const same = resolveModel(doc, 'implementer', 'balanced', 'normal', { unavailable: ['haiku', 'fable'] });
+  assert.equal(same.tier, 'work');
+  assert.equal(same.fell_from, null, 'a resolution that did not move must not claim it fell');
+});
+
+test('the fallback is announced on stderr, because a weaker model is a fact about the run', () => {
+  // MUTANT: drop the notice. The routing table then quietly means something
+  // other than what it says, which is the one thing this whole file exists to
+  // prevent.
+  const dir = repoWithConfig();
+  const out = execFileSync(process.execPath, [SCRIPT, '--role', 'acceptance', '--unavailable', 'fable', '--field', 'json'],
+    { cwd: dir, encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'] });
+  assert.equal(JSON.parse(out.trim()).tier, 'deep');
+});
+
+test('--unavailable is repeatable', () => {
+  const dir = repoWithConfig();
+  const out = execFileSync(
+    process.execPath,
+    [SCRIPT, '--role', 'acceptance', '--unavailable', 'fable', '--unavailable', 'opus', '--field', 'tier'],
+    { cwd: dir, encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'] },
+  );
+  assert.equal(out.trim(), 'work');
 });

--- a/tests/unit/yaml-patch.test.mjs
+++ b/tests/unit/yaml-patch.test.mjs
@@ -239,3 +239,34 @@ test('refuses a value this subset cannot spell back', () => {
   assert.throws(() => patch(template('config.yaml'), ['profile'], 'a\nb'), YamlPatchError);
   assert.throws(() => patch(template('config.yaml'), ['profile'], bidi), YamlPatchError);
 });
+
+test('a key is located by the parser rule, not by the first colon on the line', () => {
+  // `a:b` is a legal key in this subset, and `indexOf(':')` finds the colon
+  // INSIDE it — so a request for `a` landed on the `a:b` line and rewrote the
+  // wrong key. A wrong write, not a failed one; the round-trip proof caught it
+  // only because the result happened to contain a duplicate key.
+  // MUTANT: go back to line.trimmed.indexOf(':').
+  const after = patch('a:b: 1\na: 2\n', ['a'], 5);
+  assert.deepEqual(parse(after), { 'a:b': 1, a: 5 });
+  assert.match(after, /^a:b: 1$/m, 'the neighbouring key is untouched');
+});
+
+test('a path ending in an integer edits that list item', () => {
+  // The module documents integer segments and the locator has a whole branch
+  // for them, but `scalarLine` assumed every target was a `key: value` line:
+  // it dropped the dash and shifted the indent by one, and the proof then
+  // blamed a NEIGHBOURING line for the indentation it had just broken.
+  // MUTANT: remove the colon === -1 branch in scalarLine.
+  const after = patch('validation:\n  - npm test\n  - npm run build\n', ['validation', 1], 'npm run lint');
+  assert.deepEqual(parse(after).validation, ['npm test', 'npm run lint']);
+  assert.match(after, /^ {2}- npm run lint$/m);
+});
+
+test('replacing a list that is the FIRST key of a sequence item keeps the item', () => {
+  // On a dash line the line's indent is the DASH's, not the key's, so the
+  // block ran to the end of the whole item and the splice took the sibling
+  // keys with it. MUTANT: pass line.indent instead of the key indent.
+  const after = patch('rules:\n  - tags:\n      - a\n    class: AUTO\n', ['rules', 0, 'tags'], ['z']);
+  assert.deepEqual(parse(after), { rules: [{ tags: ['z'], class: 'AUTO' }] });
+  assert.match(after, /^ {4}class: AUTO$/m, 'the sibling key survived');
+});


### PR DESCRIPTION
### Answer a question from the board

The last context switch in the operator loop is gone. Every question in the
**Waiting on you** tab now carries a box: type an answer and press **Answer**,
or press **Take the default** on a question that records one. The three
`answer render / edit / apply` commands still work and stay printed on the tab —
the box is a convenience, and a board opened over `file://` or without
`--write` has to leave you somewhere to go.

The request carries exactly two things: **which** ask, and your words. The
question, the recorded default, the ticket and the gate id are all read back
out of the journal by the server — the same guarantee the answer sheet makes,
for the same reason. The append is `answerOne`, the function `answer apply`
already calls, unwrapped: both routes produce byte-identical events, the gate
is re-checked INSIDE the journal's write lock so a question closed in a
terminal thirty seconds ago cannot be closed twice, and the decision is written
before the gate.

Each card also says which kind of question it is, and that costs no new event
type: **decision · a default is recorded** means saying nothing has a safe
outcome; **blocking · no safe default** means it waits for you. It is the same
distinction that already makes the answer sheet sort no-default-first.

### A tier that runs out of capacity falls to the next one down

Measured on a real run: the strongest tier hit its limit and the subagents
**failed** rather than finishing on the tier below, which had capacity the
whole time.

```bash
node scripts/tiers.mjs --role acceptance --unavailable fable --field json
# tiers: FELL BACK top -> deep because the top model is unavailable.
```

**Down the ladder, never up** — which is the answer to the question this was
blocked on. Climbing would spend more than the routing table promised,
silently, at exactly the moment nobody is watching. Three things the fall does
not do: it does not lower the **effort** (that judgement did not change because
a model ran out of capacity), it does not cross a **role floor** (a security
review on the cheapest model is not a security review), and it does not
**pretend** — the substitution is announced, and `fell_from` records it. When
every tier a role may use is unavailable, it exits 2 rather than returning the
bottom of the ladder: that is a pause, not a substitution, and overnight mode
is what knows how to wait.

### Twelve confirmed findings from an adversarial review of 0.1.24 and 0.1.25

Five lenses attacked the shipped code and each finding was re-attacked
independently. Two were serious:

- **A config with no `limits:` block killed the whole Settings tab.** That
  block is optional and every install set up before 0.1.24 has none, so
  `resolvePath` returned null, `readAt` tried to iterate it, and the tab
  rendered "the board server did not answer" while the server answered every
  request. Every write on such a repo was an HTTP 500 in the terminal the docs
  designate as the audit trail.
- **The page could reload under a half-typed value.** A `meta http-equiv=refresh`
  is scheduled by the browser when it parses the tag, and REMOVING THE NODE
  DOES NOT CANCEL IT — the code sincerely believed otherwise, in a comment. The
  page now carries an inert marker only its own script reads, so the single
  reload path is a timer it can actually stop.

And:

- **An unreadable journal wrote an absolute path** — a home directory and a
  username — into `board.json`, which is committed and compared byte for byte,
  so it also failed `--check` on every other machine. Now the error code and a
  repo-relative path.
- **An initiative whose directory could not be read vanished** from the board
  with nothing said; the totals just went down by one. `existsSync` cannot tell
  "there is no journal here" from "I cannot tell whether there is one".
- **`--dir` pointed at the repo root silently succeeded**, creating a `state/`
  directory in the wrong place and reporting that all was well about a repo
  whose real journals sat one level down.
- **The settings write had no compare-and-swap.** Two boards on one directory,
  or a board and a terminal, could discard each other's change with both
  reporting success.
- Plus a wrong number in the CHANGELOG, an overclaim in `docs/configuration.md`
  (`pricing:` and `main_writable_paths:` have no knob), a lane emptied by the
  filter showing no placeholder, a stale "Four tabs" comment, one of ten lanes
  unaccounted for in the stalled-card prose, and two unverifiable claims about
  the sandbox.

### yaml-lite: the writer and the reader disagreed about numbers

`formatScalar` required a digit before the decimal point and `parseScalar` did
not, so the **string** `.5` was written unquoted and read back as the **number**
0.5. Both now use the reader's two patterns. This was found by `yaml-patch`'s
round-trip proof — the guard whose comment claimed no input was known to reach
it. That claim is now corrected rather than repeated.

A leading **BOM** is also handled: `trimStart` counts it as whitespace, so it
read as one column of indentation and the parser rejected the whole file with a
complaint about a line the operator could see nothing wrong with.

Three more in the patcher, each of which wrote or refused the wrong thing: a
key was located with `indexOf(':')` rather than the parser's own rule (so `a`
landed on the `a:b` line), a path ending in an integer dropped the list item's
dash, and replacing a list that is the FIRST key of a sequence item deleted the
item's sibling keys.

### The backtick guard

The whole browser client is one template literal, so a backtick anywhere inside
it — including in a comment — ends the literal and the page stops loading. It
happened four times in one sitting. The parse test caught it every time and
could never say so: it reports whatever identifier followed the stray backtick.
A new guard reads the source as text, imports nothing, and names the line.

### Verification

- `node --test "tests/**/*.test.mjs"` -> **1394 pass, 0 fail**
- desc-budget 4352/5000 · scan-control-chars clean (202 files) · plugin validate OK · site build + check-base-prefix OK
- Driven in a browser: two questions answered from the page (one in words, one taking the recorded default), both landing as decision-then-gate in the journal.
- Note on the review: 7 of 19 verifier agents died on a weekly usage limit, so 12 findings are independently confirmed and the rest were reproduced by hand before fixing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
