### PR TITLE
fix(spend): explicit transcript dirs, and a hint when the conductor ran elsewhere

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,31 @@
 # Changelog
 
+## Unreleased
+
+### Spend, when the conductor ran from somewhere else
+
+Measured on a real run: a Claude Code Desktop session operated on a repo
+through absolute paths and worktrees, but was itself started in a sibling
+folder. `cost.mjs` derives a transcript directory from the repo path and falls
+back to scanning every project directory for a `cwd` match — both assume the
+conductor ran *from* the repo, and neither one held here. A different,
+unrelated `claude` run had once been started inside the repo (for the trust
+dialog), so the direct lookup found a directory and stopped there. The board's
+Spend tab rendered that unrelated session — 17 requests, one model, "0 agents
+attributed", conductor overhead 100% — as if it were the whole initiative,
+with nothing on the page saying that ~66 agent transcripts and 2 300 requests
+were sitting elsewhere.
+
+Two operator-named overrides, both resolved by `cost.mjs` itself so
+`board.mjs --serve` gets them for free: a repeatable `--transcripts <dir>` on
+the command line, and `spend.transcript_dirs` in `.tyran/config.yaml`. Either
+replaces the derived-slug / cwd-probe resolution outright; a given directory
+that does not exist is reported in the new `transcript_dirs_missing` field
+rather than dropped. The Spend tab now shows a hint — pointing at both
+overrides — whenever it finds zero agent transcripts while the board itself
+lists running agents, which is the shape this failure actually has: a tab that
+renders, with honest numbers about the wrong session.
+
 ## 0.1.29 — 2026-08-16
 
 Tyran has videos. Five cuts, and a page that says which one to send.

