### PR TITLE
chore(release): 0.1.30

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
     {
       "name": "tyran",
       "description": "A task conductor for Claude Code: multi-agent orchestration with an enforced evidence contract, repo-specific learning, and update-safe local evolution.",
-      "version": "0.1.29",
+      "version": "0.1.30",
       "source": "./",
       "author": {
         "name": "Jacek Janczura",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "tyran",
-  "version": "0.1.29",
+  "version": "0.1.30",
   "description": "A task conductor for Claude Code: multi-agent orchestration with an enforced evidence contract, repo-specific learning, and update-safe local evolution.",
   "author": {
     "name": "Jacek Janczura",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 
-## Unreleased
+## 0.1.30 — 2026-08-17
+
+The first release built on an outside contribution. It fixes a spend ledger
+that was confidently reporting the wrong session, and it is also the release
+where the "change both surfaces" rule caught itself being broken.
 
 ### Spend, when the conductor ran from somewhere else
 
@@ -25,6 +29,27 @@ rather than dropped. The Spend tab now shows a hint — pointing at both
 overrides — whenever it finds zero agent transcripts while the board itself
 lists running agents, which is the shape this failure actually has: a tab that
 renders, with honest numbers about the wrong session.
+
+Contributed by [@FreddyFormosa](https://github.com/FreddyFormosa) in
+[#66](https://github.com/jjanczur/tyran/pull/66), found on a 14-ticket
+production run — the failure above is his measurement, not a constructed one.
+
+### The half of "change both, always" that got left out
+
+That contribution updated `docs/board.md`, `docs/configuration.md` and
+`docs/cost.md` and left `board.mdx`, `configuration.mdx` and `cost.mdx`
+untouched, which is precisely the divergence `CLAUDE.md` names — "docs/*.md
+and site/src/content/docs/*.mdx publish the same claims. Change both, always."
+All three pages are now mirrored, cross-links rewritten relative
+(`../cost/#when-resolution-fails`) so the Pages build keeps its `/tyran` base
+prefix.
+
+Worth naming because of *how* it was caught: not by review, but by CI going
+red on a different claim entirely. The README said 1405 unit tests and the
+suite had 1417, and that check lives in the workflow rather than in the suite
+— no test inside the suite can run the suite — so `node --test` reported green
+locally right up to the point the pull request was opened. The number is now
+1417, measured rather than typed. The .mdx gap was found while fixing it.
 
 ## 0.1.29 — 2026-08-16
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jjanczur/tyran",
-  "version": "0.1.29",
+  "version": "0.1.30",
   "description": "Command-line scripts for the Tyran task conductor (doctor, journal, schema, and repo tooling) for CI and terminals outside Claude Code. Installing this package does NOT install the Claude Code plugin — add that separately with `/plugin marketplace add jjanczur/tyran` inside Claude Code.",
   "type": "module",
   "engines": {


### PR DESCRIPTION
Ships #66 — the first outside contribution — plus the two things that
blocked it.

**The three version fields**, bumped in one commit because different tools
cross-check different ones: `.claude-plugin/plugin.json` is what
`claude plugin update` compares (the version field, not the commit),
`.claude-plugin/marketplace.json` is what `claude plugin tag` refuses to
disagree with, and `package.json` is what `npm-publish.yml` checks against the
release tag.

**CHANGELOG**: `Unreleased` becomes `0.1.30 — 2026-08-17`, crediting
@FreddyFormosa for the spend fix and recording the two follow-ups — the docs
site mirrored to match `docs/`, and the README's suite count corrected from
1405 to 1417.

Verified locally: 1417/1417 pass with 0 skipped, `scan-control-chars` clean
over 262 tracked files, `desc-budget` 4352/5000, both plugin manifests
validate, and the docs site builds with `check-base-prefix` reporting 533/533
root-absolute URLs carrying the `/tyran` prefix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)