### PR TITLE
board: run state, blast radius, evidence, and tier escalation (+ 0.1.27)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
     {
       "name": "tyran",
       "description": "A task conductor for Claude Code: multi-agent orchestration with an enforced evidence contract, repo-specific learning, and update-safe local evolution.",
-      "version": "0.1.26",
+      "version": "0.1.27",
       "source": "./",
       "author": {
         "name": "Jacek Janczura",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "tyran",
-  "version": "0.1.26",
+  "version": "0.1.27",
   "description": "A task conductor for Claude Code: multi-agent orchestration with an enforced evidence contract, repo-specific learning, and update-safe local evolution.",
   "author": {
     "name": "Jacek Janczura",

--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,8 @@ locks/
 
 # Playwright MCP scratch output (snapshots, screenshots, console logs)
 .playwright-mcp/
+
+# Marketing video production — Hyperframes projects, generated VO/art, renders.
+# Untracked on purpose: .gitattributes declares no video/audio extension as
+# binary, so a tracked .mp4/.wav/.srt would fail scan-control-chars (ADR-19).
+video/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,99 @@
 # Changelog
 
+## 0.1.27 — 2026-08-15
+
+The last four items of the munder-difflin plan, and the half of the model
+fallback that was still missing. `NOTES-REQUESTS.md` §7 is now closed.
+
+### The board says whether the run is supposed to be running
+
+Three agent chips reading "6 HOURS since last signal — likely dead" covered
+four unrelated situations, and 0.1.25 could only tell you about one of them:
+an operator `STOP`. That one is committed repo state and travels in the
+artefact. The rest is machine-local and gitignored — the pause marker, the
+resume watcher's pid, the usage sidecar — so `--serve` answers it at
+**`/run.json`**, on exactly the argument spend already makes.
+
+The page turns it into one banner above the tiles when any of three things is
+true: a usage-limit pause is live, a pause was due to resume and has not, or
+the resume watcher is not running. A damaged or missing file reads as absent —
+this answers a question *about* the run and must never be the reason nobody can
+see the board.
+
+### The queue knows what each question is holding up
+
+Nine open questions sorted by age alone put the one gating six tickets wherever
+it happened to fall. `deps` is resolved FORWARD everywhere else — a ticket is
+`ready` when its dependencies are merged — and the reverse direction was never
+computed at all.
+
+Each ask now carries `blocks: {count, ids}`, walked transitively and skipping
+merged tickets. The board sorts by it and **so does the answer sheet**, because
+those are two renderings of one queue. Two deliberate limits:
+no-recorded-default still sorts first (the only questions where saying nothing
+has no safe outcome), and an initiative that declares no dependencies reports
+`null` rather than `0` on every ask — an absence rendered as a measurement is
+worse than saying nothing.
+
+### Signal is not evidence
+
+The agent strip aged on `progress`, which an agent emits at will. An agent
+looping without achieving anything therefore had the freshest chip on the
+board — and, because the strip is stalest-first, sorted to the bottom.
+
+Agents now carry both times: **`last_signal`** is what it said,
+**`last_evidence`** is what it showed (a `report` with its `evidence[]`, a
+`finding` with its proof, a `review` verdict). The strip sorts on evidence, and
+an agent that has shown nothing ages from its **spawn** rather than from the
+last thing it said — otherwise the chatty agent still outranks one that
+produced something twenty minutes ago, which is the exact inversion this split
+exists to correct.
+
+No doctor finding for it, deliberately. The threshold separating "quiet because
+the work is hard" from "quiet because nothing is happening" is not one this
+project can pick for every repo, and a warning that fires on healthy agents is
+one people learn to scroll past.
+
+### A ticket that failed twice is re-tried a tier higher
+
+The escalation rule lived in the conductor's memory, which iron rule 7 already
+names the least reliable store in the system: after a compaction, the ticket is
+re-spawned at the tier that failed both times.
+
+```bash
+node scripts/tiers.mjs --role implementer \
+  --journal .tyran/state/<init>/journal.jsonl --ticket T-3 --field json
+# tiers: ESCALATED work -> deep after 2 failed attempt(s) on T-3 (ceiling deep).
+```
+
+Capped twice over — two steps, and a ceiling of `deep`. A ticket that has
+failed five times does not need the most expensive model in the table; it needs
+a human, and the `changes-requested` lane already shows that. The same read
+picks up any model an `error` event recorded as `model-unavailable` and feeds
+it to the fallback, so **the exclusion is durable in the ledger** rather than
+in a session that will be compacted. Escalation happens first and the fallback
+second: a re-try asks for a stronger model, then discovers whether it is
+available.
+
+The weakness, stated rather than left to be found: "did this attempt fail" is
+`APPROVING_RE`, written for lane assignment — "approved with nits" escalates
+nothing and "looks fine" escalates. And a journal that cannot be read routes as
+a first attempt, loudly, because routing must never depend on a readable
+journal.
+
+**Detection is still not automatic.** The limit surfaces inside a subagent's
+API call where no hook can see it, so something still has to notice and write
+the `error` event down. That seam is recorded in `NOTES-REQUESTS.md` rather
+than papered over.
+
+### Left alone on purpose
+
+`budget:` in the config schema is dead weight — validated, read by nothing —
+and it stays. Removing a key from the `known` list makes every config that
+carries it invalid, and an invalid config makes the policy gate refuse every
+write in that repo. The cost lands on whoever set the key; the benefit is a
+shorter array.
+
 ## 0.1.26 — 2026-08-15
 
 ### Answer a question from the board

--- a/NOTES-REQUESTS.md
+++ b/NOTES-REQUESTS.md
@@ -163,14 +163,18 @@ this study and both confirmed by reproduction:
   the whole Overnight section of the new Settings tab was dead text on every
   fresh install (0.1.24).
 
-Shipped since (0.1.25): the STOP half of item 1, item 4 (ticketless errors on
-the board) and item 5 (card ages). The machine-local half of item 1 —
-`paused-until.json`, `resume.json`, `usage.json` behind a `/run.json` route —
-is still open, and is what tells a stalled fleet apart from a scheduled pause.
+**All six are now shipped** — 0.1.25 (STOP, ticketless errors, card ages),
+0.1.26 (the tier fallback) and 0.1.27 (`/run.json`, blast radius,
+signal-vs-evidence, escalation on a failed attempt). What remains of item 1 is
+not routing but DETECTION: the limit surfaces inside a subagent's API call
+where no hook can see it, so the conductor still has to notice a dead agent and
+write `error {class: 'model-unavailable', model}` before `tiers.mjs` can act on
+it. That convention is the seam; closing it needs a platform signal Tyran does
+not have.
 
-Ranked, still to build:
+The original list, for the record:
 
-1. **`/run.json`: the machine-local half of "is the run supposed to be running"** Three chips reading
+1. ~~**`/run.json`: the machine-local half of "is the run supposed to be running"**~~ SHIPPED 0.1.27. Three chips reading
    "6 HOURS since last signal" cover four unrelated situations — an operator
    `STOP`, an overnight pause waiting on a reset, a dead resume watcher, and
    genuinely dead agents — and the board distinguishes none of them. Split by
@@ -179,14 +183,14 @@ Ranked, still to build:
    `usage.json` are machine-local and gitignored, so they must be SERVED, on
    the same argument `cost.json` already makes. `scheduleDecision`, `watcherAlive` and
    `humanWait` are already exported from `scripts/overnight.mjs`. **M.**
-2. **Blast radius on the waiting-on-you queue.** Asks sort by age alone, so
+2. ~~**Blast radius on the waiting-on-you queue.**~~ SHIPPED 0.1.27. Asks sort by age alone, so
    the question holding up six tickets sits below the one holding up nothing.
    `deps[]` is resolved forward in `boardOf` and never reversed. Build the
    reverse index, walk it transitively, sort by it in both `crossBoard()` and
    `answer.mjs renderSheet` — one queue, two renderings. Guard: `deps` is
    optional, and "blocks 0" everywhere is an absence rendered as a
    measurement. **M.**
-3. **Signal is not evidence.** Agent freshness comes from `progressByAgent`,
+3. ~~**Signal is not evidence.**~~ SHIPPED 0.1.27. Agent freshness comes from `progressByAgent`,
    which is the agent's own self-report: an agent emitting `working` every few
    minutes while achieving nothing is the healthiest-looking chip on the
    board. Keep a second map fed only by events another party produced
@@ -200,7 +204,7 @@ Ranked, still to build:
    with two meanings is the ADR-21 defect by name. **S.**
 5. ~~**Cards say how long they have stood still.**~~ SHIPPED 0.1.25. `boardOf()` already puts
    `since` on every card and the page never renders it. Client-side only. **S.**
-6. **Escalate the tier on a failed attempt.** A ticket that comes back
+6. ~~**Escalate the tier on a failed attempt.**~~ SHIPPED 0.1.27. A ticket that comes back
    `changes-requested` is re-spawned at the same tier and fails the same way,
    because the escalation rule lives in the conductor's memory — which iron
    rule 7 already names the least reliable store in the system. `tiers.mjs`
@@ -224,3 +228,14 @@ the measured install is at 31.
 One piece of dead weight the study found on the way: `budget:` in
 `scripts/schema.mjs`'s `known` list is validated, documented by its own
 validation, and read by nothing. It should be deleted.
+
+## 8. `budget:` in the config schema — left in place deliberately
+
+The munder-difflin study flagged `budget:` in `scripts/schema.mjs`'s `known`
+list as dead weight: validated, documented only by its own validation, read by
+nothing. That is accurate, and it is still there on purpose.
+
+Removing a key from `known` turns any config that carries it INVALID, and an
+invalid config makes the policy gate refuse every write in that repo. So the
+cost of the tidy-up lands on whoever set the key, and the benefit is a shorter
+array. It stays accepted and inert until there is a reason to migrate.

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -186,6 +186,42 @@ returning the bottom of the ladder. That case is not a routing problem — there
 is nothing left to substitute — and the thing that already knows how to wait
 for capacity is [overnight mode](overnight.md).
 
+### Re-trying a ticket that already failed
+
+The escalation rule used to live in the conductor's memory, which iron rule 7
+already names the least reliable store in the system: after a compaction, or
+under a second conductor, a ticket that has come back `changes-requested` twice
+is re-spawned at the tier that failed both times, burns the same money and
+fails the same way.
+
+```bash
+node scripts/tiers.mjs --role implementer \
+  --journal .tyran/state/<init>/journal.jsonl --ticket T-3 --field json
+# tiers: ESCALATED work -> deep after 2 failed attempt(s) on T-3 (ceiling deep).
+```
+
+The journal is what remembers. `--journal --ticket` counts the reviews on that
+ticket whose verdict was not an approval, and climbs one tier per failed
+attempt — capped twice over, at two steps and at a ceiling of `deep`. A ticket
+that has failed five times does not need the most expensive model in the table;
+it needs a human, and the `changes-requested` lane is where that is already
+visible. A role that already resolves above the ceiling is not dragged down to
+it.
+
+The same read picks up any model an `error` event has recorded as out of
+capacity — `{class: 'model-unavailable', model: '<alias>'}` — and feeds it to
+the fallback above. That convention is a convention on purpose: the failure
+surfaces inside a subagent's API call, where no hook can see it, so something
+has to write it down before routing can act on it. **Detection is still the
+operator's or the conductor's job; this is what makes the decision durable
+once it is made.**
+
+State the weakness rather than let someone find it: "did this attempt fail" is
+`APPROVING_RE`, which was written for lane assignment. "Approved with nits"
+reads as an approval and escalates nothing; "looks fine" does not and
+escalates. A journal that cannot be read routes as a first attempt, loudly —
+routing must never depend on a readable journal.
+
 ## The brake
 
 An operator can halt a running initiative without killing the session:

--- a/docs/board.md
+++ b/docs/board.md
@@ -379,6 +379,16 @@ the artefact rather than behind a route. Note what it does and does not mean:
 nothing new starts while it exists, and agents already running are not killed
 by it.
 
+**And whether a watcher is still breathing.** `STOP` is committed, so it
+travels in the artefact. The rest of "is this supposed to be running" is
+machine-local and gitignored — the pause marker, the resume watcher's pid, the
+usage sidecar — so `--serve` answers it at `/run.json` instead, on exactly the
+argument [Spend](#spend) makes. The page turns it into one banner above the
+tiles when any of three things is true: a usage-limit pause is live, a pause is
+overdue to resume and has not, or the resume watcher is not running. A damaged
+or missing file reads as absent: this answers a question about the run, and it
+must never be the reason nobody can see the board.
+
 **Cards say how long they have stood still.** The board would tell you an agent
 had been silent for three hours and refuse to tell you a ticket had been blocked
 for four days — the timestamp was in `board.json` all along and nothing rendered
@@ -395,10 +405,49 @@ Both are worded as observations rather than verdicts. The board reports the
 last event on a ticket; only you know whether that is a stall or a long test
 run.
 
+## What a question is holding up
+
+Nine open questions sorted by age put the one gating six tickets wherever it
+happened to fall. `deps` is resolved FORWARD everywhere else — a ticket is
+`ready` when its dependencies are merged — and the reverse direction was never
+computed at all.
+
+Each ask now carries `blocks: {count, ids}`: the tickets that cannot proceed
+until it is answered, walked transitively, skipping tickets already merged
+(nothing holds those up). The queue sorts by it, and so does the answer sheet,
+because those are two renderings of ONE queue and an operator should not meet a
+different order depending on which surface they opened.
+
+Two deliberate limits. No-recorded-default still sorts **first**, above any
+amount of downstream work: those are the only questions where saying nothing
+has no safe outcome. And an initiative that declares no dependencies at all
+reports `blocks: null` rather than `0` on every ask — an absence rendered as a
+measurement is worse than saying nothing.
+
+## Signal is not evidence
+
+The agent strip aged on `progress` events, which an agent emits at will. An
+agent looping without achieving anything therefore had the freshest chip on the
+board, and — because the strip is sorted stalest-first — sorted to the bottom.
+
+Every agent now carries two times. **`last_signal`** is what it SAID, from its
+own `progress` events. **`last_evidence`** is what it SHOWED: a `report` with
+its `evidence[]`, a `finding` with its proof, a `review` verdict. The strip
+sorts on evidence, and an agent that has shown nothing ages from its SPAWN
+rather than from the last thing it said — otherwise the chatty agent outranks
+one that produced something twenty minutes ago, which is the exact inversion
+this split exists to correct.
+
+There is deliberately no doctor finding for it. The threshold that separates
+"quiet because the work is hard" from "quiet because nothing is happening" is
+not one this project can pick for every repo, and a warning that fires on
+healthy agents is a warning people learn to scroll past.
+
 ## board.json, schema 1
 
 Fixed key order (`schema`, `as_of`, `totals`, `stop`, `paused`, `asks`,
-`agents`, `files`, `lanes`, `errors_logged`, `errors_logged_total`, `errors`,
+`agents` (each with `last_signal`, `last_evidence` and `since`), `files`,
+`lanes`, `errors_logged`, `errors_logged_total`, `errors`,
 `warned`); timestamps copied verbatim from events; invisibles escaped as
 `\uXXXX`, never removed; byte-identical reruns. Consumers check `schema === 1`
 — the HTML shows "regenerate with a newer Tyran" on a mismatch instead of

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jjanczur/tyran",
-  "version": "0.1.26",
+  "version": "0.1.27",
   "description": "Command-line scripts for the Tyran task conductor (doctor, journal, schema, and repo tooling) for CI and terminals outside Claude Code. Installing this package does NOT install the Claude Code plugin — add that separately with `/plugin marketplace add jjanczur/tyran` inside Claude Code.",
   "type": "module",
   "engines": {

--- a/scripts/answer.mjs
+++ b/scripts/answer.mjs
@@ -146,8 +146,16 @@ export function openAsks(tyranDir) {
  */
 export function sortAsks(asks) {
   return [...asks].sort(
+    // No-default FIRST, and that stays primary: those are the only questions
+    // where saying nothing has no safe outcome, which is a stronger claim on
+    // the operator than any amount of downstream work.
     (a, b) =>
       Number(a.default != null) - Number(b.default != null) ||
+      // Then blast radius. Nine questions sorted by age alone put the one
+      // gating six tickets wherever it happened to fall; `blocks` is null on a
+      // journal that declares no dependencies, and null sorts as zero so those
+      // queues keep their old order exactly.
+      (b.blocks?.count ?? 0) - (a.blocks?.count ?? 0) ||
       String(a.since ?? '').localeCompare(String(b.since ?? '')) ||
       naturalCompare(a.init, b.init) ||
       naturalCompare(a.kind, b.kind),

--- a/scripts/board-html.mjs
+++ b/scripts/board-html.mjs
@@ -440,6 +440,15 @@ if (data.schema !== 1) {
         : ageMs >= 10800000 ? Math.round(ageMs / 3600000) + ' HOURS since last signal — likely dead'
         : Math.round(ageMs / 60000) + ' min since last signal';
       chip.appendChild(el('div', ageClass(ageMs), ageText));
+      // Signal is what the agent SAID; evidence is what it SHOWED. An agent
+      // emitting progress every few minutes while achieving nothing is the
+      // healthiest-looking chip on the board, and the strip is sorted by the
+      // first of those two, so it also sorts to the bottom.
+      var evMs = ageMsOf(a.last_evidence);
+      chip.appendChild(el('div', evMs === null ? 'age-cold' : ageClass(evMs),
+        evMs === null
+          ? 'nothing shown yet'
+          : (a.evidence_kind || 'evidence') + ' ' + ago(a.last_evidence)));
       strip.appendChild(chip);
     });
     return strip;
@@ -797,6 +806,7 @@ if (data.schema !== 1) {
       hasDefault ? 'decision \\u00b7 a default is recorded' : 'blocking \\u00b7 no safe default'));
     card.appendChild(el('div', 'q', a.question || '(no question recorded — gate ' + a.kind + ')'));
     [['answer with', a.kind], ['recommendation', a.recommendation], ['default', a.default],
+     ['blocks', a.blocks && a.blocks.count > 0 ? a.blocks.count + ' ticket(s): ' + a.blocks.ids.join(', ') : null],
      ['ticket', a.ticket], ['initiative', a.init], ['since', a.since]].forEach(function (pair) {
       if (pair[1] === null || pair[1] === undefined) return;
       var row = el('div', 'row');
@@ -1256,6 +1266,36 @@ if (data.schema !== 1) {
       if (key === 'settings') holdRefresh(); else armRefresh();
     });
   });
+
+  // Machine-local run state, fetched beside spend. A 404 means this page is
+  // not being served by a board server — a copy on a docs site, a file behind
+  // some other host — and that is an answer, not a failure.
+  fetch('run.json', { headers: { accept: 'application/json' } })
+    .then(function (r) { return r.ok ? r.json() : null; })
+    .then(function (run) {
+      if (run === null || run.schema !== 1) return;
+      var lines = [];
+      if (run.paused) {
+        lines.push(run.paused.overdue
+          ? 'A usage-limit pause was due to resume ' + ago(run.paused.resume_at) + ' and has not.'
+          : 'Paused on the ' + (run.paused.window || 'usage') + ' window at ' +
+            (run.paused.used_percentage === null ? 'the threshold' : run.paused.used_percentage + '%') +
+            '. Resumes ' + (run.paused.wait || 'later') + '.');
+      }
+      if (run.watcher && run.watcher.alive === false) {
+        lines.push('The resume watcher is not running, so nothing will restart this by itself.');
+      }
+      if (run.usage && run.usage.stale === true) {
+        lines.push('Usage telemetry is stale — the statusline helper may not be installed.');
+      }
+      if (lines.length === 0) return;
+      var box = el('div', 'paused');
+      box.appendChild(el('b', null, 'This run is not simply working. '));
+      lines.forEach(function (line) { box.appendChild(el('div', 'hint', line)); });
+      box.appendChild(el('div', 'hint', 'npx @jjanczur/tyran overnight status --dir .tyran'));
+      ov.insertBefore(box, ov.firstChild);
+    })
+    .catch(function () { /* no server, or none of this applies */ });
 
   fetch('settings.json', { headers: { accept: 'application/json' } })
     .then(function (r) { return r.ok ? r.json() : Promise.reject(new Error(String(r.status))); })

--- a/scripts/board.mjs
+++ b/scripts/board.mjs
@@ -46,7 +46,8 @@ import { renderBoardError, renderBoardHtml } from './board-html.mjs';
 import { COST_SCHEMA, costJson, costReport } from './cost.mjs';
 import { SettingsError, applyPolicyClass, applySetting, readSettings } from './settings.mjs';
 import { checkStopAt } from './stop-check.mjs';
-import { answerOne, answerProblem, classify, openAsks, partitionAsks, reRender } from './answer.mjs';
+import { runState } from './overnight.mjs';
+import { answerOne, answerProblem, classify, openAsks, partitionAsks, reRender, sortAsks } from './answer.mjs';
 
 export const BOARD_HTML_FILE = 'board.html';
 
@@ -232,14 +233,25 @@ export function crossBoard({ initiatives, errors, warned = [], stop = null }) {
       for (const card of board.lanes.get(lane)) lanes[lane].push({ ...card, init: name });
     }
   }
-  asks.sort((a, b) => String(a.since ?? '').localeCompare(String(b.since ?? '')));
+  // The SAME rule the answer sheet uses, imported rather than restated: the
+  // sheet and the page are two renderings of one queue, and two orderings
+  // would make an operator answer them in different sequences depending on
+  // which surface they happened to open (ADR-21).
+  const ordered = sortAsks(asks);
+  asks.length = 0;
+  asks.push(...ordered);
   // Stalest FIRST. Rendering agents in the order the journals happened to spawn
   // them puts the one that has said nothing for six hours anywhere at all,
   // including last — and the whole reason the strip carries a last-signal time
   // is that the silent agent is the one worth looking at. `last_signal` is an
   // ISO string from the journal, so ascending string order IS ascending time;
   // an agent with no signal at all sorts to the front, where it belongs.
-  agents.sort((a, b) => String(a.last_signal ?? '').localeCompare(String(b.last_signal ?? '')));
+  // Sorted on EVIDENCE where there is any, falling back to the signal. An
+  // agent that has shown nothing for three hours belongs at the top even if it
+  // has been saying "working" every four minutes the whole time — which is
+  // exactly the case the old signal-only sort put last.
+  agents.sort((a, b) =>
+    String(a.last_evidence ?? a.since ?? '').localeCompare(String(b.last_evidence ?? b.since ?? '')));
   // Newest first: an error from four days ago is history, the one from ten
   // minutes ago is the reason you opened this page.
   logged.sort((a, b) => String(b.ts ?? '').localeCompare(String(a.ts ?? '')));
@@ -325,6 +337,9 @@ export function renderCrossMd(payload) {
     parts.push(`- **${inline(a.question ?? `(no question recorded — gate ${a.kind})`)}**\n`);
     if (a.recommendation != null) parts.push(`  - recommendation: ${inline(a.recommendation)}\n`);
     if (a.default != null) parts.push(`  - default: ${inline(a.default)}\n`);
+    if (a.blocks != null && a.blocks.count > 0) {
+      parts.push(`  - blocks ${a.blocks.count} ticket(s): ${a.blocks.ids.map((id) => inline(id)).join(', ')}\n`);
+    }
     parts.push(`  - ${inline(a.init)}${a.ticket != null ? ` · \`${inline(a.ticket)}\`` : ''} · since ${inline(a.since)}\n`);
   }
 
@@ -633,6 +648,20 @@ function main() {
         // `board.json` would break the byte-exact `--check` contract. Over
         // `file://` the fetch fails and the tab says how to open the board
         // with a server, which is the honest answer.
+        // The MACHINE-LOCAL half of "is this run supposed to be running".
+        // `.tyran/STOP` is committed and travels in the artefact; the pause
+        // marker, the resume watcher and the usage sidecar are gitignored and
+        // different on every machine, so they are served — the same split, and
+        // the same argument, spend already makes.
+        if (req.url === '/run.json') {
+          try {
+            sendJson(res, 200, { schema: 1, ...runState(resolve(dir, '..')) });
+          } catch (err) {
+            // A run-state failure must never take the board down with it.
+            sendJson(res, 503, { schema: 1, error: String(err?.message ?? err) });
+          }
+          return;
+        }
         if (req.url === '/settings.json') {
           sendJson(res, 200, { ...readSettings(dir), writable: flags.write });
           return;

--- a/scripts/overnight.mjs
+++ b/scripts/overnight.mjs
@@ -186,6 +186,60 @@ export function scheduleDecision(marker, { forceResume = false } = {}) {
 
 // --------------------------------------------------------------- plumbing
 
+/**
+ * The machine-local run state, for a reader that only wants to LOOK at it.
+ *
+ * Composed here rather than in the board, because these three files and the
+ * rules for reading them are this module's business: the marker says whether a
+ * pause is live, the resume state says whether a watcher is still breathing,
+ * and the sidecar says how full the window was when it was last written. All
+ * three are gitignored and different on every machine, which is why the board
+ * SERVES this rather than embedding it — the same argument spend makes.
+ *
+ * Everything is read defensively: a missing, oversized or unparseable file is
+ * simply absent. This answers a question about the run; it must never be the
+ * reason nobody can see the board.
+ */
+export function runState(repo, nowMs = Date.now()) {
+  const marker = readSmallJson(join(repo, MARKER_RELPATH));
+  const resume = readSmallJson(join(repo, RESUME_STATE_RELPATH));
+  const sidecar = readSmallJson(join(repo, SIDECAR_RELPATH));
+  const resumeAtMs = marker?.resume_at ? Date.parse(marker.resume_at) : NaN;
+  return {
+    paused: marker === null ? null : {
+      since: typeof marker.paused_at === 'string' ? marker.paused_at : null,
+      window: typeof marker.window === 'string' ? marker.window : null,
+      used_percentage: typeof marker.used_percentage === 'number' ? marker.used_percentage : null,
+      resume_at: typeof marker.resume_at === 'string' ? marker.resume_at : null,
+      // A marker whose resume time has passed while a watcher was supposed to
+      // act on it is the shape of a dead watcher, and it reads as an ordinary
+      // pause unless something says otherwise.
+      overdue: Number.isFinite(resumeAtMs) && resumeAtMs < nowMs,
+      wait: Number.isFinite(resumeAtMs) ? humanWait(resumeAtMs - nowMs) : null,
+    },
+    watcher: resume === null ? null : {
+      state: typeof resume.state === 'string' ? resume.state : null,
+      alive: watcherAlive(resume, nowMs),
+      resume_at: typeof resume.resume_at === 'string' ? resume.resume_at : null,
+    },
+    usage: sidecar === null ? null : {
+      written_at: typeof sidecar.written_at === 'string' ? sidecar.written_at : null,
+      stale: !(typeof sidecar.written_at === 'string' && nowMs - Date.parse(sidecar.written_at) < SIDECAR_FRESH_MS),
+      five_hour: pickWindow(sidecar.five_hour),
+      seven_day: pickWindow(sidecar.seven_day),
+    },
+  };
+}
+
+/** Numbers and an ISO string only — never a free payload string from a hook. */
+function pickWindow(w) {
+  if (w === null || typeof w !== 'object') return null;
+  return {
+    used_percentage: typeof w.used_percentage === 'number' ? w.used_percentage : null,
+    resets_at: typeof w.resets_at === 'string' ? w.resets_at : null,
+  };
+}
+
 function readSmallJson(path) {
   try {
     if (!existsSync(path) || statSync(path).size > 64 * 1024) return null;

--- a/scripts/project.mjs
+++ b/scripts/project.mjs
@@ -205,6 +205,21 @@ function clearBlockageBy(state, agent) {
 }
 
 /** A `review`/`merge` settles the ticket for EVERY agent blocked on it. */
+/**
+ * Record that an agent SHOWED something, as opposed to said something.
+ *
+ * Newest wins, and only ever moves forward: events arrive in journal order, but
+ * a hand-edited file need not be monotonic, and an older evidence event must
+ * not make an agent look staler than the board already knows it is.
+ */
+function noteEvidence(state, agent, kind, ts) {
+  if (agent == null) return;
+  const key = String(agent);
+  const prev = state.evidenceByAgent.get(key);
+  if (prev !== undefined && String(prev.ts ?? '') > String(ts ?? '')) return;
+  state.evidenceByAgent.set(key, { kind, ts });
+}
+
 function clearBlockagesOn(state, ticketId) {
   for (const [key, blockage] of state.blockages) {
     // A ticketless blockage is keyed to its agent and belongs to no ticket —
@@ -264,6 +279,13 @@ export function fold({ events = [], truncatedTail = false, badLines = [] } = {})
     ambiguousAgents: [],
     // agent name -> latest self-reported signal (last one wins)
     progressByAgent: new Map(),
+    // What an agent has SHOWN, as opposed to what it has said. A `progress`
+    // event is a heartbeat an agent emits at will; the events here each carry
+    // a work product — a report with its evidence[], a finding with its proof,
+    // a review or a merge on the agent's ticket. An agent looping without
+    // achieving anything can keep `progressByAgent` perfectly fresh, and used
+    // to sort to the BOTTOM of a strip ordered by staleness.
+    evidenceByAgent: new Map(),
     // agent name -> that agent's open blockage, the ticket inside the value.
     //
     // Keyed by AGENT and not by ticket, because one agent has at most one live
@@ -412,6 +434,7 @@ export function fold({ events = [], truncatedTail = false, badLines = [] } = {})
         break;
       }
       case 'report': {
+        noteEvidence(state, data.agent ?? actor, 'report', ts);
         // A report that pairSpawns matched to a spawn has already been applied
         // to that spawn's row above — this branch only has to render what
         // pairing left over, so the two never compute the same thing twice.
@@ -458,6 +481,7 @@ export function fold({ events = [], truncatedTail = false, badLines = [] } = {})
         break;
       }
       case 'finding':
+        noteEvidence(state, actor, 'finding', ts);
         state.findings.push({
           id: data.id ?? null,
           area: data.area ?? null,
@@ -520,6 +544,7 @@ export function fold({ events = [], truncatedTail = false, badLines = [] } = {})
         // and the same correlator closes what that spawn left behind. Without
         // it a reviewer's ticketless blockage outlived its own review with no
         // later event that could ever clear it.
+        noteEvidence(state, data.by ?? actor, 'review', ts);
         if (data.by != null) closeAgent(state, data.by);
         break;
       }
@@ -631,7 +656,16 @@ export const LANES = Object.freeze([
   'done',
 ]);
 
-const APPROVING_RE = /^approv|^lgtm$|^pass/i;
+/**
+ * A review verdict that counts as an approval.
+ *
+ * Exported because `tiers.mjs` counts FAILED attempts on a ticket to decide
+ * whether to escalate, and "did this attempt fail" must not have two answers
+ * (ADR-21). Note the asymmetry this creates, stated because someone will meet
+ * it: the pattern was written for lane assignment, so "approved with nits"
+ * reads as an approval and "looks fine" does not.
+ */
+export const APPROVING_RE = /^approv|^lgtm$|^pass/i;
 
 /**
  * The kanban view of a folded state. PURE and clock-free: every timestamp is
@@ -658,10 +692,45 @@ export function boardOf(state) {
     (g) => PAUSED_RE.test(g.kind) && !GATE_PASS.has(String(g.result ?? '').toLowerCase()),
   ) ?? null;
 
+  // What each open question is HOLDING UP.
+  //
+  // `deps` is resolved forward everywhere else — a ticket is ready when its
+  // dependencies are merged — and the reverse direction was never computed, so
+  // a queue of nine questions sorted by age alone put the one gating six
+  // tickets wherever it happened to fall. The walk is transitive and skips
+  // merged tickets, which are not held up by anything.
+  //
+  // Only when the initiative declares deps at all: on a journal that records
+  // none, every ask would report "blocks 0", and an absence rendered as a
+  // measurement is worse than saying nothing.
+  const declaresDeps = state.ticketList.some((x) => Array.isArray(x.deps) && x.deps.length > 0);
+  const dependents = new Map();
+  if (declaresDeps) {
+    for (const x of state.ticketList) {
+      for (const d of Array.isArray(x.deps) ? x.deps.map(String) : []) {
+        dependents.set(d, [...(dependents.get(d) ?? []), x.id]);
+      }
+    }
+  }
+  const blockedBy = (ticket) => {
+    if (!declaresDeps || ticket == null) return null;
+    const seen = new Set();
+    const queue = [String(ticket)];
+    while (queue.length > 0) {
+      for (const next of dependents.get(queue.shift()) ?? []) {
+        if (seen.has(next) || mergedIds.has(next)) continue;
+        seen.add(next);
+        queue.push(next);
+      }
+    }
+    return { count: seen.size, ids: [...seen].sort(naturalCompare) };
+  };
+
   const asks = [];
   for (const g of state.openGates) {
     if (WAITING_RE.test(String(g.result ?? ''))) {
       asks.push({
+        blocks: blockedBy(g.ticket),
         kind: g.kind,
         ticket: g.ticket ?? null,
         question: g.question ?? null,
@@ -731,6 +800,7 @@ export function boardOf(state) {
     .filter((a) => a.status === 'running')
     .map((a) => {
       const signal = state.progressByAgent.get(a.agent) ?? null;
+      const evidence = state.evidenceByAgent.get(a.agent) ?? null;
       return {
         agent: a.agent,
         role: a.role,
@@ -739,6 +809,17 @@ export function boardOf(state) {
         detail: signal?.detail ?? null,
         next: signal?.next ?? null,
         last_signal: signal?.ts ?? a.spawnTs,
+        // What it has SHOWN. Null until it shows something, which is the
+        // ordinary state of an agent that has just started — the strip says
+        // "nothing yet" rather than implying silence.
+        last_evidence: evidence?.ts ?? null,
+        evidence_kind: evidence?.kind ?? null,
+        // When it started. An agent that has shown nothing is stale from its
+        // SPAWN, not from the last thing it said — without this an agent
+        // chattering every four minutes and producing nothing outranks one
+        // that produced something twenty minutes ago, which is the exact
+        // inversion the evidence split exists to correct.
+        since: a.spawnTs,
       };
     });
 

--- a/scripts/tiers.mjs
+++ b/scripts/tiers.mjs
@@ -36,6 +36,8 @@ import { fileURLToPath } from 'node:url';
 import { parse } from './yaml-lite.mjs';
 import { validateConfig, PROFILES, TIER_KEYS } from './schema.mjs';
 import { escapeInvisible } from './invisible.mjs';
+import { APPROVING_RE } from './project.mjs';
+import { readJournal } from './journal.mjs';
 
 /** Capability tiers, cheapest first. Index order is the escalation ladder. */
 export const TIER_ORDER = TIER_KEYS;
@@ -116,6 +118,52 @@ export const ROLE_FLOOR = Object.freeze({
 });
 
 export const ROLES = Object.freeze(Object.keys(ROLE_TIERS));
+
+/**
+ * The tier a fallback or an escalation may never pass.
+ *
+ * `top` is the most expensive thing Tyran can spend, and an automatic climb to
+ * it is a decision about money made while nobody is watching. Roles whose
+ * FLOOR is already `top` still resolve there — this bounds what escalation
+ * ADDS, not what the table asks for.
+ */
+export const ESCALATION_CEILING = 'deep';
+
+/** How many steps repeated failure may add, however many attempts there were. */
+export const MAX_ESCALATION_STEPS = 2;
+
+/**
+ * What the journal says about a ticket that is being re-tried.
+ *
+ * Both facts live in the ledger rather than in the conductor's memory, which
+ * iron rule 7 already names the least reliable store in the system: a session
+ * that compacts, or a second conductor picking the work up, otherwise re-spawns
+ * at the tier that has already failed twice and on the model that has already
+ * run out.
+ *
+ *  - `attempts` counts reviews that did NOT approve. The regex is the board's
+ *    own, imported, because "did this attempt fail" must not have two answers.
+ *  - `unavailable` collects models an `error` event named as out of capacity.
+ *    The convention is `{class: 'model-unavailable', model: '<alias>'}` and it
+ *    is a convention on purpose: the failure surfaces inside a subagent's API
+ *    call, where no hook can see it, so SOMETHING has to write it down before
+ *    routing can act on it.
+ */
+export function ticketHistory(events, ticket) {
+  const id = String(ticket);
+  let attempts = 0;
+  const unavailable = [];
+  for (const e of events) {
+    if (e?.ev === 'review' && String(e.data?.ticket) === id && !APPROVING_RE.test(String(e.data?.verdict ?? ''))) {
+      attempts += 1;
+    }
+    if (e?.ev === 'error' && e.data?.class === 'model-unavailable' && typeof e.data?.model === 'string') {
+      // NOT scoped to the ticket: a model that ran out is out for everything.
+      if (!unavailable.includes(e.data.model)) unavailable.push(e.data.model);
+    }
+  }
+  return { attempts, unavailable };
+}
 
 function validateInputs(role, profile, risk) {
   if (!Object.hasOwn(ROLE_TIERS, role)) {
@@ -220,21 +268,48 @@ export function resolveModel(config, role, profile, risk = 'normal', override = 
     (ROLE_EFFORT_FLOOR[role] !== undefined && override.effort !== undefined && override.effort !== effort);
 
   const unavailable = normalizeUnavailable(override.unavailable);
-  const resolved = { tier, model: aliasFor(tier), effort, floored, fell_from: null };
+  // Escalation first, fallback second, and the order matters: a re-try should
+  // ask for a stronger model, and only then discover whether that model is
+  // available. Doing it the other way round would fall back from a tier the
+  // run was never going to use.
+  const attempts = Number.isInteger(override.attempts) && override.attempts > 0 ? override.attempts : 0;
+  const climbed = attempts === 0 ? tier : escalateTier(tier, attempts);
+  const resolved = {
+    tier: climbed,
+    model: aliasFor(climbed),
+    effort,
+    floored,
+    fell_from: null,
+    escalated_from: climbed === tier ? null : tier,
+    attempts,
+  };
   if (unavailable.length === 0 || !unavailable.includes(resolved.model)) return resolved;
 
-  const substitute = fallbackTier(config, role, tier, unavailable);
+  const substitute = fallbackTier(config, role, resolved.tier, unavailable);
   return {
+    ...resolved,
     tier: substitute,
     model: aliasFor(substitute),
     // Effort follows the ORIGINAL tier, not the substitute. The judgement
     // "this task needs deep reasoning" did not change because a model ran out
     // of capacity, and dropping both dials at once turns a substitution into a
     // second, unasked-for downgrade.
-    effort,
-    floored,
-    fell_from: tier,
+    fell_from: resolved.tier,
   };
+}
+
+/**
+ * One step up per failed attempt, capped twice over: by MAX_ESCALATION_STEPS,
+ * and by the ceiling. A ticket that has failed four times does not need the
+ * most expensive model in the table — it needs a human, and the board's
+ * changes-requested lane is where that is already visible.
+ */
+function escalateTier(from, attempts) {
+  const ceiling = Math.min(TIER_ORDER.indexOf(ESCALATION_CEILING), TIER_ORDER.length - 1);
+  const start = TIER_ORDER.indexOf(from);
+  // Never lower a role that already resolves above the ceiling.
+  if (start >= ceiling) return from;
+  return TIER_ORDER[Math.min(start + Math.min(attempts, MAX_ESCALATION_STEPS), ceiling)];
 }
 
 function normalizeUnavailable(value) {
@@ -338,7 +413,28 @@ function main() {
   const field = flag('field', 'model');
   // Repeatable: an overnight run can exhaust more than one tier.
   const unavailable = args.reduce((acc, arg, i) => (arg === '--unavailable' && args[i + 1] ? [...acc, args[i + 1]] : acc), []);
-  const override = { tier: flag('tier', undefined), effort: flag('effort', undefined), unavailable };
+  // The ledger, not the conductor's memory. `--journal <path> --ticket T-n`
+  // counts the failed attempts on that ticket and picks up any model an error
+  // event has recorded as out of capacity, so a re-spawn after a compaction
+  // routes the same way a re-spawn before it would have.
+  const journalPath = flag('journal', null);
+  const ticket = flag('ticket', null);
+  let history = { attempts: 0, unavailable: [] };
+  if (journalPath !== null && ticket !== null) {
+    try {
+      history = ticketHistory(readJournal(resolve(journalPath)).events, ticket);
+    } catch (error) {
+      // Routing must not depend on a readable journal: a missing or damaged
+      // one means no history, which is the same answer as a first attempt.
+      console.error(`tiers: could not read ${escapeInvisible(journalPath)} (${error.message}) — routing without history`);
+    }
+  }
+  const override = {
+    tier: flag('tier', undefined),
+    effort: flag('effort', undefined),
+    unavailable: [...unavailable, ...history.unavailable],
+    attempts: history.attempts,
+  };
 
   try {
     if (role === null) {
@@ -365,6 +461,17 @@ function main() {
     }
     // A substitution that said nothing would be the routing table quietly
     // meaning something else than it says.
+    if (resolved.escalated_from) {
+      // The tier the CLIMB reached, which is what a fallback then fell FROM.
+      // Reporting `resolved.tier` here narrated "work -> work" whenever both
+      // happened, which is the one case where a reader most needs the two
+      // steps told apart.
+      const climbedTo = resolved.fell_from ?? resolved.tier;
+      console.error(
+        `tiers: ESCALATED ${resolved.escalated_from} -> ${climbedTo} after ${resolved.attempts} failed attempt(s) ` +
+          `on ${escapeInvisible(String(ticket))} (ceiling ${ESCALATION_CEILING}).`,
+      );
+    }
     if (resolved.fell_from !== null) {
       console.error(
         `tiers: FELL BACK ${resolved.fell_from} -> ${resolved.tier} because the ${resolved.fell_from} model is ` +

--- a/site/src/content/docs/agents.mdx
+++ b/site/src/content/docs/agents.mdx
@@ -196,6 +196,42 @@ returning the bottom of the ladder. That case is not a routing problem — there
 is nothing left to substitute — and the thing that already knows how to wait
 for capacity is [overnight mode](../overnight/).
 
+### Re-trying a ticket that already failed
+
+The escalation rule used to live in the conductor's memory, which iron rule 7
+already names the least reliable store in the system: after a compaction, or
+under a second conductor, a ticket that has come back `changes-requested` twice
+is re-spawned at the tier that failed both times, burns the same money and
+fails the same way.
+
+```bash
+node scripts/tiers.mjs --role implementer \
+  --journal .tyran/state/<init>/journal.jsonl --ticket T-3 --field json
+# tiers: ESCALATED work -> deep after 2 failed attempt(s) on T-3 (ceiling deep).
+```
+
+The journal is what remembers. `--journal --ticket` counts the reviews on that
+ticket whose verdict was not an approval, and climbs one tier per failed
+attempt — capped twice over, at two steps and at a ceiling of `deep`. A ticket
+that has failed five times does not need the most expensive model in the table;
+it needs a human, and the `changes-requested` lane is where that is already
+visible. A role that already resolves above the ceiling is not dragged down to
+it.
+
+The same read picks up any model an `error` event has recorded as out of
+capacity — `{class: 'model-unavailable', model: '<alias>'}` — and feeds it to
+the fallback above. That convention is a convention on purpose: the failure
+surfaces inside a subagent's API call, where no hook can see it, so something
+has to write it down before routing can act on it. **Detection is still the
+operator's or the conductor's job; this is what makes the decision durable
+once it is made.**
+
+State the weakness rather than let someone find it: "did this attempt fail" is
+`APPROVING_RE`, which was written for lane assignment. "Approved with nits"
+reads as an approval and escalates nothing; "looks fine" does not and
+escalates. A journal that cannot be read routes as a first attempt, loudly —
+routing must never depend on a readable journal.
+
 ## The brake
 
 An operator can halt a running initiative without killing the session:

--- a/site/src/content/docs/board.mdx
+++ b/site/src/content/docs/board.mdx
@@ -382,6 +382,16 @@ the artefact rather than behind a route. Note what it does and does not mean:
 nothing new starts while it exists, and agents already running are not killed
 by it.
 
+**And whether a watcher is still breathing.** `STOP` is committed, so it
+travels in the artefact. The rest of "is this supposed to be running" is
+machine-local and gitignored — the pause marker, the resume watcher's pid, the
+usage sidecar — so `--serve` answers it at `/run.json` instead, on exactly the
+argument [Spend](#spend) makes. The page turns it into one banner above the
+tiles when any of three things is true: a usage-limit pause is live, a pause is
+overdue to resume and has not, or the resume watcher is not running. A damaged
+or missing file reads as absent: this answers a question about the run, and it
+must never be the reason nobody can see the board.
+
 **Cards say how long they have stood still.** The board would tell you an agent
 had been silent for three hours and refuse to tell you a ticket had been blocked
 for four days — the timestamp was in `board.json` all along and nothing rendered
@@ -398,10 +408,49 @@ Both are worded as observations rather than verdicts. The board reports the
 last event on a ticket; only you know whether that is a stall or a long test
 run.
 
+## What a question is holding up
+
+Nine open questions sorted by age put the one gating six tickets wherever it
+happened to fall. `deps` is resolved FORWARD everywhere else — a ticket is
+`ready` when its dependencies are merged — and the reverse direction was never
+computed at all.
+
+Each ask now carries `blocks: {count, ids}`: the tickets that cannot proceed
+until it is answered, walked transitively, skipping tickets already merged
+(nothing holds those up). The queue sorts by it, and so does the answer sheet,
+because those are two renderings of ONE queue and an operator should not meet a
+different order depending on which surface they opened.
+
+Two deliberate limits. No-recorded-default still sorts **first**, above any
+amount of downstream work: those are the only questions where saying nothing
+has no safe outcome. And an initiative that declares no dependencies at all
+reports `blocks: null` rather than `0` on every ask — an absence rendered as a
+measurement is worse than saying nothing.
+
+## Signal is not evidence
+
+The agent strip aged on `progress` events, which an agent emits at will. An
+agent looping without achieving anything therefore had the freshest chip on the
+board, and — because the strip is sorted stalest-first — sorted to the bottom.
+
+Every agent now carries two times. **`last_signal`** is what it SAID, from its
+own `progress` events. **`last_evidence`** is what it SHOWED: a `report` with
+its `evidence[]`, a `finding` with its proof, a `review` verdict. The strip
+sorts on evidence, and an agent that has shown nothing ages from its SPAWN
+rather than from the last thing it said — otherwise the chatty agent outranks
+one that produced something twenty minutes ago, which is the exact inversion
+this split exists to correct.
+
+There is deliberately no doctor finding for it. The threshold that separates
+"quiet because the work is hard" from "quiet because nothing is happening" is
+not one this project can pick for every repo, and a warning that fires on
+healthy agents is a warning people learn to scroll past.
+
 ## board.json, schema 1
 
 Fixed key order (`schema`, `as_of`, `totals`, `stop`, `paused`, `asks`,
-`agents`, `files`, `lanes`, `errors_logged`, `errors_logged_total`, `errors`,
+`agents` (each with `last_signal`, `last_evidence` and `since`), `files`,
+`lanes`, `errors_logged`, `errors_logged_total`, `errors`,
 `warned`); timestamps copied verbatim from events; invisibles escaped as
 `\uXXXX`, never removed; byte-identical reruns. Consumers check `schema === 1`
 — the HTML shows "regenerate with a newer Tyran" on a mismatch instead of

--- a/tests/fixtures/golden/board.json
+++ b/tests/fixtures/golden/board.json
@@ -10,6 +10,10 @@
   "paused": null,
   "asks": [
     {
+      "blocks": {
+        "count": 0,
+        "ids": []
+      },
       "kind": "Q-1",
       "ticket": "T-10",
       "question": "flat fee or per-seat on the team plan?",
@@ -18,6 +22,7 @@
       "since": "2026-07-26T09:41:55.000Z"
     },
     {
+      "blocks": null,
       "kind": "Q-2",
       "ticket": null,
       "question": "en dash or em dash in headings?",
@@ -34,7 +39,10 @@
       "state": "blocked",
       "detail": "waiting on the worktree lease",
       "next": null,
-      "last_signal": "2026-07-26T09:41:40.000Z"
+      "last_signal": "2026-07-26T09:41:40.000Z",
+      "last_evidence": "2026-07-26T09:41:45.000Z",
+      "evidence_kind": "finding",
+      "since": "2026-07-26T09:36:01.000Z"
     }
   ],
   "lanes": {

--- a/tests/unit/board-write.test.mjs
+++ b/tests/unit/board-write.test.mjs
@@ -526,3 +526,68 @@ test('board.mjs refuses a --dir that is not a .tyran directory', () => {
     }
   })();
 });
+
+test('run.json serves the machine-local half of "is this supposed to be running"', () => {
+  // Three chips reading "6 HOURS since last signal" cover four unrelated
+  // situations. STOP is committed and travels in the artefact; the pause
+  // marker, the resume watcher and the usage sidecar are gitignored and
+  // different on every machine, so they are SERVED — the same split spend
+  // already makes. MUTANT: put any of this in board.json and --check fails on
+  // the next machine.
+  return (async () => {
+    const f = fixture();
+    const s = await serve(f.tyran, ['--write']);
+    try {
+      const quiet = await (await fetch(`${s.base}/run.json`)).json();
+      assert.deepEqual(quiet, { schema: 1, paused: null, watcher: null, usage: null });
+
+      writeFileSync(join(f.tyran, 'state', 'paused-until.json'), JSON.stringify({
+        paused_at: '2026-08-15T09:00:00.000Z',
+        window: 'five_hour',
+        used_percentage: 97.4,
+        resume_at: '2999-01-01T00:00:00.000Z',
+      }));
+      const paused = await (await fetch(`${s.base}/run.json`)).json();
+      assert.equal(paused.paused.window, 'five_hour');
+      assert.equal(paused.paused.used_percentage, 97.4);
+      assert.equal(paused.paused.overdue, false, 'a future resume time is not overdue');
+
+      // A marker whose resume time has passed is the shape of a dead watcher.
+      writeFileSync(join(f.tyran, 'state', 'paused-until.json'), JSON.stringify({
+        paused_at: '2026-08-15T09:00:00.000Z', resume_at: '2000-01-01T00:00:00.000Z',
+      }));
+      assert.equal((await (await fetch(`${s.base}/run.json`)).json()).paused.overdue, true);
+
+      // None of it may reach the committed artefact. Render it first —
+      // board.json does not exist until something writes it.
+      await fetch(`${s.base}/board.json`);
+      const { execFileSync } = await import('node:child_process');
+      execFileSync(process.execPath, [SCRIPT, '--dir', f.tyran], { stdio: 'pipe' });
+      const board = readFileSync(join(f.tyran, 'state', 'board.json'), 'utf8');
+      assert.doesNotMatch(board, /paused_at|used_percentage|resume_at/);
+    } finally {
+      await s.stop();
+      f.cleanup();
+    }
+  })();
+});
+
+test('a damaged run-state file is absent, not fatal', () => {
+  // This answers a question ABOUT the run; it must never be the reason nobody
+  // can see the board. MUTANT: let JSON.parse throw out of runState.
+  return (async () => {
+    const f = fixture();
+    const s = await serve(f.tyran, ['--write']);
+    try {
+      writeFileSync(join(f.tyran, 'state', 'paused-until.json'), 'not json at all');
+      writeFileSync(join(f.tyran, 'state', 'resume.json'), '[]');
+      const run = await (await fetch(`${s.base}/run.json`)).json();
+      assert.equal(run.paused, null);
+      assert.equal(run.watcher, null);
+      assert.equal((await fetch(`${s.base}/`)).status, 200, 'and the board still renders');
+    } finally {
+      await s.stop();
+      f.cleanup();
+    }
+  })();
+});

--- a/tests/unit/board.test.mjs
+++ b/tests/unit/board.test.mjs
@@ -682,3 +682,73 @@ test('the sandbox ships spend built by the real rollup, not a hand-written blob'
   // model name anywhere but `tiers:`, and a sandbox is not an exemption.
   assert.doesNotMatch(src, /\b(haiku|sonnet|opus|fable)\b/i);
 });
+
+test('an ask says what it is holding up, and the queue sorts by it', () => {
+  // `deps` is resolved FORWARD everywhere (a ticket is ready when its
+  // dependencies are merged) and the reverse direction was never computed, so
+  // nine questions sorted by age alone put the one gating six tickets wherever
+  // it happened to fall. MUTANT: delete the blocks term from sortAsks.
+  const ev = (ts, e, data, actor = 'c') => JSON.stringify({ ts, ev: e, init: 'x', actor, data });
+  const journal = [
+    ev('2026-01-01T00:00:00Z', 'init.created', { title: 't' }),
+    ev('2026-01-01T00:01:00Z', 'ticket.created', { id: 'T-1', title: 'base', deps: [] }),
+    ev('2026-01-01T00:02:00Z', 'ticket.created', { id: 'T-2', title: 'b', deps: ['T-1'] }),
+    ev('2026-01-01T00:03:00Z', 'ticket.created', { id: 'T-3', title: 'c', deps: ['T-2'] }),
+    ev('2026-01-01T00:04:00Z', 'ticket.created', { id: 'T-4', title: 'd', deps: ['T-1'] }),
+    ev('2026-01-01T00:05:00Z', 'ticket.created', { id: 'T-5', title: 'e', deps: [] }),
+    ev('2026-01-01T00:06:00Z', 'merge', { ticket: 'T-4', sha: 'a' }),
+    // The SMALL question is older, so age alone would put it first.
+    ev('2026-01-01T00:07:00Z', 'gate', { kind: 'Q-1', result: 'WAITING_ON_OPERATOR', ticket: 'T-5', question: 'small', default: 'd' }),
+    ev('2026-01-01T00:08:00Z', 'gate', { kind: 'Q-2', result: 'WAITING_ON_OPERATOR', ticket: 'T-1', question: 'big', default: 'd' }),
+  ].join('\n') + '\n';
+  const { payload, files } = renderAll(tree({ x: journal }));
+
+  const big = payload.asks.find((a) => a.kind === 'Q-2');
+  // Transitive, and a MERGED dependent is not held up by anything.
+  assert.deepEqual(big.blocks, { count: 2, ids: ['T-2', 'T-3'] });
+  assert.deepEqual(payload.asks.find((a) => a.kind === 'Q-1').blocks, { count: 0, ids: [] });
+  assert.equal(payload.asks[0].kind, 'Q-2', 'the question holding work up comes first');
+  assert.match(files[BOARD_FILE], /blocks 2 ticket\(s\): T-2, T-3/);
+});
+
+test('an initiative that declares no dependencies reports nothing rather than zero', () => {
+  // "blocks 0" on every ask is an absence rendered as a measurement, which is
+  // worse than silence. MUTANT: always compute the reverse index.
+  const { payload } = renderAll(tree({ demo: demo() }));
+  const noDeps = payload.asks.find((a) => a.ticket === null);
+  assert.equal(noDeps.blocks, null, 'an ask with no ticket cannot block anything');
+});
+
+test('the strip sorts on what agents SHOWED, not on what they said', () => {
+  // An agent emitting progress every few minutes while achieving nothing is
+  // the healthiest-looking chip on the board and sorted to the BOTTOM of a
+  // strip ordered by staleness. MUTANT: sort on last_signal again.
+  const ev = (ts, e, data, actor = 'c') => JSON.stringify({ ts, ev: e, init: 'x', actor, data });
+  const journal = [
+    ev('2026-01-01T00:00:00Z', 'init.created', { title: 't' }),
+    ev('2026-01-01T00:01:00Z', 'ticket.created', { id: 'T-1', title: 'a', deps: [] }),
+    ev('2026-01-01T00:02:00Z', 'ticket.created', { id: 'T-2', title: 'b', deps: [] }),
+    ev('2026-01-01T00:03:00Z', 'spawn', { agent: 'chatty', role: 'implementer', ticket: 'T-1' }),
+    ev('2026-01-01T00:04:00Z', 'spawn', { agent: 'quiet', role: 'implementer', ticket: 'T-2' }),
+    // `quiet` showed something early and has said nothing since.
+    ev('2026-01-01T00:05:00Z', 'finding', { area: 'x', claim: 'c', proof: 'p', ticket: 'T-2' }, 'quiet'),
+    // `chatty` has shown nothing at all and keeps saying it is working.
+    ev('2026-01-01T00:30:00Z', 'progress', { agent: 'chatty', state: 'working', ticket: 'T-1' }, 'chatty'),
+  ].join('\n') + '\n';
+  const { payload } = renderAll(tree({ x: journal }));
+  const strip = payload.agents.map((a) => a.agent);
+  assert.deepEqual(strip, ['chatty', 'quiet'], 'the one that has shown nothing is at the top');
+
+  const chatty = payload.agents.find((a) => a.agent === 'chatty');
+  assert.equal(chatty.last_evidence, null, 'it has shown nothing');
+  assert.equal(chatty.last_signal, '2026-01-01T00:30:00Z', 'while saying plenty — timestamps are verbatim from the journal');
+  const quiet = payload.agents.find((a) => a.agent === 'quiet');
+  assert.equal(quiet.last_evidence, '2026-01-01T00:05:00Z');
+  assert.equal(quiet.evidence_kind, 'finding');
+});
+
+test('the page shows signal and evidence as two different facts', () => {
+  const html = demoHtml();
+  assert.match(html, /nothing shown yet/, 'an agent that has shown nothing says so');
+  assert.match(html, /a\.evidence_kind/, 'and what it showed is named');
+});

--- a/tests/unit/tiers.test.mjs
+++ b/tests/unit/tiers.test.mjs
@@ -29,6 +29,8 @@ import {
   resolveAll,
   loadConfig,
   readProfile,
+  ESCALATION_CEILING,
+  ticketHistory,
 } from '../../scripts/tiers.mjs';
 import { PROFILES } from '../../scripts/schema.mjs';
 
@@ -139,9 +141,9 @@ test('resolveAll covers every role and reports tier, model and effort', () => {
   // fallback came down FROM. Pinned in the shape rather than tested only
   // where it fires: a consumer that reads it must be able to rely on it
   // always being present.
-  assert.deepEqual(all.scout, { tier: 'cheap', model: 'haiku', effort: 'low', floored: false, fell_from: null });
-  assert.deepEqual(all['security-review'], { tier: 'top', model: 'fable', effort: 'max', floored: false, fell_from: null });
-  assert.deepEqual(all.implementer, { tier: 'work', model: 'sonnet', effort: 'medium', floored: false, fell_from: null });
+  assert.deepEqual(all.scout, { tier: 'cheap', model: 'haiku', effort: 'low', floored: false, fell_from: null, escalated_from: null, attempts: 0 });
+  assert.deepEqual(all['security-review'], { tier: 'top', model: 'fable', effort: 'max', floored: false, fell_from: null, escalated_from: null, attempts: 0 });
+  assert.deepEqual(all.implementer, { tier: 'work', model: 'sonnet', effort: 'medium', floored: false, fell_from: null, escalated_from: null, attempts: 0 });
 });
 
 // --- dynamic overrides: the conductor adjusting a single subtask -----------
@@ -214,6 +216,8 @@ test('CLI --field selects what lands on stdout', () => {
     effort: 'low',
     floored: false,
     fell_from: null,
+    escalated_from: null,
+    attempts: 0,
   });
 });
 
@@ -372,4 +376,75 @@ test('--unavailable is repeatable', () => {
     { cwd: dir, encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'] },
   );
   assert.equal(out.trim(), 'work');
+});
+
+// --- escalation: the journal remembers what the conductor forgets ----------
+
+test('a failed attempt escalates one step, and the journal is what remembers', () => {
+  // The escalation rule used to live in the conductor's memory, which iron
+  // rule 7 already names the least reliable store in the system: after a
+  // compaction, or under a second conductor, the ticket is re-spawned at the
+  // tier that has already failed twice. MUTANT: return the base tier from
+  // resolveModel regardless of `attempts`.
+  const doc = { tiers: { cheap: 'haiku', work: 'sonnet', deep: 'opus', top: 'fable' } };
+  const at = (attempts) => resolveModel(doc, 'implementer', 'balanced', 'normal', { attempts });
+  assert.equal(at(0).tier, 'work');
+  assert.equal(at(0).escalated_from, null);
+  assert.equal(at(1).tier, 'deep');
+  assert.equal(at(1).escalated_from, 'work');
+  assert.equal(at(1).attempts, 1);
+});
+
+test('escalation stops at the ceiling, however many attempts there were', () => {
+  // A ticket that has failed five times does not need the most expensive model
+  // in the table — it needs a human, and the changes-requested lane already
+  // shows that. MUTANT: drop the ceiling and five failures reach `top`.
+  const doc = { tiers: { cheap: 'haiku', work: 'sonnet', deep: 'opus', top: 'fable' } };
+  for (const attempts of [2, 3, 9]) {
+    assert.equal(resolveModel(doc, 'implementer', 'balanced', 'normal', { attempts }).tier, ESCALATION_CEILING);
+  }
+  // A role that already resolves above the ceiling is not dragged down to it.
+  assert.equal(resolveModel(doc, 'security-review', 'balanced', 'normal', { attempts: 3 }).tier, 'top');
+});
+
+test('escalation happens first, then the fallback — and both are reported', () => {
+  // A re-try asks for a stronger model and only THEN discovers whether it is
+  // available. The other order would fall back from a tier the run was never
+  // going to use. MUTANT: swap them.
+  const doc = { tiers: { cheap: 'haiku', work: 'sonnet', deep: 'opus', top: 'fable' } };
+  const r = resolveModel(doc, 'implementer', 'balanced', 'normal', { attempts: 2, unavailable: ['opus'] });
+  assert.equal(r.escalated_from, 'work', 'it climbed from work');
+  assert.equal(r.fell_from, 'deep', 'and fell from the tier it climbed to');
+  assert.equal(r.tier, 'work');
+});
+
+test('ticketHistory reads both facts out of the journal', () => {
+  // MUTANT: count every review instead of the non-approving ones — an
+  // approved ticket re-spawns on a more expensive model for no reason.
+  const events = [
+    { ev: 'review', data: { ticket: 'T-1', verdict: 'CHANGES-REQUESTED' } },
+    { ev: 'review', data: { ticket: 'T-1', verdict: 'APPROVE' } },
+    { ev: 'review', data: { ticket: 'T-2', verdict: 'CHANGES-REQUESTED' } },
+    { ev: 'error', data: { class: 'model-unavailable', model: 'fable' } },
+    { ev: 'error', data: { class: 'model-unavailable', model: 'fable' } },
+    { ev: 'error', data: { class: 'flaky-test', detail: 'unrelated' } },
+  ];
+  const h = ticketHistory(events, 'T-1');
+  assert.equal(h.attempts, 1, 'only the non-approving review on THIS ticket');
+  // A model that ran out is out for everything, not just for one ticket, and
+  // it is recorded once however many agents hit it.
+  assert.deepEqual(h.unavailable, ['fable']);
+  assert.equal(ticketHistory(events, 'T-9').attempts, 0);
+});
+
+test('a journal that cannot be read routes as a first attempt, loudly', () => {
+  // Routing must never DEPEND on a readable journal. MUTANT: let the read
+  // throw — every spawn in a repo with a damaged journal fails to resolve.
+  const dir = repoWithConfig();
+  const out = execFileSync(
+    process.execPath,
+    [SCRIPT, '--role', 'implementer', '--journal', join(dir, 'nope.jsonl'), '--ticket', 'T-1', '--field', 'json'],
+    { cwd: dir, encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'] },
+  );
+  assert.equal(JSON.parse(out.trim()).attempts, 0);
 });


### PR DESCRIPTION
The last four items of the munder-difflin plan, and the half of the model
fallback that was still missing. `NOTES-REQUESTS.md` §7 is now closed.

### The board says whether the run is supposed to be running

Three agent chips reading "6 HOURS since last signal — likely dead" covered
four unrelated situations, and 0.1.25 could only tell you about one of them:
an operator `STOP`. That one is committed repo state and travels in the
artefact. The rest is machine-local and gitignored — the pause marker, the
resume watcher's pid, the usage sidecar — so `--serve` answers it at
**`/run.json`**, on exactly the argument spend already makes.

The page turns it into one banner above the tiles when any of three things is
true: a usage-limit pause is live, a pause was due to resume and has not, or
the resume watcher is not running. A damaged or missing file reads as absent —
this answers a question *about* the run and must never be the reason nobody can
see the board.

### The queue knows what each question is holding up

Nine open questions sorted by age alone put the one gating six tickets wherever
it happened to fall. `deps` is resolved FORWARD everywhere else — a ticket is
`ready` when its dependencies are merged — and the reverse direction was never
computed at all.

Each ask now carries `blocks: {count, ids}`, walked transitively and skipping
merged tickets. The board sorts by it and **so does the answer sheet**, because
those are two renderings of one queue. Two deliberate limits:
no-recorded-default still sorts first (the only questions where saying nothing
has no safe outcome), and an initiative that declares no dependencies reports
`null` rather than `0` on every ask — an absence rendered as a measurement is
worse than saying nothing.

### Signal is not evidence

The agent strip aged on `progress`, which an agent emits at will. An agent
looping without achieving anything therefore had the freshest chip on the
board — and, because the strip is stalest-first, sorted to the bottom.

Agents now carry both times: **`last_signal`** is what it said,
**`last_evidence`** is what it showed (a `report` with its `evidence[]`, a
`finding` with its proof, a `review` verdict). The strip sorts on evidence, and
an agent that has shown nothing ages from its **spawn** rather than from the
last thing it said — otherwise the chatty agent still outranks one that
produced something twenty minutes ago, which is the exact inversion this split
exists to correct.

No doctor finding for it, deliberately. The threshold separating "quiet because
the work is hard" from "quiet because nothing is happening" is not one this
project can pick for every repo, and a warning that fires on healthy agents is
one people learn to scroll past.

### A ticket that failed twice is re-tried a tier higher

The escalation rule lived in the conductor's memory, which iron rule 7 already
names the least reliable store in the system: after a compaction, the ticket is
re-spawned at the tier that failed both times.

```bash
node scripts/tiers.mjs --role implementer \
  --journal .tyran/state/<init>/journal.jsonl --ticket T-3 --field json
# tiers: ESCALATED work -> deep after 2 failed attempt(s) on T-3 (ceiling deep).
```

Capped twice over — two steps, and a ceiling of `deep`. A ticket that has
failed five times does not need the most expensive model in the table; it needs
a human, and the `changes-requested` lane already shows that. The same read
picks up any model an `error` event recorded as `model-unavailable` and feeds
it to the fallback, so **the exclusion is durable in the ledger** rather than
in a session that will be compacted. Escalation happens first and the fallback
second: a re-try asks for a stronger model, then discovers whether it is
available.

The weakness, stated rather than left to be found: "did this attempt fail" is
`APPROVING_RE`, written for lane assignment — "approved with nits" escalates
nothing and "looks fine" escalates. And a journal that cannot be read routes as
a first attempt, loudly, because routing must never depend on a readable
journal.

**Detection is still not automatic.** The limit surfaces inside a subagent's
API call where no hook can see it, so something still has to notice and write
the `error` event down. That seam is recorded in `NOTES-REQUESTS.md` rather
than papered over.

### Left alone on purpose

`budget:` in the config schema is dead weight — validated, read by nothing —
and it stays. Removing a key from the `known` list makes every config that
carries it invalid, and an invalid config makes the policy gate refuse every
write in that repo. The cost lands on whoever set the key; the benefit is a
shorter array.

### Verification

- 1405 tests pass, 0 fail · desc-budget 4352/5000 · control-char scan clean · plugin validate OK · site build + check-base-prefix OK
- Exercised end to end: /run.json across quiet, paused, overdue and damaged-file states; the transitive blast-radius walk skipping a merged dependent; the strip re-ordering when an agent shows nothing; escalation, the ceiling, and escalation-then-fallback together.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