--- a/README.md
+++ b/README.md
@@ -297,7 +297,7 @@ enforces the cap (4352 of 5000 characters). What each one assumes, when it
 fires and who invokes it, is in
 [skills and agents](https://jjanczur.github.io/tyran/skills/); the prompts
 themselves are in [`skills/`](skills/) and [`agents/`](agents/). Behind all of
-it: 1405 unit tests, run with `node --test "tests/**/*.test.mjs"`.
+it: 1417 unit tests, run with `node --test "tests/**/*.test.mjs"`.
 
 ## Documentation
 

--- a/docs/board.md
+++ b/docs/board.md
@@ -233,12 +233,16 @@ node scripts/board.mjs --dir .tyran            # render all three artefacts
 node scripts/board.mjs --dir .tyran --check    # byte-exact drift check, exit 1
 node scripts/board.mjs --dir .tyran --serve    # localhost viewer, always fresh
 node scripts/board.mjs --dir .tyran --serve --write   # ... and Settings can edit
+node scripts/board.mjs --dir .tyran --serve --transcripts <dir>   # ... and Spend reads THAT dir
 ```
 
 `--serve` binds `127.0.0.1` only, re-renders per request, and never derives a
 filesystem path from a URL; `--write` adds the [Settings](#settings) routes and
 nothing else, and refuses on its own (`--write` without `--serve` is a usage
-error, not a silent no-op). The initiative ceiling is 64, refused loudly —
+error, not a silent no-op). `--transcripts <dir>` is the same refusal, for the
+same reason: it means something only to `/cost.json`, which only exists under
+`--serve`. Repeatable, and it overrides `spend.transcript_dirs` in
+`.tyran/config.yaml` — see [Spend](#spend). The initiative ceiling is 64, refused loudly —
 archive closed initiatives rather than boarding them. An unreadable journal
 renders as a visible **UNREADABLE** entry: a board that omits a broken
 initiative would read as "all is well" exactly when it is not.
@@ -272,6 +276,17 @@ one same-origin request to loopback, and the same defences cover it: the
 `--serve` (a foreign `Host` gets 403, verified), and a cost read that fails
 returns 503 rather than taking the board down — the board answers "what is
 going on", and that answer does not depend on knowing what it cost.
+
+**When the resolved directory is the wrong one.** Both of `cost.mjs`'s
+heuristics for finding a repo's transcripts assume the conductor session ran
+from the repo it operates on. A conductor started from another working
+directory — Desktop opened in a sibling folder, working the repo through
+absolute paths and worktrees — breaks that assumption, and the tab still
+renders: honest numbers, about the wrong session. The tell is zero agent
+transcripts while the board itself lists running agents, and the tab shows a
+hint for it, naming the two overrides: start this server with `--serve
+--transcripts <dir>`, or set `spend.transcript_dirs` in `.tyran/config.yaml`.
+Details and the measured failure are in [the spend ledger](cost.md#when-resolution-fails).
 
 ## Settings
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -66,6 +66,16 @@ pricing:                   # OPTIONAL. The spend ledger (docs/cost.md).
       cache_write: 18.75
       cache_read: 1.5
       output: 75
+
+spend:                     # OPTIONAL. Where cost.mjs looks for THIS repo's
+  transcript_dirs:         # transcripts, when the derived-slug / cwd-probe
+    - '~/.claude/projects/-Users-me-work-a-different-checkout'
+                           # fallback lands on the wrong session (docs/cost.md
+                           # #when-resolution-fails) — a conductor that ran
+                           # from a working directory other than the repo it
+                           # operates on. `--transcripts` on the command line
+                           # outranks this block; both replace the fallback
+                           # resolution entirely rather than adding to it.
 ```
 
 Setup also seeds `MISTAKES.md` at the repository root, create-only. There is no
@@ -126,6 +136,31 @@ every amount.
 `rate_card` is a label, not a lookup — nothing fetches anything. It exists so
 that every amount can say which card produced it, because two people quoting
 different cards get different money from one set of tokens.
+
+## Explicit transcript directories
+
+`spend:` is the other optional, operator-written block the spend ledger reads
+— no provenance wrapper, exactly like `pricing:` and `limits:`. `cost.mjs`
+normally locates a repo's transcripts itself: first by the directory name the
+platform derives from the repo path, then, if that is absent, by opening
+every project directory and matching on the `cwd` its records carry. Both
+assume the conductor session ran **from the repo it operates on**, and when it
+did not — Claude Code Desktop opened in a sibling folder, working the repo
+through absolute paths and worktrees — neither heuristic can find it: the
+transcript lives under a project directory named after the conductor's own
+working directory, not the repo's.
+
+| key | required | accepted |
+|---|---|---|
+| `transcript_dirs` | no | a list of non-empty directory paths, each the per-project directory holding `<session>.jsonl` and `<session>/subagents/` |
+
+A leading `~` expands to the home directory. Given a non-empty list, `cost.mjs`
+scans the union of those directories instead of running either heuristic; a
+directory that does not exist is reported in the report's
+`transcript_dirs_missing` rather than silently skipped. `--transcripts <dir>`
+on the command line is the same override and outranks this block when both are
+given. Full account of the failure this exists for, and what the board shows
+when it fires, is in [the spend ledger](cost.md#when-resolution-fails).
 
 ## Autonomy classes
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -154,9 +154,16 @@ working directory, not the repo's.
 |---|---|---|
 | `transcript_dirs` | no | a list of non-empty directory paths, each the per-project directory holding `<session>.jsonl` and `<session>/subagents/` |
 
-A leading `~` expands to the home directory. Given a non-empty list, `cost.mjs`
-scans the union of those directories instead of running either heuristic; a
-directory that does not exist is reported in the report's
+A leading `~` expands to the home directory. **A path without `~` or a leading
+`/` resolves against the process's current working directory** — the shell
+`cost.mjs` (or `board.mjs --serve`) happens to have been launched from, not
+`.tyran/`'s location and not the repo root. Write an absolute path or a `~`
+path; a bare relative entry works only by accident of where the command was
+run, which is the exact kind of assumption this block exists to replace.
+
+Given a non-empty list, `cost.mjs` scans the union of those directories
+instead of running either heuristic; a directory that does not exist is
+reported in the report's
 `transcript_dirs_missing` rather than silently skipped. `--transcripts <dir>`
 on the command line is the same override and outranks this block when both are
 given. Full account of the failure this exists for, and what the board shows

--- a/docs/cost.md
+++ b/docs/cost.md
@@ -98,7 +98,7 @@ Two refinements that stop the warnings becoming noise or becoming lies:
 ## CLI
 
 ```bash
-node scripts/cost.mjs [--dir <.tyran>] [--session <id>] [--projects <dir>] [--json]
+node scripts/cost.mjs [--dir <.tyran>] [--session <id>] [--projects <dir>] [--transcripts <dir>]... [--json]
 ```
 
 - `--dir` is the `.tyran` directory (default `.tyran`); the repository it
@@ -107,6 +107,10 @@ node scripts/cost.mjs [--dir <.tyran>] [--session <id>] [--projects <dir>] [--js
 - `--session <id>` narrows the report to one session and its agents.
 - `--projects <dir>` overrides where the transcripts are looked for; the
   default is `~/.claude/projects`.
+- `--transcripts <dir>` names a transcript directory explicitly — the per-project
+  directory holding `<session>.jsonl` and `<session>/subagents/`. Repeatable;
+  sources are the union over every directory given. See
+  [When resolution fails](#when-resolution-fails) below.
 - `--json` writes `.tyran/state/cost.json` atomically and prints its path
   instead of the table.
 - Exit `0` ok · `2` usage or I/O error, including *no transcripts found for
@@ -125,6 +129,36 @@ documentation, so it is verified rather than trusted: if the computed directory
 is absent, every project directory is opened and matched on the `cwd` its
 records carry.
 
+## When resolution fails
+
+Both heuristics above assume the conductor session ran **from the repo it is
+working on**. When it did not — a Claude Code Desktop session opened in a
+sibling folder, operating on the repo through absolute paths and worktrees —
+neither one finds it: the computed slug is derived from the conductor's own
+working directory, not the repo path, and every record in that transcript
+carries the conductor's cwd too, never the repo's.
+
+Measured: a `claude` run once started inside the repo (for the trust dialog)
+left a directory the direct lookup matched and stopped at, while ~66 agent
+transcripts and 2 300 requests sat under the conductor's real project
+directory with nothing on the report pointing at them — the ledger showed one
+session, one model, `unattributed` agents, and a conductor overhead reading
+100%, as if that were the whole initiative.
+
+Two overrides, highest priority first, both resolved by `cost.mjs` itself so
+`board.mjs --serve` gets them too with no extra plumbing:
+
+1. `--transcripts <dir>` on the command line, repeatable — sources are the
+   union over every directory given.
+2. `spend.transcript_dirs` in `.tyran/config.yaml` — see
+   [the configuration reference](configuration.md#explicit-transcript-directories).
+
+Either one replaces the derived-slug / cwd-probe resolution entirely rather
+than adding to it. A given directory that does not exist is reported in
+`transcript_dirs_missing` on the report, never silently dropped — the same
+"gaps are reported, never zeroed" rule that governs every other hole in this
+file.
+
 ## What the dashboard shows
 
 `board.html` renders a **Spend** section: total tokens and requests, the amount
@@ -133,6 +167,12 @@ a composition bar across input / cache write / cache read / output, and three
 ranked charts — by model, by agent type, by ticket — with a tokens/cost toggle.
 A row whose models have no rate draws no bar at all, because "not priced" and
 "cost nothing" must not look the same.
+
+Zero agent transcripts while the board itself lists running agents is a sign
+worth surfacing rather than a quiet empty table: the tab shows a hint pointing
+at [the two overrides above](#when-resolution-fails) whenever that shape
+appears, and lists any `--transcripts` / `spend.transcript_dirs` entry that
+was given but not found.
 
 The section is **fetched, not embedded**, which is a deliberate amendment to
 the board's "self-contained, no network" description — see
@@ -145,6 +185,11 @@ more than the report: a `sources[]` entry per transcript, keyed on path, mtime
 and size. Consumers check `schema === 1`; the dashboard renders nothing rather
 than garbage on a mismatch. Invisible characters are escaped as `\uXXXX` and
 never removed, exactly as in `board.json`.
+
+`transcript_dirs` names the directory (or directories) the report actually
+scanned, and `transcript_dirs_missing` names any `--transcripts` /
+`spend.transcript_dirs` entry that was given but does not exist on this
+machine — both present whichever resolution path produced the report.
 
 That cache is what makes a page refreshing every 30 seconds affordable.
 Transcripts reach tens of megabytes, so the reader streams them in chunks

--- a/docs/cost.md
+++ b/docs/cost.md
@@ -109,7 +109,10 @@ node scripts/cost.mjs [--dir <.tyran>] [--session <id>] [--projects <dir>] [--tr
   default is `~/.claude/projects`.
 - `--transcripts <dir>` names a transcript directory explicitly — the per-project
   directory holding `<session>.jsonl` and `<session>/subagents/`. Repeatable;
-  sources are the union over every directory given. See
+  sources are the union over every directory given. A leading `~` expands to
+  the home directory; anything else resolves against the process's current
+  working directory, so a relative path is only as reliable as the directory
+  the command happens to be run from — prefer absolute or `~`. See
   [When resolution fails](#when-resolution-fails) below.
 - `--json` writes `.tyran/state/cost.json` atomically and prints its path
   instead of the table.

--- a/scripts/board-html.mjs
+++ b/scripts/board-html.mjs
@@ -932,6 +932,26 @@ if (data.schema !== 1) {
         ' oversized record(s) were skipped; their tokens are missing from every figure here.');
     }
     into.appendChild(el('div', 'caveat', notes.join(' ')));
+
+    // Zero agent transcripts while the board itself lists agents is not "no
+    // agents ran" — it is the resolved directory being the WRONG one. A
+    // conductor session started from a working directory other than the repo
+    // it operates on files its transcript under a project directory no
+    // derivation from the repo path reaches, and this is the one place an
+    // operator would otherwise have no reason to suspect it: the tab renders,
+    // the totals are honest numbers, and they are honest numbers about the
+    // wrong session.
+    if ((cov.agent_transcripts || 0) === 0 && agents.length > 0) {
+      into.appendChild(el('div', 'hint',
+        'No agent transcripts found where this repo\\u2019s transcripts are expected. If the conductor ' +
+        'ran from another working directory, point the board at that session: board.mjs --serve ' +
+        '--transcripts <dir> or set spend.transcript_dirs in .tyran/config.yaml.'));
+    }
+    if ((cost.transcript_dirs_missing || []).length > 0) {
+      var missingNoun = cost.transcript_dirs_missing.length === 1 ? 'directory' : 'directories';
+      into.appendChild(el('div', 'hint',
+        'Given transcript ' + missingNoun + ' not found: ' + cost.transcript_dirs_missing.join(', ') + '.'));
+    }
   };
 
   // Spend is FETCHED, never embedded: it is derived from transcripts under

--- a/scripts/board-html.mjs
+++ b/scripts/board-html.mjs
@@ -858,6 +858,37 @@ if (data.schema !== 1) {
     return box;
   };
 
+  // A PURE function on purpose: no DOM, so a test can extract this one
+  // function's source out of the page and evaluate it standalone, without a
+  // browser, and check what it decides for a payload it never had to fetch.
+  //
+  // Two callers, one decision. renderSpend calls this once spend loaded
+  // normally; the cost-fetch handler below calls it BEFORE the early return
+  // on a payload with transcripts_found false — a directory named in
+  // transcript_dirs_missing is exactly as real a fact when nothing was
+  // found at all as when something was, and a single function neither call
+  // site can restate differently is what keeps that true.
+  var spendResolutionHints = function (payload) {
+    var hints = [];
+    var missing = (payload && payload.transcript_dirs_missing) || [];
+    if (missing.length > 0) {
+      var noun = missing.length === 1 ? 'directory' : 'directories';
+      hints.push('Given transcript ' + noun + ' not found: ' + missing.join(', ') + '.');
+    }
+    // Only on the branch that never reaches renderSpend at all: when spend
+    // WAS found, "no transcripts" would be false and misleading — the tab
+    // renders its own numbers and, if it turns out zero agents were among
+    // them, the separate agents-vs-coverage hint inside renderSpend covers it.
+    if (payload && payload.transcripts_found === false) {
+      hints.push(
+        'No transcripts found for this repo. If the conductor ran from another working directory, ' +
+        'point the board at that session: board.mjs --serve --transcripts <dir> or set ' +
+        'spend.transcript_dirs in .tyran/config.yaml.'
+      );
+    }
+    return hints;
+  };
+
   var renderSpend = function (into, metric) {
     clear(into);
     var t = cost.totals || {};
@@ -947,11 +978,12 @@ if (data.schema !== 1) {
         'ran from another working directory, point the board at that session: board.mjs --serve ' +
         '--transcripts <dir> or set spend.transcript_dirs in .tyran/config.yaml.'));
     }
-    if ((cost.transcript_dirs_missing || []).length > 0) {
-      var missingNoun = cost.transcript_dirs_missing.length === 1 ? 'directory' : 'directories';
-      into.appendChild(el('div', 'hint',
-        'Given transcript ' + missingNoun + ' not found: ' + cost.transcript_dirs_missing.join(', ') + '.'));
-    }
+    // cost.transcripts_found is true whenever this function runs at all, so
+    // spendResolutionHints only ever contributes the missing-dirs line here
+    // — the "no transcripts found" line is reachable exclusively through the
+    // fetch handler's own call below, on the branch that never reaches this
+    // function.
+    spendResolutionHints(cost).forEach(function (h) { into.appendChild(el('div', 'hint', h)); });
   };
 
   // Spend is FETCHED, never embedded: it is derived from transcripts under
@@ -993,7 +1025,21 @@ if (data.schema !== 1) {
             ((payload && payload.schema) || 'absent') + ') — regenerate the board with the Tyran that served it.');
           return;
         }
-        if (!payload.transcripts_found) return; // genuinely nothing to show
+        if (!payload.transcripts_found) {
+          // Genuinely nothing to roll up — but the explanation still has to
+          // reach the page. This used to be a silent early return that left
+          // spBody carrying the "open with --serve" hint written before the
+          // fetch even started, unconditionally wrong once the fetch answers:
+          // it made the everyday single-typo spend.transcript_dirs case
+          // (payload carries transcript_dirs_missing but no coverage at all,
+          // since renderSpend — the only other place that hint used to live
+          // — never runs on this branch) look exactly like a repo that had
+          // never been served at all. Reviewed and reproduced live via
+          // cost.json before this fix.
+          clear(spBody);
+          spendResolutionHints(payload).forEach(function (h) { spBody.appendChild(el('div', 'hint', h)); });
+          return;
+        }
         cost = payload;
         renderSpend(spBody, 'tokens');
         var t = cost.totals || {};

--- a/scripts/board.mjs
+++ b/scripts/board.mjs
@@ -20,7 +20,8 @@
  * initiative reads as "all is well" exactly when it is not.
  *
  * CLI:
- *   node board.mjs [--dir <.tyran>] [--check] [--serve [--port <n>] [--write]]
+ *   node board.mjs [--dir <.tyran>] [--check]
+ *                  [--serve [--port <n>] [--write] [--transcripts <dir>]...]
  * Exit: 0 ok · 1 drift (--check) · 2 usage/IO
  */
 import { existsSync, readdirSync, statSync, readFileSync } from 'node:fs';
@@ -561,9 +562,12 @@ function handleSettingsWrite(dir, route, body) {
 
 const BOOLEAN_FLAGS = ['check', 'serve', 'write'];
 const VALUE_FLAGS = ['dir', 'port'];
+// Repeatable, unlike VALUE_FLAGS: sources are the union over every directory
+// given, exactly like cost.mjs's own `--transcripts`.
+const REPEATABLE_FLAGS = ['transcripts'];
 
 function parseArgs(argv) {
-  const flags = { dir: '.tyran', port: 4173, check: false, serve: false, write: false };
+  const flags = { dir: '.tyran', port: 4173, check: false, serve: false, write: false, transcripts: [] };
   for (let i = 0; i < argv.length; i += 1) {
     const arg = argv[i];
     if (!arg.startsWith('--')) throw new UsageError(`unexpected argument "${arg}"`);
@@ -573,6 +577,11 @@ function parseArgs(argv) {
       const value = argv[i + 1];
       if (value === undefined) throw new UsageError(`flag --${name} needs a value`);
       flags[name] = name === 'port' ? Number(value) : value;
+      i += 1;
+    } else if (REPEATABLE_FLAGS.includes(name)) {
+      const value = argv[i + 1];
+      if (value === undefined) throw new UsageError(`flag --${name} needs a value`);
+      flags[name].push(value);
       i += 1;
     } else throw new UsageError(`unknown flag --${name}`);
   }
@@ -589,11 +598,21 @@ function main() {
   } catch (err) {
     if (!(err instanceof UsageError)) throw err;
     console.error(`board: ${err.message}`);
-    console.error('usage: board.mjs [--dir <.tyran>] [--check] [--serve [--port <n>] [--write]]');
+    console.error(
+      'usage: board.mjs [--dir <.tyran>] [--check] ' +
+        '[--serve [--port <n>] [--write] [--transcripts <dir>]...]'
+    );
     process.exit(2);
   }
   if (flags.write && !flags.serve) {
     console.error('board: --write only means anything with --serve (it is what the served page may edit)');
+    process.exit(2);
+  }
+  if (flags.transcripts.length > 0 && !flags.serve) {
+    console.error(
+      'board: --transcripts only means anything with --serve (it is what /cost.json reads instead of ' +
+        'the derived transcript directory)'
+    );
     process.exit(2);
   }
   const dir = resolve(flags.dir);
@@ -717,7 +736,11 @@ function main() {
         if (req.url === '/cost.json') {
           let body;
           try {
-            body = costJson(costReport({ tyranDir: dir }));
+            // `flags.transcripts` is [] unless the operator started this
+            // server with `--transcripts`; costReport falls through to
+            // `spend.transcript_dirs` and then the derived directory on its
+            // own, so an empty array here changes nothing for the common case.
+            body = costJson(costReport({ tyranDir: dir, transcriptDirs: flags.transcripts }));
           } catch (err) {
             // A cost failure must never take the board down with it: the
             // board answers "what is going on", and that answer does not

--- a/scripts/cost.mjs
+++ b/scripts/cost.mjs
@@ -35,6 +35,7 @@
  *
  * CLI:
  *   node cost.mjs [--dir <.tyran>] [--session <id>] [--json] [--projects <dir>]
+ *                 [--transcripts <dir>]...
  * Exit: 0 ok · 2 usage/IO
  */
 import { closeSync, existsSync, mkdirSync, openSync, readdirSync, readFileSync, readSync, realpathSync, renameSync, statSync, writeFileSync } from 'node:fs';
@@ -345,6 +346,61 @@ function findTranscriptDir(want, projectsRoot) {
   return null;
 }
 
+/**
+ * Where BOTH `transcriptDirFor` heuristics fail: a conductor session started
+ * from a working directory OTHER than the repo it operates on — Claude Code
+ * Desktop opened in a sibling folder, working the repo through absolute paths
+ * and worktrees. The computed slug does not match (it is derived from the
+ * conductor's own cwd, not the repo path), and the cwd probe does not match
+ * either (every record in that transcript carries the CONDUCTOR's cwd, never
+ * the repo's). Measured: a `claude` run once started inside the repo for the
+ * trust dialog left a directory the direct lookup matched and stopped at,
+ * while ~66 agent transcripts and 2 300 requests sat under the conductor's
+ * real project dir with nothing on the board pointing at them.
+ *
+ * A leading `~` expanded to the home directory — the same narrow rule
+ * `main_writable_paths` uses in `config.yaml`, so a transcript dir is written
+ * the way an operator already writes every other out-of-repo path in this
+ * file.
+ */
+function expandHome(p) {
+  if (p === '~') return homedir();
+  if (p.startsWith('~/')) return join(homedir(), p.slice(2));
+  return p;
+}
+
+/**
+ * The parsed `.tyran/config.yaml`, or null when it is absent or will not
+ * parse. Shared by every config-driven reader below (pricing, the transcript
+ * override) so there is one place that opens and parses the file, not two
+ * loaders that quietly drift apart.
+ */
+function loadConfigDoc(tyranDir) {
+  try {
+    return parse(readFileSync(join(tyranDir, 'config.yaml'), 'utf8'));
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * `spend.transcript_dirs` from config.yaml — the middle tier of the
+ * transcript-dir precedence (CLI `--transcripts` > this > the derived-slug /
+ * cwd-probe fallback above). Operator-written, never scanner-inferred,
+ * exactly like `pricing:` and `limits:`: a config that will not parse or
+ * carries nothing here simply falls through to the fallback, same as an
+ * absent block.
+ */
+function loadSpendTranscriptDirs(tyranDir) {
+  const doc = loadConfigDoc(tyranDir);
+  const spend = doc !== null && typeof doc === 'object' ? doc.spend : undefined;
+  const list =
+    spend !== null && typeof spend === 'object' && Array.isArray(spend.transcript_dirs)
+      ? spend.transcript_dirs
+      : [];
+  return list.filter((d) => typeof d === 'string' && d.trim() !== '');
+}
+
 /** Every transcript belonging to this repo: the sessions and their agents. */
 export function listSources(transcriptDir, sessionFilter) {
   const out = [];
@@ -644,6 +700,10 @@ export function renderReport(report) {
   if (report.unpriced.length > 0) {
     out.push(`Unpriced models (counted in tokens, absent from every amount): ${report.unpriced.join(', ')}`);
   }
+  if ((report.transcript_dirs_missing ?? []).length > 0) {
+    const noun = report.transcript_dirs_missing.length === 1 ? 'directory' : 'directories';
+    out.push(`Given transcript ${noun} not found: ${report.transcript_dirs_missing.join(', ')}`);
+  }
   return out.join('\n') + '\n';
 }
 
@@ -655,13 +715,11 @@ export function costJson(report) {
 /* ---------------------------------- CLI ---------------------------------- */
 
 function loadPricing(tyranDir) {
-  try {
-    return pricingOf(parse(readFileSync(join(tyranDir, 'config.yaml'), 'utf8')));
-  } catch {
-    // A config that will not parse is doctor's problem to report, not this
-    // reader's problem to refuse over: tokens are still worth counting.
-    return { rate_card: null, models: Object.create(null) };
-  }
+  // A config that will not parse is doctor's problem to report, not this
+  // reader's problem to refuse over: tokens are still worth counting.
+  // `pricingOf(null)` already reads as "no pricing block" (see schema.mjs),
+  // so an absent/unparseable file needs no separate branch here.
+  return pricingOf(loadConfigDoc(tyranDir) ?? {});
 }
 
 function readCache(path) {
@@ -683,20 +741,21 @@ function writeAtomic(path, text) {
   renameSync(tmp, path);
 }
 
-/** Build the report for a repo. Exported so the board server reuses it. */
-export function costReport({ tyranDir, projectsRoot, session = null, repoRoot = null } = {}) {
-  const root = repoRoot ?? resolve(tyranDir, '..');
-  const dir = transcriptDirFor(root, projectsRoot ?? join(homedir(), '.claude', 'projects'));
-  const pricing = loadPricing(tyranDir);
-  if (dir === null) {
-    const empty = rollup([], pricing, {});
-    empty.transcripts_found = false;
-    return empty;
-  }
+/**
+ * The scan-and-persist tail shared by every path through `costReport`: fold
+ * `sources` against the on-disk cache, roll it up, attach the fields callers
+ * read straight off the report, and write the sidecar. One function so the
+ * caching contract — persisted here, not only in the `--json` branch, so the
+ * served board benefits too — cannot drift between the derived-dir path and
+ * the explicit-dirs path below.
+ */
+function finishReport({ sources, pricing, tyranDir, session, transcriptDirsUsed, transcriptDirsMissing }) {
   const cachePath = join(tyranDir, 'state', COST_FILE);
-  const { scanned, unreadable, reused } = scanAll(listSources(dir, session), readCache(cachePath));
+  const { scanned, unreadable, reused } = scanAll(sources, readCache(cachePath));
   const report = rollup(scanned, pricing, { unreadable, reused });
   report.transcripts_found = true;
+  report.transcript_dirs = transcriptDirsUsed;
+  report.transcript_dirs_missing = transcriptDirsMissing;
   report.session = session;
   report.sources = scanned.map((s) => ({
     path: s.path,
@@ -738,12 +797,85 @@ export function costReport({ tyranDir, projectsRoot, session = null, repoRoot = 
   return report;
 }
 
+/**
+ * Build the report for a repo. Exported so the board server reuses it.
+ *
+ * `transcriptDirs` is the explicit override — the fix for a conductor that
+ * ran from a working directory other than the repo it operates on (see the
+ * comment above `expandHome`). Precedence, highest first: the `transcriptDirs`
+ * this caller passed in (the CLI's repeatable `--transcripts`) · `.tyran/
+ * config.yaml`'s `spend.transcript_dirs` · the derived-slug / cwd-probe
+ * fallback `transcriptDirFor` already does. Reading the config tier HERE
+ * rather than in every caller is what lets `board.mjs --serve` honour
+ * `spend:` with no `--transcripts` flag at all — one precedence order, read
+ * once, for both the CLI and the served page.
+ *
+ * A dir that does not exist is never silently dropped: it is reported in
+ * `transcript_dirs_missing` on the returned report, and if EVERY given dir is
+ * missing the report reads exactly like "no transcripts found" — gaps are
+ * reported, never zeroed (property 3 above).
+ */
+export function costReport({ tyranDir, projectsRoot, session = null, repoRoot = null, transcriptDirs = [] } = {}) {
+  const root = repoRoot ?? resolve(tyranDir, '..');
+  const pricing = loadPricing(tyranDir);
+
+  const given = transcriptDirs.length > 0 ? transcriptDirs : loadSpendTranscriptDirs(tyranDir);
+  // De-duplicated: two spellings of the same directory (a repeated flag, or a
+  // flag that repeats what the config already says) must not double-count
+  // every transcript under it.
+  const explicit = [...new Set(given.map((d) => resolve(expandHome(d))))];
+
+  if (explicit.length > 0) {
+    const present = explicit.filter((d) => existsSync(d));
+    const missing = explicit.filter((d) => !existsSync(d));
+    if (present.length === 0) {
+      const empty = rollup([], pricing, {});
+      empty.transcripts_found = false;
+      empty.transcript_dirs = [];
+      empty.transcript_dirs_missing = missing;
+      return empty;
+    }
+    const sources = present.flatMap((dir) => listSources(dir, session));
+    return finishReport({
+      sources,
+      pricing,
+      tyranDir,
+      session,
+      transcriptDirsUsed: present,
+      transcriptDirsMissing: missing,
+    });
+  }
+
+  const dir = transcriptDirFor(root, projectsRoot ?? join(homedir(), '.claude', 'projects'));
+  if (dir === null) {
+    const empty = rollup([], pricing, {});
+    empty.transcripts_found = false;
+    empty.transcript_dirs = [];
+    empty.transcript_dirs_missing = [];
+    return empty;
+  }
+  return finishReport({
+    sources: listSources(dir, session),
+    pricing,
+    tyranDir,
+    session,
+    transcriptDirsUsed: [dir],
+    transcriptDirsMissing: [],
+  });
+}
+
 function parseArgs(argv) {
-  const flags = { dir: '.tyran', session: null, projects: null, json: false };
+  const flags = { dir: '.tyran', session: null, projects: null, json: false, transcripts: [] };
   for (let i = 0; i < argv.length; i += 1) {
     const arg = argv[i];
     if (arg === '--json') flags.json = true;
-    else if (arg === '--dir' || arg === '--session' || arg === '--projects') {
+    else if (arg === '--transcripts') {
+      const value = argv[i + 1];
+      if (value === undefined || value.startsWith('--')) throw new UsageError(`${arg} needs a value`);
+      // Repeatable: sources are the union over every directory given.
+      flags.transcripts.push(value);
+      i += 1;
+    } else if (arg === '--dir' || arg === '--session' || arg === '--projects') {
       const value = argv[i + 1];
       if (value === undefined || value.startsWith('--')) throw new UsageError(`${arg} needs a value`);
       flags[arg.slice(2)] = value;
@@ -759,7 +891,10 @@ function main(argv) {
     flags = parseArgs(argv);
   } catch (err) {
     console.error(String(err.message ?? err));
-    console.error('usage: cost.mjs [--dir <.tyran>] [--session <id>] [--projects <dir>] [--json]');
+    console.error(
+      'usage: cost.mjs [--dir <.tyran>] [--session <id>] [--projects <dir>] ' +
+        '[--transcripts <dir>]... [--json]'
+    );
     return 2;
   }
   const tyranDir = resolve(flags.dir);
@@ -767,12 +902,27 @@ function main(argv) {
     console.error(`cost: no such directory: ${tyranDir}`);
     return 2;
   }
-  const report = costReport({ tyranDir, projectsRoot: flags.projects, session: flags.session });
+  const report = costReport({
+    tyranDir,
+    projectsRoot: flags.projects,
+    session: flags.session,
+    transcriptDirs: flags.transcripts,
+  });
   if (report.transcripts_found === false) {
-    console.error(
-      'cost: no transcripts found for this repo under the Claude Code projects directory.\n' +
-        'Spend is read from the transcripts the platform writes; nothing here estimates it.'
-    );
+    // Two different gaps, two different sentences: a `--transcripts` (or
+    // `spend.transcript_dirs`) dir that does not exist is an operator typo,
+    // not the same "nothing to find" as the derived directory being absent.
+    if ((report.transcript_dirs_missing ?? []).length > 0) {
+      console.error(
+        'cost: none of the given transcript directories exist:\n' +
+          report.transcript_dirs_missing.map((d) => `  - ${d}`).join('\n')
+      );
+    } else {
+      console.error(
+        'cost: no transcripts found for this repo under the Claude Code projects directory.\n' +
+          'Spend is read from the transcripts the platform writes; nothing here estimates it.'
+      );
+    }
     return 2;
   }
   if (flags.json) {

--- a/scripts/cost.mjs
+++ b/scripts/cost.mjs
@@ -384,15 +384,18 @@ function loadConfigDoc(tyranDir) {
 }
 
 /**
- * `spend.transcript_dirs` from config.yaml — the middle tier of the
- * transcript-dir precedence (CLI `--transcripts` > this > the derived-slug /
- * cwd-probe fallback above). Operator-written, never scanner-inferred,
- * exactly like `pricing:` and `limits:`: a config that will not parse or
- * carries nothing here simply falls through to the fallback, same as an
- * absent block.
+ * `spend.transcript_dirs` out of an ALREADY-PARSED config doc — the middle
+ * tier of the transcript-dir precedence (CLI `--transcripts` > this > the
+ * derived-slug / cwd-probe fallback above). Operator-written, never
+ * scanner-inferred, exactly like `pricing:` and `limits:`: a doc that carries
+ * nothing here simply falls through to the fallback, same as an absent block.
+ *
+ * Takes the parsed doc rather than `tyranDir` so `costReport` can read
+ * `config.yaml` once and hand the same doc to this and to `pricingOf` —
+ * two readers opening and parsing the same file on every call was the
+ * reviewed nit this signature exists to close.
  */
-function loadSpendTranscriptDirs(tyranDir) {
-  const doc = loadConfigDoc(tyranDir);
+function spendTranscriptDirsOf(doc) {
   const spend = doc !== null && typeof doc === 'object' ? doc.spend : undefined;
   const list =
     spend !== null && typeof spend === 'object' && Array.isArray(spend.transcript_dirs)
@@ -714,12 +717,16 @@ export function costJson(report) {
 
 /* ---------------------------------- CLI ---------------------------------- */
 
-function loadPricing(tyranDir) {
-  // A config that will not parse is doctor's problem to report, not this
-  // reader's problem to refuse over: tokens are still worth counting.
-  // `pricingOf(null)` already reads as "no pricing block" (see schema.mjs),
-  // so an absent/unparseable file needs no separate branch here.
-  return pricingOf(loadConfigDoc(tyranDir) ?? {});
+/**
+ * The rate card out of an ALREADY-PARSED config doc — see `spendTranscriptDirsOf`
+ * for why this takes a doc instead of `tyranDir` and reading the file itself.
+ * A config that will not parse is doctor's problem to report, not this
+ * reader's problem to refuse over: tokens are still worth counting.
+ * `pricingOf(null)` already reads as "no pricing block" (see schema.mjs), so
+ * an absent/unparseable doc needs no separate branch here.
+ */
+function pricingOfDoc(doc) {
+  return pricingOf(doc ?? {});
 }
 
 function readCache(path) {
@@ -817,9 +824,14 @@ function finishReport({ sources, pricing, tyranDir, session, transcriptDirsUsed,
  */
 export function costReport({ tyranDir, projectsRoot, session = null, repoRoot = null, transcriptDirs = [] } = {}) {
   const root = repoRoot ?? resolve(tyranDir, '..');
-  const pricing = loadPricing(tyranDir);
+  // Read ONCE and handed to both readers below: `pricingOfDoc` and
+  // `spendTranscriptDirsOf` used to each open and parse config.yaml
+  // themselves, which meant every `costReport` call — including the ones
+  // `board.mjs --serve` makes per request — read the same file twice.
+  const configDoc = loadConfigDoc(tyranDir);
+  const pricing = pricingOfDoc(configDoc);
 
-  const given = transcriptDirs.length > 0 ? transcriptDirs : loadSpendTranscriptDirs(tyranDir);
+  const given = transcriptDirs.length > 0 ? transcriptDirs : spendTranscriptDirsOf(configDoc);
   // De-duplicated: two spellings of the same directory (a repeated flag, or a
   // flag that repeats what the config already says) must not double-count
   // every transcript under it.

--- a/scripts/schema.mjs
+++ b/scripts/schema.mjs
@@ -68,7 +68,7 @@ export function validateConfig(doc) {
   const errors = [];
   if (!isPlainObject(doc)) return ['config must be a mapping'];
 
-  const known = ['profile', 'autonomy', 'tiers', 'validation', 'shared_zones', 'budget', 'main_writable_paths', 'limits', 'pricing'];
+  const known = ['profile', 'autonomy', 'tiers', 'validation', 'shared_zones', 'budget', 'main_writable_paths', 'limits', 'pricing', 'spend'];
   for (const key of Object.keys(doc)) {
     if (!known.includes(key)) errors.push(`${key}: unknown top-level key`);
   }
@@ -225,6 +225,32 @@ export function validateConfig(doc) {
       const knownPricing = ['rate_card', 'models'];
       for (const key of Object.keys(pricing)) {
         if (!knownPricing.includes(key)) errors.push(`pricing.${key}: unknown key`);
+      }
+    }
+  }
+
+  // Where cost.mjs should look for THIS repo's transcripts, when the
+  // derived-slug / cwd-probe fallback lands on the wrong session — a
+  // conductor that ran from a working directory other than the repo it
+  // operates on. Operator-written, never scanner-inferred, exactly like
+  // `pricing:` and `limits:` above, and optional for the same reason: absence
+  // means the existing fallback resolution applies, unchanged.
+  if ('spend' in doc) {
+    if (!isPlainObject(doc.spend)) errors.push('spend: must be a mapping');
+    else {
+      const spend = doc.spend;
+      if ('transcript_dirs' in spend) {
+        if (!Array.isArray(spend.transcript_dirs)) {
+          errors.push('spend.transcript_dirs: must be a list of directory paths');
+        } else {
+          spend.transcript_dirs.forEach((d, i) => {
+            if (!isNonEmptyString(d)) errors.push(`spend.transcript_dirs[${i}]: must be a non-empty path`);
+          });
+        }
+      }
+      const knownSpend = ['transcript_dirs'];
+      for (const key of Object.keys(spend)) {
+        if (!knownSpend.includes(key)) errors.push(`spend.${key}: unknown key`);
       }
     }
   }

--- a/site/src/content/docs/board.mdx
+++ b/site/src/content/docs/board.mdx
@@ -236,12 +236,16 @@ node scripts/board.mjs --dir .tyran            # render all three artefacts
 node scripts/board.mjs --dir .tyran --check    # byte-exact drift check, exit 1
 node scripts/board.mjs --dir .tyran --serve    # localhost viewer, always fresh
 node scripts/board.mjs --dir .tyran --serve --write   # ... and Settings can edit
+node scripts/board.mjs --dir .tyran --serve --transcripts <dir>   # ... and Spend reads THAT dir
 ```
 
 `--serve` binds `127.0.0.1` only, re-renders per request, and never derives a
 filesystem path from a URL; `--write` adds the [Settings](#settings) routes and
 nothing else, and refuses on its own (`--write` without `--serve` is a usage
-error, not a silent no-op). The initiative ceiling is 64, refused loudly —
+error, not a silent no-op). `--transcripts <dir>` is the same refusal, for the
+same reason: it means something only to `/cost.json`, which only exists under
+`--serve`. Repeatable, and it overrides `spend.transcript_dirs` in
+`.tyran/config.yaml` — see [Spend](#spend). The initiative ceiling is 64, refused loudly —
 archive closed initiatives rather than boarding them. An unreadable journal
 renders as a visible **UNREADABLE** entry: a board that omits a broken
 initiative would read as "all is well" exactly when it is not.
@@ -275,6 +279,18 @@ one same-origin request to loopback, and the same defences cover it: the
 `--serve` (a foreign `Host` gets 403, verified), and a cost read that fails
 returns 503 rather than taking the board down — the board answers "what is
 going on", and that answer does not depend on knowing what it cost.
+
+**When the resolved directory is the wrong one.** Both of `cost.mjs`'s
+heuristics for finding a repo's transcripts assume the conductor session ran
+from the repo it operates on. A conductor started from another working
+directory — Desktop opened in a sibling folder, working the repo through
+absolute paths and worktrees — breaks that assumption, and the tab still
+renders: honest numbers, about the wrong session. The tell is zero agent
+transcripts while the board itself lists running agents, and the tab shows a
+hint for it, naming the two overrides: start this server with `--serve
+--transcripts <dir>`, or set `spend.transcript_dirs` in `.tyran/config.yaml`.
+Details and the measured failure are in
+[the spend ledger](../cost/#when-resolution-fails).
 
 ## Settings
 

--- a/site/src/content/docs/configuration.mdx
+++ b/site/src/content/docs/configuration.mdx
@@ -73,6 +73,16 @@ pricing:                   # OPTIONAL. The spend ledger (see the Spend page).
       cache_write: 18.75
       cache_read: 1.5
       output: 75
+
+spend:                     # OPTIONAL. Where cost.mjs looks for THIS repo's
+  transcript_dirs:         # transcripts, when the derived-slug / cwd-probe
+    - '~/.claude/projects/-Users-me-work-a-different-checkout'
+                           # fallback lands on the wrong session (see the Spend
+                           # page) — a conductor that ran from a working
+                           # directory other than the repo it operates on.
+                           # `--transcripts` on the command line outranks this
+                           # block; both replace the fallback resolution
+                           # entirely rather than adding to it.
 ```
 
 Setup also seeds `MISTAKES.md` at the repository root, create-only. There is no
@@ -133,6 +143,38 @@ every amount.
 `rate_card` is a label, not a lookup — nothing fetches anything. It exists so
 that every amount can say which card produced it, because two people quoting
 different cards get different money from one set of tokens.
+
+## Explicit transcript directories
+
+`spend:` is the other optional, operator-written block the spend ledger reads
+— no provenance wrapper, exactly like `pricing:` and `limits:`. `cost.mjs`
+normally locates a repo's transcripts itself: first by the directory name the
+platform derives from the repo path, then, if that is absent, by opening
+every project directory and matching on the `cwd` its records carry. Both
+assume the conductor session ran **from the repo it operates on**, and when it
+did not — Claude Code Desktop opened in a sibling folder, working the repo
+through absolute paths and worktrees — neither heuristic can find it: the
+transcript lives under a project directory named after the conductor's own
+working directory, not the repo's.
+
+| key | required | accepted |
+|---|---|---|
+| `transcript_dirs` | no | a list of non-empty directory paths, each the per-project directory holding `<session>.jsonl` and `<session>/subagents/` |
+
+A leading `~` expands to the home directory. **A path without `~` or a leading
+`/` resolves against the process's current working directory** — the shell
+`cost.mjs` (or `board.mjs --serve`) happens to have been launched from, not
+`.tyran/`'s location and not the repo root. Write an absolute path or a `~`
+path; a bare relative entry works only by accident of where the command was
+run, which is the exact kind of assumption this block exists to replace.
+
+Given a non-empty list, `cost.mjs` scans the union of those directories
+instead of running either heuristic; a directory that does not exist is
+reported in the report's `transcript_dirs_missing` rather than silently
+skipped. `--transcripts <dir>` on the command line is the same override and
+outranks this block when both are given. Full account of the failure this
+exists for, and what the board shows when it fires, is in
+[the spend ledger](../cost/#when-resolution-fails).
 
 ## Autonomy classes
 

--- a/site/src/content/docs/cost.mdx
+++ b/site/src/content/docs/cost.mdx
@@ -101,7 +101,7 @@ Two refinements that stop the warnings becoming noise or becoming lies:
 ## CLI
 
 ```bash
-node scripts/cost.mjs [--dir <.tyran>] [--session <id>] [--projects <dir>] [--json]
+node scripts/cost.mjs [--dir <.tyran>] [--session <id>] [--projects <dir>] [--transcripts <dir>]... [--json]
 ```
 
 - `--dir` is the `.tyran` directory (default `.tyran`); the repository it
@@ -110,6 +110,13 @@ node scripts/cost.mjs [--dir <.tyran>] [--session <id>] [--projects <dir>] [--js
 - `--session <id>` narrows the report to one session and its agents.
 - `--projects <dir>` overrides where the transcripts are looked for; the
   default is `~/.claude/projects`.
+- `--transcripts <dir>` names a transcript directory explicitly — the
+  per-project directory holding `<session>.jsonl` and `<session>/subagents/`.
+  Repeatable; sources are the union over every directory given. A leading `~`
+  expands to the home directory; anything else resolves against the process's
+  current working directory, so a relative path is only as reliable as the
+  directory the command happens to be run from — prefer absolute or `~`. See
+  [When resolution fails](#when-resolution-fails) below.
 - `--json` writes `.tyran/state/cost.json` atomically and prints its path
   instead of the table.
 - Exit `0` ok · `2` usage or I/O error, including *no transcripts found for
@@ -128,6 +135,36 @@ documentation, so it is verified rather than trusted: if the computed directory
 is absent, every project directory is opened and matched on the `cwd` its
 records carry.
 
+## When resolution fails
+
+Both heuristics above assume the conductor session ran **from the repo it is
+working on**. When it did not — a Claude Code Desktop session opened in a
+sibling folder, operating on the repo through absolute paths and worktrees —
+neither one finds it: the computed slug is derived from the conductor's own
+working directory, not the repo path, and every record in that transcript
+carries the conductor's cwd too, never the repo's.
+
+Measured: a `claude` run once started inside the repo (for the trust dialog)
+left a directory the direct lookup matched and stopped at, while ~66 agent
+transcripts and 2 300 requests sat under the conductor's real project
+directory with nothing on the report pointing at them — the ledger showed one
+session, one model, `unattributed` agents, and a conductor overhead reading
+100%, as if that were the whole initiative.
+
+Two overrides, highest priority first, both resolved by `cost.mjs` itself so
+`board.mjs --serve` gets them too with no extra plumbing:
+
+1. `--transcripts <dir>` on the command line, repeatable — sources are the
+   union over every directory given.
+2. `spend.transcript_dirs` in `.tyran/config.yaml` — see
+   [the configuration reference](../configuration/#explicit-transcript-directories).
+
+Either one replaces the derived-slug / cwd-probe resolution entirely rather
+than adding to it. A given directory that does not exist is reported in
+`transcript_dirs_missing` on the report, never silently dropped — the same
+"gaps are reported, never zeroed" rule that governs every other hole in this
+file.
+
 ## What the dashboard shows
 
 `board.html` renders a **Spend** section: total tokens and requests, the amount
@@ -136,6 +173,12 @@ a composition bar across input / cache write / cache read / output, and three
 ranked charts — by model, by agent type, by ticket — with a tokens/cost toggle.
 A row whose models have no rate draws no bar at all, because "not priced" and
 "cost nothing" must not look the same.
+
+Zero agent transcripts while the board itself lists running agents is a sign
+worth surfacing rather than a quiet empty table: the tab shows a hint pointing
+at [the two overrides above](#when-resolution-fails) whenever that shape
+appears, and lists any `--transcripts` / `spend.transcript_dirs` entry that
+was given but not found.
 
 The section is **fetched, not embedded**, which is a deliberate amendment to
 the board's "self-contained, no network" description — see
@@ -148,6 +191,11 @@ more than the report: a `sources[]` entry per transcript, keyed on path, mtime
 and size. Consumers check `schema === 1`; the dashboard renders nothing rather
 than garbage on a mismatch. Invisible characters are escaped as `\uXXXX` and
 never removed, exactly as in `board.json`.
+
+`transcript_dirs` names the directory (or directories) the report actually
+scanned, and `transcript_dirs_missing` names any `--transcripts` /
+`spend.transcript_dirs` entry that was given but does not exist on this
+machine — both present whichever resolution path produced the report.
 
 That cache is what makes a page refreshing every 30 seconds affordable.
 Transcripts reach tens of megabytes, so the reader streams them in chunks

--- a/tests/unit/board-client-literal.test.mjs
+++ b/tests/unit/board-client-literal.test.mjs
@@ -40,3 +40,59 @@ test('no backtick reaches the client template literal', () => {
       'Reword the comment: name identifiers in prose, never in backticks.',
   );
 });
+
+/**
+ * Two callers share one hint-selecting function: `renderSpend`, which only
+ * runs once spend resolved successfully, and the cost-fetch handler, which
+ * has to decide what to show on the branch where nothing resolved at all —
+ * exactly the branch `renderSpend` never reaches. There is no DOM in this
+ * test file (see the header above for why CLIENT_JS cannot be imported), so
+ * this pulls `spendResolutionHints` out of the source as TEXT, the same way
+ * the guard above does, and evaluates JUST that function with `new Function`
+ * — no browser, no `document`, because the function needs neither.
+ */
+test('spendResolutionHints reports a missing directory even when nothing was found at all', () => {
+  const src = readFileSync(SOURCE, 'utf8');
+  const marker = 'var spendResolutionHints = function (payload) {';
+  const start = src.indexOf(marker);
+  assert.notEqual(start, -1, 'spendResolutionHints is gone — this guard needs rewriting');
+  const bodyStart = start + 'var spendResolutionHints = '.length; // begins at "function (payload) {"
+  const closeMarker = '\n  };\n';
+  const closeAt = src.indexOf(closeMarker, bodyStart);
+  assert.ok(closeAt > bodyStart, 'the closing brace could not be found — this guard needs rewriting');
+  const fnSource = src.slice(bodyStart, closeAt + closeMarker.length - 1); // through the closing "  };"
+  const spendResolutionHints = new Function('return ' + fnSource)();
+
+  // MUST-PASS: the exact shape review reproduced live against a real board —
+  // every `--transcripts` / `spend.transcript_dirs` entry given, and every
+  // one of them missing (the everyday single-typo case). Before this fix the
+  // fetch handler's `if (!payload.transcripts_found) return;` fired first and
+  // silently, so the Spend tab kept showing the pre-fetch "open this board
+  // with board.mjs --serve" hint forever — indistinguishable from a repo that
+  // had never been served at all, with nothing on the page about the typo.
+  const hits = spendResolutionHints({
+    schema: 1,
+    transcripts_found: false,
+    transcript_dirs: [],
+    transcript_dirs_missing: ['/nope'],
+  });
+  assert.equal(hits.length, 2, 'both the missing-dir hint and the not-found hint must render');
+  assert.match(hits[0], /^Given transcript directory not found: \/nope\.$/);
+  assert.match(hits[1], /No transcripts found for this repo/);
+  assert.match(hits[1], /--transcripts/);
+  assert.match(hits[1], /spend\.transcript_dirs/);
+
+  // Several missing dirs pluralise the noun rather than mis-stating one.
+  const plural = spendResolutionHints({ transcripts_found: false, transcript_dirs_missing: ['/a', '/b'] });
+  assert.match(plural[0], /^Given transcript directories not found: \/a, \/b\.$/);
+
+  // MUTANT this line guards against: unconditionally push the "no transcripts
+  // found" line. On a SUCCESSFUL resolution (the shape renderSpend's own call
+  // produces) that line would flatly contradict the numbers rendered right
+  // next to it, so it must not appear here — only the missing-dir line may.
+  const partial = spendResolutionHints({ transcripts_found: true, transcript_dirs_missing: ['/nope'] });
+  assert.deepEqual(partial, ['Given transcript directory not found: /nope.']);
+
+  // The everyday healthy case has nothing to say.
+  assert.deepEqual(spendResolutionHints({ transcripts_found: true, transcript_dirs_missing: [] }), []);
+});

--- a/tests/unit/board.test.mjs
+++ b/tests/unit/board.test.mjs
@@ -315,6 +315,28 @@ test('spend reaches three places from the one fetch, and explains itself when th
   assert.match(html, /Over file:\/\/ there is no server, so this tab stays empty\./);
 });
 
+test('the missing-transcript-dir hint renders even when nothing was found at all', () => {
+  // MUTANT: revert the fetch handler's `if (!payload.transcripts_found)` back
+  // to a bare `return;`. The pure function's own tests (board-client-literal
+  // .test.mjs) would stay green — they never touch this call site — while the
+  // Spend tab silently keeps its pre-fetch "open with --serve" hint on the
+  // exact payload review reproduced live: every `spend.transcript_dirs` entry
+  // present but every one of them a typo. This test pins the WIRING, not just
+  // the function it wires in.
+  const html = demoHtml();
+  const handler = html.slice(
+    html.indexOf('if (!payload.transcripts_found) {'),
+    html.indexOf('cost = payload;'),
+  );
+  assert.notEqual(handler.indexOf('if (!payload.transcripts_found) {'), -1, 'the guard itself must survive');
+  assert.match(handler, /clear\(spBody\)/, 'the stale pre-fetch hint must be cleared, not left standing');
+  assert.match(
+    handler,
+    /spendResolutionHints\(payload\)\.forEach\(function \(h\) \{ spBody\.appendChild\(el\('div', 'hint', h\)\); \}\)/,
+    'the branch that never reaches renderSpend must still call the shared hint function',
+  );
+});
+
 // --- the half that did not render -----------------------------------------
 //
 // The damage guard above fires only when NOTHING was readable. Everything

--- a/tests/unit/board.test.mjs
+++ b/tests/unit/board.test.mjs
@@ -149,6 +149,16 @@ test('the initiative ceiling refuses loudly instead of quietly truncating', () =
   assert.match(cli.stderr, /ceiling/);
 });
 
+test('--transcripts only means anything with --serve, exactly like --write', () => {
+  const dir = tree({ demo: demo() });
+  // MUTANT: let --transcripts through without --serve — it would silently do
+  // nothing (the one-shot renderer never calls costReport at all), which is
+  // the same kind of invisible no-op --write's own guard already refuses.
+  const r = run(['--dir', dir, '--transcripts', '/tmp/somewhere']);
+  assert.equal(r.code, 2);
+  assert.match(r.stderr, /--transcripts only means anything with --serve/);
+});
+
 test('the CLI writes three files, --check is clean after and drifts after a hand edit', () => {
   const dir = tree({ demo: demo() });
   assert.equal(run(['--dir', dir]).code, 0);

--- a/tests/unit/cost.test.mjs
+++ b/tests/unit/cost.test.mjs
@@ -254,6 +254,168 @@ test('a repo with no transcripts says so rather than reporting zero spend', () =
   assert.equal(empty.transcripts_found, false);
 });
 
+/* -------------------------- explicit transcript dirs --------------------- */
+//
+// The measured bug: a conductor session started from a working directory
+// OTHER than the repo it operates on has its transcript filed under a
+// project directory neither `transcriptDirFor` heuristic can reach — the
+// computed slug is derived from the CONDUCTOR's cwd, and every record in
+// that transcript carries the conductor's cwd too, never the repo's. Real
+// run: a `claude` session once started inside the repo (for the trust
+// dialog) left a directory the direct lookup matched and stopped at, while
+// ~66 agent transcripts sat under the real project dir with nothing on the
+// board pointing at them. `--transcripts` / `spend.transcript_dirs` is the
+// operator-named escape hatch.
+
+test('an explicit transcript dir is used even when it is not derivable from the repo root at all', () => {
+  const base = mkdtempSync(join(tmpdir(), 'tyran-cost-explicit-'));
+  const repo = join(base, 'repo'); // the repo the conductor is WORKING ON
+  const otherCwd = join(base, 'other-session-cwd'); // where the conductor actually RAN from
+  const projects = join(base, 'projects'); // empty: the fallback must find nothing here
+  const elsewhere = join(base, 'elsewhere-transcripts'); // not under `projects` at all
+  mkdirSync(join(repo, '.tyran', 'state'), { recursive: true });
+  mkdirSync(join(elsewhere, 'sess-1', 'subagents'), { recursive: true });
+  writeFileSync(
+    join(elsewhere, 'sess-1.jsonl'),
+    assistant('m-cheap', usage(1, 1, 1, 1), 'r1', otherCwd) + '\n'
+  );
+  const agents = join(elsewhere, 'sess-1', 'subagents');
+  writeFileSync(join(agents, 'agent-a1.jsonl'), assistant('m-cheap', usage(1, 1, 1, 1), 'r2', otherCwd) + '\n');
+  writeFileSync(join(agents, 'agent-a1.meta.json'), JSON.stringify({ agentType: 'implementer', description: 'T-1 do it' }));
+  writeFileSync(join(repo, '.tyran', 'config.yaml'), "profile: 'balanced'\n");
+
+  // MUTANT: ignore `transcriptDirs` and keep calling `transcriptDirFor` —
+  // this is the exact shape of the measured failure this flag exists to fix.
+  assert.equal(transcriptDirFor(repo, projects), null, 'the existing resolution genuinely cannot find it');
+
+  const out = costReport({
+    tyranDir: join(repo, '.tyran'),
+    projectsRoot: projects,
+    repoRoot: repo,
+    transcriptDirs: [elsewhere],
+  });
+  assert.equal(out.transcripts_found, true);
+  assert.deepEqual(out.transcript_dirs, [elsewhere]);
+  assert.deepEqual(out.transcript_dirs_missing, []);
+  assert.equal(out.coverage.agent_transcripts, 1, 'the agent transcript sitting in the explicit dir is found');
+});
+
+test('a --transcripts dir that does not exist is reported missing, never silently dropped', () => {
+  const tree = makeTree();
+  const missing = join(tree.base, 'nowhere-at-all');
+  const out = costReport({ tyranDir: tree.tyranDir, projectsRoot: tree.projects, transcriptDirs: [missing] });
+  // MUTANT: skip an absent dir instead of reporting it — property 3 in this
+  // file's header: gaps are reported, never zeroed.
+  assert.equal(out.transcripts_found, false);
+  assert.deepEqual(out.transcript_dirs, []);
+  assert.deepEqual(out.transcript_dirs_missing, [missing]);
+});
+
+test('one present and one missing --transcripts dir: the present one still reports, the missing one is named', () => {
+  const a = makeTree();
+  const missing = join(a.base, 'nope');
+  const out = costReport({
+    tyranDir: a.tyranDir,
+    projectsRoot: a.projects,
+    transcriptDirs: [a.project, missing],
+  });
+  assert.equal(out.transcripts_found, true);
+  assert.deepEqual(out.transcript_dirs, [a.project]);
+  assert.deepEqual(out.transcript_dirs_missing, [missing]);
+  assert.equal(out.coverage.agent_transcripts, 2);
+});
+
+test('spend.transcript_dirs in config.yaml is honoured when no --transcripts flag is given', () => {
+  const tree = makeTree({ slugged: false }); // the derived slug will not match
+  const configPath = join(tree.tyranDir, 'config.yaml');
+  writeFileSync(
+    configPath,
+    readFileSync(configPath, 'utf8') + 'spend:\n' + '  transcript_dirs:\n' + `    - '${tree.project}'\n`
+  );
+  // `projectsRoot` points at an empty directory, so the derived-slug / cwd
+  // probe fallback has nothing to find — only the config block can locate it.
+  const out = costReport({
+    tyranDir: tree.tyranDir,
+    projectsRoot: join(tree.base, 'nowhere'),
+    repoRoot: tree.repo,
+  });
+  assert.equal(out.transcripts_found, true);
+  assert.deepEqual(out.transcript_dirs, [tree.project]);
+});
+
+test('a CLI --transcripts argument outranks spend.transcript_dirs in config.yaml', () => {
+  const winner = makeTree();
+  const loser = makeTree();
+  const configPath = join(winner.tyranDir, 'config.yaml');
+  writeFileSync(
+    configPath,
+    readFileSync(configPath, 'utf8') + 'spend:\n' + '  transcript_dirs:\n' + `    - '${loser.project}'\n`
+  );
+  const out = costReport({
+    tyranDir: winner.tyranDir,
+    projectsRoot: join(winner.base, 'nowhere'),
+    repoRoot: winner.repo,
+    transcriptDirs: [winner.project],
+  });
+  // MUTANT: read the config block before the CLI argument, or merge the two
+  // instead of the CLI winning outright — the documented precedence is CLI >
+  // config > fallback, in that order.
+  assert.deepEqual(out.transcript_dirs, [winner.project]);
+});
+
+test('CLI accepts repeated --transcripts, unions the dirs, and reports a missing one', () => {
+  const a = makeTree();
+  const b = makeTree();
+  const missing = join(a.base, 'nope');
+  const out = execFileSync(
+    process.execPath,
+    [
+      COST_CLI,
+      '--dir', a.tyranDir,
+      '--transcripts', a.project,
+      '--transcripts', b.project,
+      '--transcripts', missing,
+      '--json',
+    ],
+    { encoding: 'utf8' }
+  ).trim();
+  const parsed = JSON.parse(readFileSync(out, 'utf8'));
+  assert.equal(parsed.transcripts_found, true);
+  assert.deepEqual(parsed.transcript_dirs.slice().sort(), [a.project, b.project].sort());
+  assert.deepEqual(parsed.transcript_dirs_missing, [missing]);
+  // MUTANT: scan only the first --transcripts dir instead of the union — the
+  // agent count would read 2 instead of 4, the exact shape of the measured
+  // bug this flag exists to fix (agents sitting in a dir the report never
+  // opened).
+  assert.equal(parsed.coverage.agent_transcripts, 4);
+});
+
+test('CLI: --transcripts with no value is a usage error, exit 2', () => {
+  const tree = makeTree();
+  assert.throws(
+    () => execFileSync(process.execPath, [COST_CLI, '--dir', tree.tyranDir, '--transcripts'], { encoding: 'utf8', stdio: 'pipe' }),
+    (err) => err.status === 2
+  );
+});
+
+test('CLI: none of the given transcript dirs exist names them, distinct from the derived-dir message', () => {
+  const tree = makeTree();
+  const missing = join(tree.base, 'gone');
+  assert.throws(
+    () =>
+      execFileSync(process.execPath, [COST_CLI, '--dir', tree.tyranDir, '--transcripts', missing], {
+        encoding: 'utf8',
+        stdio: 'pipe',
+      }),
+    (err) => {
+      assert.equal(err.status, 2);
+      assert.match(String(err.stderr), /none of the given transcript directories exist/);
+      assert.match(String(err.stderr), new RegExp(missing.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')));
+      return true;
+    }
+  );
+});
+
 test('an unchanged transcript is reused from cache; a changed one is rescanned', () => {
   const tree = makeTree();
   const sources = listSources(tree.project, null);

--- a/tests/unit/schema.test.mjs
+++ b/tests/unit/schema.test.mjs
@@ -549,6 +549,31 @@ test('pricing accepts a full rate card and rejects every partial shape', () => {
   assert.deepEqual(validateConfig(unlabelled), ['pricing.rate_card: must be a non-empty label']);
 });
 
+// --- spend ---------------------------------------------------------------
+//
+// Where cost.mjs should look for a repo's transcripts when the derived-slug /
+// cwd-probe fallback lands on the wrong session. Operator-written, never
+// scanner-inferred, exactly like `pricing:` above.
+
+test('spend.transcript_dirs accepts a list of non-empty strings and rejects every other shape', () => {
+  const full = { ...minimalConfig(), spend: { transcript_dirs: ['/abs/path', '~/.claude/projects/x-y'] } };
+  assert.deepEqual(validateConfig(full), []);
+
+  // MUTANT: accept a bare string instead of requiring a list — a single dir
+  // typed without brackets would silently scan its own characters as paths.
+  const notList = { ...minimalConfig(), spend: { transcript_dirs: '/abs/path' } };
+  assert.deepEqual(validateConfig(notList), ['spend.transcript_dirs: must be a list of directory paths']);
+
+  const emptyEntry = { ...minimalConfig(), spend: { transcript_dirs: ['/abs/path', ''] } };
+  assert.deepEqual(validateConfig(emptyEntry), ['spend.transcript_dirs[1]: must be a non-empty path']);
+
+  const notMapping = { ...minimalConfig(), spend: 'nope' };
+  assert.deepEqual(validateConfig(notMapping), ['spend: must be a mapping']);
+
+  const stray = { ...minimalConfig(), spend: { transcript_dirs: [], currency: 'USD' } };
+  assert.deepEqual(validateConfig(stray), ['spend.currency: unknown key']);
+});
+
 test('pricingOf drops a model the validator would reject rather than half-pricing it', () => {
   const doc = {
     pricing: {


### PR DESCRIPTION
## What broke (measured on a real 14-ticket initiative, v0.1.29)

The Spend tab showed **the wrong session** with no hint. `cost.mjs` finds "this repo's transcripts" by deriving the project directory from the repo path (`~/.claude/projects/<repo-path-with-dashes>/`), with a fallback that scans project dirs for a transcript whose first records carry `cwd === repoRoot`.

Our conductor ran in a Claude Code Desktop session whose working directory was a *sibling* folder; it operated on the repo through absolute paths and worktrees. Meanwhile one unrelated `claude` session had been started inside the repo dir once (the workspace-trust dialog). That made the derived directory exist, resolution stopped there, and the board reported that session — 17 requests, one model, "0 agents attributed", "conductor overhead 100 %" — as if it were the initiative. The real spend (2,311 requests, ~66 agent transcripts, three models) sat in another project directory. Nothing on the page said so, which is the one thing `cost.mjs`'s own third property (gaps are reported, never zeroed) exists to prevent.

## What this changes

- `cost.mjs`: repeatable `--transcripts <dir>` (an explicit per-project transcript dir; union across dirs, `--session` filter applies across all); `spend.transcript_dirs` in `.tyran/config.yaml`; precedence CLI > config > existing resolution. New report fields `transcript_dirs` (used) and `transcript_dirs_missing` (given but absent — reported, never dropped; the CLI names them and exits 2 when none exist). Cache rule unchanged: filtered runs are never persisted. Config is parsed once per `costReport`.
- `board.mjs`: `--transcripts <dir>` (only with `--serve`, guarded like `--write`), passed through to `/cost.json`.
- `board-html.mjs`: the Spend tab now says when it found **no agent transcripts** although the board lists agents, and lists any given-but-missing dirs — including in the `transcripts_found: false` case, which the fetch handler used to swallow with a bare `return` (a reviewer caught that in round one; the decision is now a small pure `spendResolutionHints(payload)` so it can be tested without a DOM).
- `schema.mjs`: `spend` is a known top-level key; `spend.transcript_dirs` must be a list of non-empty strings; unknown sub-keys rejected (mirrors `limits`).
- Tests: +10 (explicit dir not derivable from repo root; missing dir reported; mixed present/missing; config-driven; CLI-over-config precedence; repeated flag union; CLI usage error; distinct missing-dir error; schema shapes; board `--serve` guard; client hint function on the exact live payload; wiring test that goes red if the call site is removed). Every new test was shown red under a mutation before being shown green.
- Docs: `docs/cost.md` ("When resolution fails"), `docs/board.md` (Spend section + CLI), `docs/configuration.md` (`spend:` block; note that relative entries resolve against the process cwd — use absolute or `~`). `CHANGELOG.md` gets an Unreleased entry; no version bump.

## Verification

```
node --test "tests/**/*.test.mjs"      -> tests 1417, pass 1417, fail 0
node scripts/desc-budget.mjs .          -> 4352 / 5000
node scripts/scan-control-chars.mjs .   -> clean (262 scanned)
```

Default path (no flag, no config): `cost.mjs` table output byte-identical to `main` on the same fixture; `--json` differs only by the two additive fields. End-to-end on the real repo: `cost.mjs --transcripts ~/.claude/projects/<conductor-project-dir> --session <id>` reports the initiative (2,311 requests: 1,951 sonnet / 429 fable / 6 haiku) instead of the trust-dialog session.

## Not covered here

Two smaller things from the same run, left for you to judge (they change the playbook, not a script): a `spawn` event journaled before the Agent call was issued left three tickets "in progress" for 25 min after the conductor's turn died on an API error (a `spawn-silent` doctor finding, or journaling after the agent id returns, would catch it); and a reviewer-raised operator gate stayed open after the ticket was merged (a merge-time gate check would). Full field report with all six process findings and what each cost: happy to share.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
