### PR TITLE
fix(projection): four things the fold recorded and threw away (O-1, O-2, O-3, O-6)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,65 @@
 # Changelog
 
+## Unreleased
+
+### Four things the fold recorded and threw away
+
+Each of these was a question an operator asked the board, got a confident
+answer to, and the answer was wrong in the same direction: everything looked
+fine.
+
+**An agent the initiative moved on without now reads `stale`, not `running`.**
+Nothing in the projection ever downgraded a spawn, so an agent that never
+reported stayed `running` in every artefact for as long as the journal
+survived, and the board's header counted week-old ghosts as live work. Doctor
+had been calling those same spawns abandoned the whole time, from the same
+events — two answers to one question, which is the defect ADR-21 is named
+after and which `pairSpawns` had already been through once for the adjacent
+question of who is still working.
+
+There is now one predicate, `journal.spawnStaleness`, and both consumers call
+it; doctor's copy is gone rather than kept in sync. It could not live in
+doctor, which imports the projection, so it sits in `journal.mjs` beside
+`pairSpawns` where both already reach.
+
+The threshold is journal time — measured against the initiative's own latest
+event, never the wall clock. That is what `spawn-stale` has always meant, and
+it is the only version that keeps `board.json` byte-exact under `--check`.
+`blocked` still outranks `stale`, because that is the agent's own account of
+why it stopped. The `age-fresh/warm/cold/dead` colours on the page are a
+different question and keep their own vocabulary: an agent can be quiet for
+hours without being stale, and stale while chattering every minute.
+
+**A closing checkpoint closes the spawns it leaves open.** No event type
+closed an initiative, so one could be explicitly wound up with three agents
+that never reported still running forever. `checkpoint` with `phase: closed`
+— the one reserved value in an otherwise free-text field — now closes that
+initiative's still-open spawns at fold time, and only the ones folded before
+it, so an agent spawned afterwards keeps its own lifecycle. They are closed,
+never reported: no verdict is invented for an agent that never filed one, and
+each is named in the warnings rather than tidied away.
+
+**A gate that passes after refusing no longer erases the refusal.** Results
+are keyed by `kind`, so a re-run won the slot, and *"security denied this,
+then someone re-ran it green"* rendered identically to *"security has only
+ever passed"*. The event count always survived, so the volume was never lost
+— only the verdict. The last refusal is kept beside the current result and
+gets its own column in `STATE.md`. A refusal is a named set (`deny`, `fail`,
+`rejected`, …) rather than "anything that is not a pass": the first draft was
+the latter, and the demo fixture caught it at once, marking every `open` gate
+as carrying a permanent objection it had never raised.
+
+**A report carries what the agent said, not only its verdict.** `decision`
+folds its `text` and `gate` folds its `evidence`; `report` was the one carrier
+of description that wrote to nowhere, so a `changes-needed` card reached the
+board with the reason it came back discarded at fold time. One field reads
+`text`, then `note`, then `evidence`, because agents improvise the key.
+
+The board header now says *open* rather than *running* and names the stale
+count beside it — the agents are still counted and still in the strip, but an
+open spawn and live work are not the same fact and the tile was asserting the
+second from the first.
+
 ## 0.1.30 — 2026-08-17
 
 The first release built on an outside contribution. It fixes a spend ledger

--- a/README.md
+++ b/README.md
@@ -297,7 +297,7 @@ enforces the cap (4352 of 5000 characters). What each one assumes, when it
 fires and who invokes it, is in
 [skills and agents](https://jjanczur.github.io/tyran/skills/); the prompts
 themselves are in [`skills/`](skills/) and [`agents/`](agents/). Behind all of
-it: 1417 unit tests, run with `node --test "tests/**/*.test.mjs"`.
+it: 1432 unit tests, run with `node --test "tests/**/*.test.mjs"`.
 
 ## Documentation
 

--- a/docs/board.md
+++ b/docs/board.md
@@ -445,6 +445,24 @@ The agent strip aged on `progress` events, which an agent emits at will. An
 agent looping without achieving anything therefore had the freshest chip on the
 board, and — because the strip is sorted stalest-first — sorted to the bottom.
 
+**Stale is a third thing, and it does not share their vocabulary.** The four
+colours above are wall-clock: "how long since it spoke, right now, where you
+are sitting", computed in the reader's own browser because the artefact may
+not read a clock. **Stale** is journal time, decided on the server by the same
+predicate `doctor` uses — "the initiative moved on without it" — and it reads
+the same tomorrow, and in six months, for every reader of that journal. An
+agent can be quiet for hours without being stale, and stale while chattering
+every minute. So it marks the whole chip in brass rather than joining the age
+scale: two questions sharing one vocabulary is how an operator ends up with
+two contradictory answers on one strip.
+
+The header tile counts the **live** ones and names the rest. It used to read
+"N agents running" for every open spawn, which made a fleet that died before
+you went to bed indistinguishable from one working through the night. The
+stale agents are still counted, still in the strip, and now said out loud. The
+same correction reaches `BOARD.md`, whose headline says *open* rather than
+*running*, with the stale count beside it.
+
 Every agent now carries two times. **`last_signal`** is what it SAID, from its
 own `progress` events. **`last_evidence`** is what it SHOWED: a `report` with
 its `evidence[]`, a `finding` with its proof, a `review` verdict. The strip
@@ -461,7 +479,8 @@ healthy agents is a warning people learn to scroll past.
 ## board.json, schema 1
 
 Fixed key order (`schema`, `as_of`, `totals`, `stop`, `paused`, `asks`,
-`agents` (each with `last_signal`, `last_evidence` and `since`), `files`,
+`agents` (each with `last_signal`, `last_evidence`, `since`, and `stale` /
+`open_hours` in journal time), `files`,
 `lanes`, `errors_logged`, `errors_logged_total`, `errors`,
 `warned`); timestamps copied verbatim from events; invisibles escaped as
 `\uXXXX`, never removed; byte-identical reruns. Consumers check `schema === 1`
@@ -470,6 +489,11 @@ rendering garbage.
 
 Two of those keys are easy to confuse, so they are named apart on purpose.
 **`errors`** is the list of initiatives whose journal could not be read at all.
+**`totals.agents`** counts OPEN SPAWNS, and **`totals.agents_stale`** says how
+many of those the journal has moved on without. The page shows the difference
+as its headline and names the remainder; adding the two back together is the
+reading the split exists to prevent.
+
 **`errors_logged`** is what agents recorded as failures with an `error` event —
 newest first, capped at 20 with the true count in `errors_logged_total`,
 because this artefact is committed and compared byte for byte. One key with two

--- a/docs/journal.md
+++ b/docs/journal.md
@@ -1,6 +1,6 @@
 # Journal reference
 
-`scripts/journal.mjs` · 66 unit tests
+`scripts/journal.mjs` · 69 unit tests
 
 This page is the schema contract; extending the event set is a reviewed core
 change.
@@ -47,7 +47,7 @@ contents are moved, one initiative directory at a time, under `state/`.
 | `finding` | `area`, `claim` | a claim about one `area`, with its proof, queryable by other agents (+ `proof`, `ticket`, `confidence`; `append` issues `F-<n>` ids) |
 | `lease.acquired` | `resource`, `holder` | worktree / heavy-slot lease taken |
 | `lease.released` | `resource`, `holder` | lease returned |
-| `checkpoint` | `phase`, `next_steps` | resume surface (re-injected after compaction) |
+| `checkpoint` | `phase`, `next_steps` | resume surface (re-injected after compaction); `phase: closed` also closes the initiative's open spawns |
 | `retro.entry` | `kind`, `target` | self-improvement ledger (+ `confidence`) |
 | `error` | `class` | failure record (+ `detail`) |
 

--- a/docs/projections.md
+++ b/docs/projections.md
@@ -1,6 +1,6 @@
 # Projections reference
 
-`scripts/project.mjs` · 69 unit tests, including byte-exact
+`scripts/project.mjs` · 79 unit tests, including byte-exact
 golden files
 
 The journal stays the only source of truth; everything on this page is a
@@ -114,14 +114,69 @@ catch.
 | Section | Built from |
 |---|---|
 | Checkpoint | the last `checkpoint` event (+ `plan.accepted`, and the last event of any type) |
-| Agents | `spawn`, closed by the next `report` for the same agent name; the Last signal column is the agent's latest `progress` event, shown on running rows only |
+| Agents | `spawn`, closed by the next `report` for the same agent name — or by a `checkpoint` whose `phase` is `closed`; the Last signal column is the agent's latest `progress` event, shown on running rows only |
 | Open blockages | `progress` with `state: blocked` — cleared by the same agent's next movement signal and by `report`/`review`/`merge` |
 | Findings | `finding` events, in journal order |
 | Ledger | `ticket.created`, `ticket.status` (a lane override that never moves the percent, and never invents a ticket — one naming an id no other event created is ignored, loudly), `spawn`, `report`, `review`, `merge` |
-| Gates | `gate` — the latest event per `kind` |
+| Gates | `gate` — the latest event per `kind`, plus the last REFUSAL that kind ever recorded |
 | Leases | `lease.acquired` / `lease.released` |
 | Decisions · Retro · Errors | `decision` · `retro.entry` · `error` |
 | Resume steps | `checkpoint.data.next_steps` |
+
+## What the fold no longer throws away
+
+Four things the journal recorded and the projection dropped. Each was a
+question an operator asked the board, got a confident answer to, and the
+answer was wrong in the same direction: everything looked fine.
+
+**An agent the initiative moved on without is `stale`, not `running`.**
+Nothing here ever downgraded a spawn, so an agent that never reported stayed
+`running` in every artefact for as long as the journal survived — and the
+board's header counted week-old ghosts as live work. Doctor had been calling
+them abandoned the whole time, from the same events, which is two answers to
+one question. There is now one predicate, `journal.spawnStaleness`, and both
+call it.
+
+The threshold is measured in **journal time** — against the initiative's own
+latest event, not the wall clock. That is what `spawn-stale` has always meant
+("the initiative moved on without it") and it is the only version that keeps
+`board.json` byte-exact under `--check`: a wall-clock verdict would make two
+clones of one journal disagree, and would call every agent in a finished
+initiative stale the moment you walked away from it. An agent carries
+`stale` and `open_hours` alongside its state; `blocked` still outranks
+`stale`, because that is the agent's own account of why it stopped.
+
+The `age-fresh/warm/cold/dead` colours on `board.html` are a **different
+question** and keep their own vocabulary — see
+[the board](board.md#signal-is-not-evidence).
+
+**A closing checkpoint closes the spawns it leaves open.** No event type
+closes an initiative, so one could be explicitly wound up with three agents
+that never reported still running forever. A `checkpoint` whose `phase` is
+`closed` — the one reserved value in an otherwise free-text field, compared
+trimmed and case-insensitively — now closes that initiative's still-open
+spawns at fold time. Only the ones folded before it: an agent spawned after
+the checkpoint is a new incarnation and keeps its own lifecycle. They are
+closed, never reported: no verdict is invented for an agent that never filed
+one, and each is named in the warnings rather than tidied away.
+
+**A gate that passes after refusing does not erase the refusal.** Gate results
+are keyed by `kind`, so a re-run won the slot — and *"security denied this,
+then someone re-ran it green"* rendered identically to *"security has only ever
+passed"*. The event count always survived, so the volume was never lost, only
+the verdict. The last refusal is now kept beside the current result and shown
+in its own column. A refusal is a named set of results (`deny`, `fail`,
+`rejected`, …), not "anything that is not a pass" — `open` and
+`WAITING_ON_OPERATOR` are gates that have not answered yet, and a mark that
+fires on every pending gate says nothing at all.
+
+**A report carries what the agent said, not only its verdict.** `decision`
+folds its `text` and `gate` folds its `evidence`; a `report` was the one
+carrier of description that wrote to nowhere, so a `changes-needed` card
+reached the board with the reason it came back silently discarded. One field
+reads `text`, then `note`, then `evidence` — agents improvise the key, and
+three near-synonyms rendered as three rows would be the same answer in three
+places.
 
 Two details worth knowing:
 

--- a/scripts/board-html.mjs
+++ b/scripts/board-html.mjs
@@ -98,6 +98,12 @@ h3{font-family:var(--font);color:var(--heading);font-size:.85rem;margin:1.1rem 0
 .agent .age-fresh{color:var(--sage)}
 .agent .age-warm{color:var(--brass-bright)}
 .agent .age-cold{color:var(--clay)}
+/* Stale is a SERVER verdict in journal time, so it marks the whole chip rather
+   than joining the wall-clock age colours below — two different questions must
+   not share one vocabulary. Muted border, not red: an abandoned agent is a
+   bookkeeping fact, while the red below is "this died mid-flight". */
+.agent.stale{border-left-color:var(--brass);opacity:.82}
+.agent .stale-mark{color:var(--brass-bright);font-weight:600}
 /* A dead agent gets the only bold red on the page: three hours of silence is
    a different event from thirty minutes, and it used to share a colour. */
 .agent .age-dead{color:var(--clay-bright);font-weight:700}
@@ -423,9 +429,20 @@ if (data.schema !== 1) {
     var strip = el('div', 'agents');
     if (agents.length === 0) strip.appendChild(el('div', 'empty', 'none running'));
     agents.forEach(function (a) {
-      var chip = el('div', 'agent');
+      var chip = el('div', 'agent' + (a.stale ? ' stale' : ''));
       chip.appendChild(el('div', 'name', a.agent + (a.role ? ' · ' + a.role : '')));
       chip.appendChild(el('div', null, (a.init ? a.init + ' · ' : '') + (a.ticket || 'no ticket') + ' · ' + a.state));
+      // NOT the same statement as the age lines below, and the wording keeps
+      // them apart on purpose. Those are wall-clock: "how long since it spoke,
+      // right now, where you are sitting". This one is journal time and comes
+      // from the server, where doctor's own threshold computed it — "the
+      // initiative moved on without it", which is still true tomorrow and is
+      // the same for every reader of this journal. An agent can be quiet for
+      // hours without being stale, and stale while chattering every minute.
+      if (a.stale) {
+        chip.appendChild(el('div', 'stale-mark',
+          'STALE — open ' + (a.open_hours === null ? '?' : a.open_hours) + ' h of journal time'));
+      }
       if (a.detail) chip.appendChild(el('div', 'note', a.detail));
       // What the agent said it would do next. It has been in board.json since
       // the fold learned to read progress events, and the strip has never
@@ -473,7 +490,16 @@ if (data.schema !== 1) {
   var ovTiles = el('div', 'tiles');
   ovTiles.appendChild(tile('waiting on you', String(asks.length),
     asks.length === 0 ? 'nothing blocked on a decision' : 'answer them on the next tab', asks.length > 0 ? 'lead' : null));
-  ovTiles.appendChild(tile('agents running', String(agents.length), 'across ' + (totals.initiatives || 0) + ' initiative(s)'));
+  // The headline number is the LIVE one. "Agents running" counted every open
+  // spawn, so an initiative abandoned a week ago reported a busy fleet; the
+  // stale ones are still counted, still listed in the strip, and now said out
+  // loud rather than folded into a figure that reads as live work.
+  var staleCount = totals.agents_stale || 0;
+  ovTiles.appendChild(tile('agents running', String(agents.length - staleCount),
+    staleCount > 0
+      ? staleCount + ' more stale · across ' + (totals.initiatives || 0) + ' initiative(s)'
+      : 'across ' + (totals.initiatives || 0) + ' initiative(s)',
+    staleCount > 0 ? 'lead' : null));
   // An initiative with no tickets used to read "0% · 0 of 0 merged", which is
   // exactly what a fully stalled one reads. Nothing-started and
   // nothing-finished are different situations and deserve different words.
@@ -605,6 +631,10 @@ if (data.schema !== 1) {
     // is already done — precisely when the running-agents list is empty.
     row('worked by', card.worked_by && card.worked_by.length ? card.worked_by.join(', ') : null);
     row('note', card.annotation);
+    // What the agent SAID when it handed this back. The verdict alone told you
+    // a ticket had come back and never why, which is the one thing the card is
+    // opened for.
+    row('reported', card.report_text);
     row('last event', card.since ? ago(card.since) + ' (' + card.since + ')' : null);
     if (cost) {
       var hit = (cost.by_ticket || []).filter(function (r) { return r.ticket === card.id; })[0];

--- a/scripts/board.mjs
+++ b/scripts/board.mjs
@@ -263,6 +263,12 @@ export function crossBoard({ initiatives, errors, warned = [], stop = null }) {
     totals: {
       initiatives: initiatives.length,
       agents: agents.length,
+      // Of those, how many the journal has moved on without. `agents` counts
+      // OPEN spawns, which is what it has always counted and what the strip
+      // lists — but presenting that number as "running" made a week-old ghost
+      // indistinguishable from an agent working right now, and an overnight
+      // operator reads this tile before anything else on the page.
+      agents_stale: agents.filter((a) => a.stale === true).length,
       merged,
       tickets,
       percent: tickets === 0 ? 0 : Math.round((merged / tickets) * 100),
@@ -306,8 +312,12 @@ export function crossJson(payload) {
 export function renderCrossMd(payload) {
   const parts = [GENERATED_MD_HEADER, '# BOARD — all initiatives\n\n'];
   const t = payload.totals;
+  // "open", not "running": the headline used to assert that every open spawn
+  // was live work, and the stale ones are named right after it rather than
+  // being quietly dropped from the count (ADR-19 correction 1).
   parts.push(
-    `**${t.agents} agent(s) running across ${t.initiatives} initiative(s) · ` +
+    `**${t.agents} agent(s) open across ${t.initiatives} initiative(s)` +
+      `${t.agents_stale > 0 ? `, ${t.agents_stale} stale` : ''} · ` +
       `${t.merged}/${t.tickets} tickets merged (${t.percent}%) · as of ${inline(payload.as_of)}**\n`,
   );
   // First, and above the pause: a STOP outranks everything. It is the one

--- a/scripts/doctor.mjs
+++ b/scripts/doctor.mjs
@@ -39,7 +39,15 @@ import { existsSync, readFileSync, readdirSync, realpathSync, statSync } from 'n
 import { join, dirname, resolve, basename } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { checkHooks, DEFAULT_PLUGIN_ROOT } from './hooks-check.mjs';
-import { readJournal, validateJournal, pairSpawns, tail } from './journal.mjs';
+import {
+  readJournal,
+  validateJournal,
+  pairSpawns,
+  tail,
+  hoursBetween,
+  spawnStaleness,
+  DEFAULT_STALE_HOURS,
+} from './journal.mjs';
 import {
   boardOf,
   checkFile,
@@ -59,8 +67,14 @@ import { parseMistakes, countSignatures, fenceState, KNOWLEDGE_THRESHOLD, MISTAK
 /** Severity order is also the report order. `info` never fails the check. */
 export const SEVERITIES = Object.freeze(['error', 'warning', 'info']);
 
-/** Default: an agent open this long without the journal moving on is stuck. */
-export const DEFAULT_STALE_HOURS = 4;
+/**
+ * Default: an agent open this long without the journal moving on is stuck.
+ *
+ * Re-exported, not redefined. The threshold and the comparison both live in
+ * `journal.mjs` so the board renders doctor's answer instead of computing a
+ * second one — `--stale-hours` still moves it for this report alone.
+ */
+export { DEFAULT_STALE_HOURS };
 
 const JOURNAL_FILE = 'journal.jsonl';
 
@@ -300,12 +314,8 @@ function isDirectory(path) {
   }
 }
 
-function hoursBetween(fromTs, toTs) {
-  const from = Date.parse(fromTs);
-  const to = Date.parse(toTs);
-  if (Number.isNaN(from) || Number.isNaN(to)) return null;
-  return (to - from) / 3_600_000;
-}
+// `hoursBetween` is imported from journal.mjs, next to the staleness rule it
+// serves — see the note on `spawnStaleness` for why that rule cannot live here.
 
 // -------------------------------------------------------- policy analysis
 
@@ -722,7 +732,10 @@ function spawnFindings(journalPath, at, dirName, events, reference, staleHours) 
   const signals = lastSignals(events);
   for (const agent of sortedNames(open.keys())) {
     for (const spawn of open.get(agent)) {
-      const age = reference === null ? null : hoursBetween(spawn.ts, reference);
+      // The shared rule, not a local one: the board reads the same predicate,
+      // so an agent doctor calls abandoned can never still read `running`
+      // there. `--stale-hours` moves the threshold for this report alone.
+      const { ageHours: age, stale } = spawnStaleness(spawn.ts, reference, staleHours);
       const where = `${show(spawn.data.ticket ?? 'no ticket')}, role ${show(spawn.data.role)}`;
       // `lastSignals` is keyed by agent NAME, and ADR-18 permits a name to be
       // re-spawned once its previous spawn is closed — so the latest signal
@@ -745,7 +758,7 @@ function spawnFindings(journalPath, at, dirName, events, reference, staleHours) 
             closeSpawnHint(journalPath, spawn.init ?? dirName, agent),
           ),
         );
-      } else if (age !== null && age >= staleHours) {
+      } else if (stale) {
         findings.push(
           finding(
             'spawn-stale',

--- a/scripts/journal.mjs
+++ b/scripts/journal.mjs
@@ -331,6 +331,74 @@ export function pairSpawns(events) {
   return { open, orphanReports, badNames, pairs, unusable, ambiguous };
 }
 
+/**
+ * The one `checkpoint.phase` value that MEANS something to a reader.
+ *
+ * `phase` is otherwise free text — the field carries epic labels (`E2`),
+ * lifecycle notes (`resumed`, `usage-limit-pause`) and whatever else a
+ * conductor finds useful, and it stays that way. This single value is
+ * reserved: it says the initiative is over, which is the one thing a
+ * projection cannot infer from any other event. Nothing in `EVENT_TYPES`
+ * closes an initiative, so before this an initiative could be wound up with
+ * its spawns still open, and every consumer went on calling those agents
+ * live for as long as the journal survived.
+ *
+ * Compared case-insensitively and trimmed, because it is written by hand.
+ */
+export const CLOSED_PHASE = 'closed';
+
+/** Does this checkpoint's phase declare the initiative over? */
+export function isClosingPhase(phase) {
+  return typeof phase === 'string' && phase.trim().toLowerCase() === CLOSED_PHASE;
+}
+
+/**
+ * How long an open spawn may stand, in JOURNAL time, before it is stale.
+ *
+ * Lives here rather than in either consumer because both `doctor.mjs` and
+ * `project.mjs` have to answer the same question and neither may own it:
+ * doctor imports the projection, so the projection cannot import doctor back.
+ * It is the same reasoning `pairSpawns` above records — the projection used to
+ * compute "who is still working" with a rule of its own, and the operator got
+ * two contradictory pictures. Staleness was the half of that answer still
+ * written twice: doctor said an agent had been abandoned while the board went
+ * on calling it `running` forever.
+ */
+export const DEFAULT_STALE_HOURS = 4;
+
+/** Hours between two ISO timestamps, or null if either is unparseable. */
+export function hoursBetween(fromTs, toTs) {
+  const from = Date.parse(fromTs);
+  const to = Date.parse(toTs);
+  if (Number.isNaN(from) || Number.isNaN(to)) return null;
+  return (to - from) / 3_600_000;
+}
+
+/**
+ * Is this open spawn stale, measured against the initiative's own movement?
+ *
+ * `reference` is the journal's latest timestamp, NOT the wall clock, and that
+ * is the whole point: staleness here means "the initiative moved on without
+ * it", which is a property of the recorded history and reads the same in six
+ * months as it does now. A wall-clock rule would instead call every agent in
+ * a finished initiative stale the moment you walked away from it.
+ *
+ * That also keeps `board.json` byte-exact under `--check`: the answer is
+ * derived from event timestamps, so two clones of one journal agree. The
+ * `age-fresh/warm/cold/dead` colours on the HTML page are a DIFFERENT
+ * question — "how long since it last spoke, right now, in the reader's own
+ * timezone" — computed client-side precisely because the artefact may not
+ * read a clock. An agent can be `age-dead` (quiet for hours) without being
+ * stale, and stale without being `age-dead`.
+ *
+ * Returns the age alongside the verdict so a caller that reports the number
+ * does not recompute it — the same additive shape `pairSpawns` returns.
+ */
+export function spawnStaleness(spawnTs, reference, staleHours = DEFAULT_STALE_HOURS) {
+  const ageHours = reference === null || reference === undefined ? null : hoursBetween(spawnTs, reference);
+  return { ageHours, stale: ageHours !== null && ageHours >= staleHours, staleHours };
+}
+
 /** Agents whose `spawn` has no matching `report` or `review` yet — the "still working" set. */
 export function openSpawns(file) {
   const { open } = pairSpawns(readJournal(file).events);

--- a/scripts/project.mjs
+++ b/scripts/project.mjs
@@ -28,7 +28,7 @@ import {
 } from 'node:fs';
 import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { readJournal, pairSpawns } from './journal.mjs';
+import { readJournal, pairSpawns, spawnStaleness, isClosingPhase, DEFAULT_STALE_HOURS } from './journal.mjs';
 import { escapeInvisible, jsonEscapeInvisible } from './invisible.mjs';
 
 /** Projection file names. Both are fully generated — never hand-edited. */
@@ -50,6 +50,26 @@ const GENERATED_HEADER =
  * a session whose gate this module already considers closed.
  */
 export const GATE_PASS = new Set(['pass', 'passed', 'ok', 'green', 'approved', 'closed', 'answered']);
+
+/**
+ * Gate results that mean the gate SAID NO — as opposed to not having answered.
+ *
+ * Enumerated rather than derived as "anything that is not a pass", which was
+ * the first shape of this and was wrong in a way the demo fixture caught at
+ * once: it classified `open` — a gate that has not run yet — as a refusal, so
+ * every pending gate carried a permanent objection it had never raised. A mark
+ * that fires on everything says nothing, which is the same argument the board
+ * makes for only ageing the lanes where standing still IS the defect.
+ *
+ * A refusal spelled some way this set has never seen is therefore missed
+ * rather than invented. That is the safer direction: a missing mark leaves the
+ * reader where they already were, while a false one sends them to re-open a
+ * decision nobody ever objected to.
+ */
+export const GATE_REFUSAL = new Set([
+  'deny', 'denied', 'fail', 'failed', 'red', 'refuse', 'refused',
+  'reject', 'rejected', 'changes-requested', 'changes_requested', 'changes-needed', 'blocked',
+]);
 
 /** A gate result that means "a human owes an answer" — the board's queue. */
 export const WAITING_RE = /^waiting[_-]?on[_-]?(operator|owner|human)$/i;
@@ -185,6 +205,31 @@ function sortByKey(items, keyOf) {
     .map(([item]) => item);
 }
 
+/**
+ * The first of several near-synonymous descriptive keys that actually carries
+ * text, or null when none does.
+ *
+ * `data` may always carry extra keys (journal.mjs), and agents improvise: the
+ * same sentence arrives as `text` from one and `note` from another. Reading
+ * one and ignoring the rest is how prose gets written and never read.
+ *
+ * `evidence` may be a LIST — docs/journal.md's `evidence[]` — so a list of
+ * strings is joined rather than stringified into `[object Object]`. An empty
+ * string and a whitespace-only string are not text; falling through to the
+ * next candidate is better than rendering a blank cell that looks like a
+ * missing feature.
+ */
+function firstText(...values) {
+  for (const value of values) {
+    if (typeof value === 'string' && value.trim() !== '') return value;
+    if (Array.isArray(value)) {
+      const parts = value.filter((v) => typeof v === 'string' && v.trim() !== '');
+      if (parts.length > 0) return parts.join(' · ');
+    }
+  }
+  return null;
+}
+
 /** A Markdown table, or an explicitly empty marker — never a hidden section. */
 function table(headers, rows) {
   if (rows.length === 0) return '_none_\n';
@@ -304,6 +349,11 @@ export function fold({ events = [], truncatedTail = false, badLines = [] } = {})
     // `ticket.status` events naming a ticket no other event mentions
     unknownOverrides: [],
     unknownErrorTickets: [],
+    // Spawns a closing checkpoint closed without a report of their own.
+    // Counted and named rather than silently flipped (ADR-19 correction 1):
+    // an agent that never reported is a hole in the record, and a close is
+    // the moment to say so, not to tidy it away.
+    closedBySpawn: [],
   };
 
   /**
@@ -409,6 +459,8 @@ export function fold({ events = [], truncatedTail = false, badLines = [] } = {})
           status: 'running',
           verdict: null,
           reportTs: null,
+          // Set only by a closing checkpoint — see the `checkpoint` fold.
+          closedTs: null,
         };
         // An unusable name is NOT a correlator, so pairSpawns excludes it — and
         // this row must say so. The two answers that were available were
@@ -455,7 +507,24 @@ export function fold({ events = [], truncatedTail = false, badLines = [] } = {})
         }
         if (data.ticket != null) {
           const t = ticketOf(data.ticket, ts);
-          t.report = { verdict: data.verdict ?? null, ts, by: data.agent ?? actor };
+          t.report = {
+            verdict: data.verdict ?? null,
+            ts,
+            by: data.agent ?? actor,
+            // WHAT the agent said, not just whether it passed.
+            //
+            // Agents write prose on a report — `text`, `note`, `evidence` —
+            // and this fold read none of it, so a verdict of `changes-needed`
+            // arrived on the board with the reason it was written next to it
+            // silently discarded. `decision` already folds `data.text` and
+            // `gate` already folds `evidence_ref ?? evidence`; a report was
+            // the one carrier of description that wrote to nowhere.
+            //
+            // One field, coalesced in the order agents actually use, because
+            // three near-synonyms rendered as three separate rows is how the
+            // same answer ends up in three places (ADR-21).
+            text: firstText(data.text, data.note, data.evidence),
+          };
           t.override = null; // a lifecycle event outranks a hand-set lane
           t.error = null;
         }
@@ -514,9 +583,13 @@ export function fold({ events = [], truncatedTail = false, badLines = [] } = {})
       case 'gate': {
         const kind = String(data.kind ?? '(no kind)');
         const prev = state.gates.get(kind);
+        const result = data.result ?? null;
+        // A refusal is a gate that SAID NO, not one that has yet to answer —
+        // see GATE_REFUSAL for why this is a named set rather than "not a pass".
+        const refused = GATE_REFUSAL.has(String(result ?? '').trim().toLowerCase());
         state.gates.set(kind, {
           kind,
-          result: data.result ?? null,
+          result,
           ts,
           evidence: data.evidence_ref ?? data.evidence ?? null,
           // extra data keys are legal on append; the ask fields ride along so
@@ -527,6 +600,20 @@ export function fold({ events = [], truncatedTail = false, badLines = [] } = {})
           recommendation: data.recommendation ?? null,
           default: data.default ?? null,
           count: (prev?.count ?? 0) + 1,
+          // Gate results are keyed by `kind`, so the latest one wins the slot —
+          // and a re-run that passes therefore ERASED the refusal that came
+          // before it. That is precisely the signal a gate exists to raise:
+          // "the security gate denied this, then someone re-ran it green" and
+          // "the security gate has only ever passed" rendered identically, and
+          // the second reading is the one an operator took away.
+          //
+          // `count` already survived, so the VOLUME was never lost — only the
+          // verdict. So this is additive and narrow: the last refusal is kept
+          // beside the current result, never instead of it, and the counter is
+          // left exactly as it was.
+          lastRefusal: refused
+            ? { result, ts, evidence: data.evidence_ref ?? data.evidence ?? null, ticket: data.ticket ?? null }
+            : prev?.lastRefusal ?? null,
         });
         break;
       }
@@ -572,9 +659,34 @@ export function fold({ events = [], truncatedTail = false, badLines = [] } = {})
         else state.mismatchedReleases.push({ resource: key, by: data.holder ?? null, holder: held?.holder ?? null, ts });
         break;
       }
-      case 'checkpoint':
+      case 'checkpoint': {
         state.checkpoint = { phase: data.phase ?? null, nextSteps: data.next_steps, ts, actor };
+        // A closing checkpoint closes the initiative's still-open spawns.
+        //
+        // This fold used to record the checkpoint and nothing else, so an
+        // initiative could be explicitly wound up while three agents that
+        // never reported stayed `running` in every artefact forever. No other
+        // event closes an initiative, which is why the meaning has to hang on
+        // this one reserved phase value.
+        //
+        // Only spawns folded BEFORE this point: the pass runs in event order,
+        // so an agent spawned after the checkpoint is a new incarnation and
+        // keeps its own lifecycle. And only `running` ones — a spawn already
+        // paired with a report, or excluded for an unusable name, has an
+        // answer of its own that this must not overwrite.
+        if (isClosingPhase(data.phase)) {
+          for (const a of state.agents) {
+            if (a.status !== 'running') continue;
+            a.status = 'closed with the initiative (no report)';
+            // Not a report: the agent never filed one, and pretending it did
+            // would put a verdict on the row that nobody earned. The time is
+            // when the initiative ended, which is what "since" means here.
+            a.closedTs = ts;
+            state.closedBySpawn.push({ agent: a.agent, ticket: a.ticket ?? null, spawnTs: a.spawnTs, ts });
+          }
+        }
         break;
+      }
       case 'retro.entry':
         state.retro.push({ kind: data.kind ?? null, target: data.target ?? null, confidence: data.confidence ?? null, ts });
         break;
@@ -678,7 +790,7 @@ export const APPROVING_RE = /^approv|^lgtm$|^pass/i;
  *   in-progress > ready (all deps merged; an UNKNOWN dep counts unmet — a
  *   typo must refuse to schedule, not schedule) > backlog.
  */
-export function boardOf(state) {
+export function boardOf(state, { staleHours = DEFAULT_STALE_HOURS } = {}) {
   const lanes = new Map(LANES.map((lane) => [lane, []]));
   const runningByTicket = new Map();
   for (const a of state.agents) {
@@ -792,6 +904,11 @@ export function boardOf(state) {
       // board dropped it.
       worked_by: sortedUnique(t.agents),
       since: t.lastTs,
+      // What the agent SAID when it handed the ticket back, not only whether
+      // it passed. A `changes-needed` card used to arrive with its reason
+      // discarded at fold time, so the board could say a ticket had come back
+      // and never why — the one thing the reader opens the card for.
+      report_text: t.report?.text ?? null,
       annotation: annotations.length > 0 ? annotations.join(' · ') : null,
     });
   }
@@ -801,11 +918,30 @@ export function boardOf(state) {
     .map((a) => {
       const signal = state.progressByAgent.get(a.agent) ?? null;
       const evidence = state.evidenceByAgent.get(a.agent) ?? null;
+      // Doctor's rule, imported rather than restated (ADR-21). Nothing here
+      // ever downgraded a spawn, so an agent that never reported stayed
+      // `running` forever and the header counted week-old ghosts as live —
+      // while doctor, reading the same journal, had been calling them
+      // abandoned the whole time. Two answers, one question.
+      //
+      // Measured against `state.lastTs`, the journal's own latest event, so
+      // this stays clock-free like the rest of `boardOf`: `board.json` is
+      // byte-compared by `--check`, and a wall-clock verdict would make two
+      // clones of one journal disagree. It is also the more useful meaning —
+      // stale is "the initiative moved on without it", not "you looked late".
+      const { ageHours, stale } = spawnStaleness(a.spawnTs, state.lastTs, staleHours);
       return {
         agent: a.agent,
         role: a.role,
         ticket: a.ticket,
-        state: signal?.state ?? 'running',
+        // `blocked` outranks `stale`: it is the agent's own account of why it
+        // stopped, and it is what the waiting-operator tile counts. Staleness
+        // is what we infer when there is no such account.
+        state: signal?.state === 'blocked' ? 'blocked' : stale ? 'stale' : signal?.state ?? 'running',
+        // Carried separately as well, because `state` is one slot and a
+        // consumer may want the verdict without losing what the agent said.
+        stale,
+        open_hours: ageHours === null ? null : Math.round(ageHours * 10) / 10,
         detail: signal?.detail ?? null,
         next: signal?.next ?? null,
         last_signal: signal?.ts ?? a.spawnTs,
@@ -970,6 +1106,17 @@ export function warnings(state) {
   for (const { raw, problem } of state.unusableAgentNames) {
     out.push(`unusable data.agent ${inlinePlain(raw)}: ${problem} — excluded from spawn/report pairing`);
   }
+  // A close that closed something is a fact about the record, not bookkeeping:
+  // these agents never said how their work ended, and the checkpoint decided
+  // for them. Naming them is what makes the difference between "finished" and
+  // "stopped being tracked" visible after the fact.
+  for (const { agent, ticket } of state.closedBySpawn) {
+    out.push(
+      `agent ${inlinePlain(agent)} was still open when the initiative closed${
+        ticket == null ? '' : ` (ticket ${inlinePlain(ticket)})`
+      } — closed by the checkpoint, with no report of its own`,
+    );
+  }
   // The state ADR-18 makes unrepresentable through `append`, and which the
   // projection no longer silently guesses at now that ticket-first is gone.
   for (const { agent, count } of state.ambiguousAgents) {
@@ -1094,14 +1241,19 @@ function renderState(state) {
   );
 
   parts.push('\n## All gates\n\n');
+  // "Last refusal" is the column that makes a re-run visible. The latest
+  // result wins the row, so a gate that denied and was then re-run green read
+  // exactly like a gate that had never objected to anything — the one reading
+  // an operator must not be given by accident.
   parts.push(
     table(
-      ['Gate', 'Latest result', 'Events', 'At'],
+      ['Gate', 'Latest result', 'Events', 'At', 'Last refusal'],
       sortByKey([...state.gates.values()], (g) => g.kind).map((g) => [
         inline(g.kind),
         inline(g.result),
         String(g.count),
         inline(g.ts),
+        g.lastRefusal == null ? inline(null) : `${inline(g.lastRefusal.result)} at ${inline(g.lastRefusal.ts)}`,
       ]),
     ),
   );

--- a/site/src/content/docs/board.mdx
+++ b/site/src/content/docs/board.mdx
@@ -449,6 +449,24 @@ The agent strip aged on `progress` events, which an agent emits at will. An
 agent looping without achieving anything therefore had the freshest chip on the
 board, and — because the strip is sorted stalest-first — sorted to the bottom.
 
+**Stale is a third thing, and it does not share their vocabulary.** The four
+colours above are wall-clock: "how long since it spoke, right now, where you
+are sitting", computed in the reader's own browser because the artefact may
+not read a clock. **Stale** is journal time, decided on the server by the same
+predicate `doctor` uses — "the initiative moved on without it" — and it reads
+the same tomorrow, and in six months, for every reader of that journal. An
+agent can be quiet for hours without being stale, and stale while chattering
+every minute. So it marks the whole chip in brass rather than joining the age
+scale: two questions sharing one vocabulary is how an operator ends up with
+two contradictory answers on one strip.
+
+The header tile counts the **live** ones and names the rest. It used to read
+"N agents running" for every open spawn, which made a fleet that died before
+you went to bed indistinguishable from one working through the night. The
+stale agents are still counted, still in the strip, and now said out loud. The
+same correction reaches `BOARD.md`, whose headline says *open* rather than
+*running*, with the stale count beside it.
+
 Every agent now carries two times. **`last_signal`** is what it SAID, from its
 own `progress` events. **`last_evidence`** is what it SHOWED: a `report` with
 its `evidence[]`, a `finding` with its proof, a `review` verdict. The strip
@@ -465,7 +483,8 @@ healthy agents is a warning people learn to scroll past.
 ## board.json, schema 1
 
 Fixed key order (`schema`, `as_of`, `totals`, `stop`, `paused`, `asks`,
-`agents` (each with `last_signal`, `last_evidence` and `since`), `files`,
+`agents` (each with `last_signal`, `last_evidence`, `since`, and `stale` /
+`open_hours` in journal time), `files`,
 `lanes`, `errors_logged`, `errors_logged_total`, `errors`,
 `warned`); timestamps copied verbatim from events; invisibles escaped as
 `\uXXXX`, never removed; byte-identical reruns. Consumers check `schema === 1`
@@ -474,6 +493,11 @@ rendering garbage.
 
 Two of those keys are easy to confuse, so they are named apart on purpose.
 **`errors`** is the list of initiatives whose journal could not be read at all.
+**`totals.agents`** counts OPEN SPAWNS, and **`totals.agents_stale`** says how
+many of those the journal has moved on without. The page shows the difference
+as its headline and names the remainder; adding the two back together is the
+reading the split exists to prevent.
+
 **`errors_logged`** is what agents recorded as failures with an `error` event —
 newest first, capped at 20 with the true count in `errors_logged_total`,
 because this artefact is committed and compared byte for byte. One key with two

--- a/site/src/content/docs/journal.mdx
+++ b/site/src/content/docs/journal.mdx
@@ -6,7 +6,7 @@ import { FileTree } from '@astrojs/starlight/components';
 import Provenance from '../../components/Provenance.astro';
 
 <Provenance>
-`scripts/journal.mjs` · 66 unit tests
+`scripts/journal.mjs` · 69 unit tests
 </Provenance>
 
 This page is the schema contract; extending the event set is a reviewed core
@@ -70,7 +70,7 @@ contents are moved, one initiative directory at a time, under `state/`.
 | `finding` | `area`, `claim` | a claim about one `area`, with its proof, queryable by other agents (+ `proof`, `ticket`, `confidence`; `append` issues `F-<n>` ids) |
 | `lease.acquired` | `resource`, `holder` | worktree / heavy-slot lease taken |
 | `lease.released` | `resource`, `holder` | lease returned |
-| `checkpoint` | `phase`, `next_steps` | resume surface (re-injected after compaction) |
+| `checkpoint` | `phase`, `next_steps` | resume surface (re-injected after compaction); `phase: closed` also closes the initiative's open spawns |
 | `retro.entry` | `kind`, `target` | self-improvement ledger (+ `confidence`) |
 | `error` | `class` | failure record (+ `detail`) |
 

--- a/site/src/content/docs/projections.mdx
+++ b/site/src/content/docs/projections.mdx
@@ -5,7 +5,7 @@ description: 'How STATE.md and PROGRESS.md are generated from the journal, the d
 import Provenance from '../../components/Provenance.astro';
 
 <Provenance>
-`scripts/project.mjs` · 69 unit tests, including byte-exact golden files
+`scripts/project.mjs` · 79 unit tests, including byte-exact golden files
 </Provenance>
 
 The journal stays the only source of truth; everything on this page is a
@@ -119,14 +119,69 @@ catch.
 | Section | Built from |
 |---|---|
 | Checkpoint | the last `checkpoint` event (+ `plan.accepted`, and the last event of any type) |
-| Agents | `spawn`, closed by the next `report` for the same agent name; the Last signal column is the agent's latest `progress` event, shown on running rows only |
+| Agents | `spawn`, closed by the next `report` for the same agent name — or by a `checkpoint` whose `phase` is `closed`; the Last signal column is the agent's latest `progress` event, shown on running rows only |
 | Open blockages | `progress` with `state: blocked` — cleared by the same agent's next movement signal and by `report`/`review`/`merge` |
 | Findings | `finding` events, in journal order |
 | Ledger | `ticket.created`, `ticket.status` (a lane override that never moves the percent, and never invents a ticket — one naming an id no other event created is ignored, loudly), `spawn`, `report`, `review`, `merge` |
-| Gates | `gate` — the latest event per `kind` |
+| Gates | `gate` — the latest event per `kind`, plus the last REFUSAL that kind ever recorded |
 | Leases | `lease.acquired` / `lease.released` |
 | Decisions · Retro · Errors | `decision` · `retro.entry` · `error` |
 | Resume steps | `checkpoint.data.next_steps` |
+
+## What the fold no longer throws away
+
+Four things the journal recorded and the projection dropped. Each was a
+question an operator asked the board, got a confident answer to, and the
+answer was wrong in the same direction: everything looked fine.
+
+**An agent the initiative moved on without is `stale`, not `running`.**
+Nothing here ever downgraded a spawn, so an agent that never reported stayed
+`running` in every artefact for as long as the journal survived — and the
+board's header counted week-old ghosts as live work. Doctor had been calling
+them abandoned the whole time, from the same events, which is two answers to
+one question. There is now one predicate, `journal.spawnStaleness`, and both
+call it.
+
+The threshold is measured in **journal time** — against the initiative's own
+latest event, not the wall clock. That is what `spawn-stale` has always meant
+("the initiative moved on without it") and it is the only version that keeps
+`board.json` byte-exact under `--check`: a wall-clock verdict would make two
+clones of one journal disagree, and would call every agent in a finished
+initiative stale the moment you walked away from it. An agent carries
+`stale` and `open_hours` alongside its state; `blocked` still outranks
+`stale`, because that is the agent's own account of why it stopped.
+
+The `age-fresh/warm/cold/dead` colours on `board.html` are a **different
+question** and keep their own vocabulary — see
+[the board](../board/#signal-is-not-evidence).
+
+**A closing checkpoint closes the spawns it leaves open.** No event type
+closes an initiative, so one could be explicitly wound up with three agents
+that never reported still running forever. A `checkpoint` whose `phase` is
+`closed` — the one reserved value in an otherwise free-text field, compared
+trimmed and case-insensitively — now closes that initiative's still-open
+spawns at fold time. Only the ones folded before it: an agent spawned after
+the checkpoint is a new incarnation and keeps its own lifecycle. They are
+closed, never reported: no verdict is invented for an agent that never filed
+one, and each is named in the warnings rather than tidied away.
+
+**A gate that passes after refusing does not erase the refusal.** Gate results
+are keyed by `kind`, so a re-run won the slot — and *"security denied this,
+then someone re-ran it green"* rendered identically to *"security has only ever
+passed"*. The event count always survived, so the volume was never lost, only
+the verdict. The last refusal is now kept beside the current result and shown
+in its own column. A refusal is a named set of results (`deny`, `fail`,
+`rejected`, …), not "anything that is not a pass" — `open` and
+`WAITING_ON_OPERATOR` are gates that have not answered yet, and a mark that
+fires on every pending gate says nothing at all.
+
+**A report carries what the agent said, not only its verdict.** `decision`
+folds its `text` and `gate` folds its `evidence`; a `report` was the one
+carrier of description that wrote to nowhere, so a `changes-needed` card
+reached the board with the reason it came back silently discarded. One field
+reads `text`, then `note`, then `evidence` — agents improvise the key, and
+three near-synonyms rendered as three rows would be the same answer in three
+places.
 
 Two details worth knowing:
 

--- a/tests/fixtures/golden/STATE.md
+++ b/tests/fixtures/golden/STATE.md
@@ -48,12 +48,12 @@
 
 ## All gates
 
-| Gate | Latest result | Events | At |
-|---|---|---|---|
-| Q-1 | WAITING_ON_OPERATOR | 1 | 2026-07-26T09:41:55.000Z |
-| Q-2 | WAITING_ON_OPERATOR | 1 | 2026-07-26T09:41:57.000Z |
-| plan-approval | open | 1 | 2026-07-26T09:35:00.000Z |
-| tests | pass | 1 | 2026-07-26T09:34:00.000Z |
+| Gate | Latest result | Events | At | Last refusal |
+|---|---|---|---|---|
+| Q-1 | WAITING_ON_OPERATOR | 1 | 2026-07-26T09:41:55.000Z | &mdash; |
+| Q-2 | WAITING_ON_OPERATOR | 1 | 2026-07-26T09:41:57.000Z | &mdash; |
+| plan-approval | open | 1 | 2026-07-26T09:35:00.000Z | &mdash; |
+| tests | pass | 1 | 2026-07-26T09:34:00.000Z | &mdash; |
 
 ## Open leases
 

--- a/tests/fixtures/golden/board.json
+++ b/tests/fixtures/golden/board.json
@@ -37,6 +37,8 @@
       "role": "implementer",
       "ticket": "T-2",
       "state": "blocked",
+      "stale": false,
+      "open_hours": 0.1,
       "detail": "waiting on the worktree lease",
       "next": null,
       "last_signal": "2026-07-26T09:41:40.000Z",
@@ -53,6 +55,7 @@
         "agents": [],
         "worked_by": [],
         "since": "2026-07-26T09:02:02.000Z",
+        "report_text": null,
         "annotation": null
       }
     ],
@@ -74,6 +77,7 @@
           "impl-2"
         ],
         "since": "2026-07-26T09:41:50.000Z",
+        "report_text": null,
         "annotation": "worktree lease held by another window"
       }
     ],
@@ -86,6 +90,7 @@
           "impl-1"
         ],
         "since": "2026-07-26T09:32:00.000Z",
+        "report_text": null,
         "annotation": null
       }
     ]

--- a/tests/unit/board.test.mjs
+++ b/tests/unit/board.test.mjs
@@ -88,7 +88,10 @@ test('two initiatives merge into one payload with per-card provenance and honest
   assert.ok(payload.asks.every((a) => a.init === 'alpha' || a.init === 'beta'));
   assert.deepEqual(Object.keys(payload.lanes), [...LANES]);
   const md = renderCrossMd(payload);
-  assert.match(md, /2 agent\(s\) running across 2 initiative\(s\)/);
+  // "open", not "running": the headline counts OPEN SPAWNS, and calling every
+  // one of those running is what let a week-old ghost read as live work.
+  assert.match(md, /2 agent\(s\) open across 2 initiative\(s\)/);
+  assert.doesNotMatch(md, /stale/, 'neither agent is stale, so the headline says nothing about staleness');
   assert.match(md, /## Waiting on you/);
 });
 
@@ -193,7 +196,7 @@ test('an empty state directory renders an honest empty board, exit 0', () => {
   const r = run(['--dir', dir]);
   assert.equal(r.code, 0);
   const md = readFileSync(join(dir, 'state', BOARD_FILE), 'utf8');
-  assert.match(md, /0 agent\(s\) running across 0 initiative\(s\)/);
+  assert.match(md, /0 agent\(s\) open across 0 initiative\(s\)/);
 });
 
 test('the page fetches spend rather than embedding it, so the artefacts stay byte-exact', () => {
@@ -783,4 +786,44 @@ test('the page shows signal and evidence as two different facts', () => {
   const html = demoHtml();
   assert.match(html, /nothing shown yet/, 'an agent that has shown nothing says so');
   assert.match(html, /a\.evidence_kind/, 'and what it showed is named');
+});
+
+test('the header counts LIVE agents, and says how many are stale', () => {
+  // MUTANT: drop agents_stale, or count every open spawn as running. The tile
+  // an overnight operator reads first said "3 agents running" for a fleet that
+  // died before they went to bed — an open spawn and live work are not the
+  // same fact, and the header was asserting the second from the first.
+  const agents = [
+    { agent: 'a', state: 'running', stale: false, last_evidence: null, since: '2026-07-26T09:00:00.000Z' },
+    { agent: 'b', state: 'stale', stale: true, last_evidence: null, since: '2026-07-26T01:00:00.000Z' },
+  ];
+  const payload = crossBoard({
+    initiatives: [{
+      name: 'demo',
+      state: { merged: 0, ticketList: [], lastTs: '2026-07-26T10:00:00.000Z', errors: [] },
+      board: { asks: [], agents, paused: null, lanes: new Map(LANES.map((l) => [l, []])) },
+    }],
+    errors: [],
+  });
+  assert.equal(payload.totals.agents, 2, 'both are still counted — a stale agent is not deleted');
+  assert.equal(payload.totals.agents_stale, 1);
+  const md = renderCrossMd(payload);
+  assert.match(md, /2 agent\(s\) open across 1 initiative\(s\), 1 stale/);
+  // And the page separates the two numbers rather than adding them together.
+  const html = renderBoardHtml(crossJson(payload));
+  assert.match(html, /agents_stale/, 'the client reads the stale count');
+  assert.match(html, /STALE — open/, 'and marks the chip in journal time, not wall-clock');
+});
+
+test('the stale mark is a SERVER verdict, kept apart from the wall-clock colours', () => {
+  // MUTANT: render staleness with ageClass, or compute it from Date.now() in
+  // the client. The page already has an age vocabulary — fresh/warm/cold/dead —
+  // and it answers a different question: "how long since it spoke, right now,
+  // where you are sitting". Staleness is journal time and is the same for every
+  // reader of the journal, forever. One vocabulary for two questions is how an
+  // operator ends up with two contradictory answers on one strip.
+  const html = renderBoardHtml(crossJson(crossBoard({ initiatives: [], errors: [] })));
+  assert.match(html, /journal time/, 'the chip says which clock it used');
+  assert.match(html, /\.agent\.stale\{/, 'and it is styled as its own thing');
+  assert.doesNotMatch(html, /ageClass\(\s*a\.open_hours/, 'never coloured by the wall-clock scale');
 });

--- a/tests/unit/journal.test.mjs
+++ b/tests/unit/journal.test.mjs
@@ -23,6 +23,9 @@ import {
   nextId,
   tail,
   openSpawns,
+  spawnStaleness,
+  isClosingPhase,
+  DEFAULT_STALE_HOURS,
   closeSpawn,
   pairSpawns,
   agentNameProblem,
@@ -1245,4 +1248,41 @@ test('a review cannot close a colliding non-reviewer spawn', () => {
   assert.equal(pairSpawns(readJournal(f).events).pairs.length, 0);
   // and ADR-18 still refuses a second live spawn of the same name
   assert.throws(() => append(f, spawnEv('worker-1')), /already has an open spawn/);
+});
+
+// --- the one staleness rule, and the one closing phase -------------------
+
+test('spawnStaleness is measured in JOURNAL time and owns the threshold', () => {
+  // This predicate exists so doctor and the board cannot disagree. It lived in
+  // doctor alone, and the projection had no notion of staleness at all — so an
+  // agent doctor called abandoned went on reading `running` on the board for as
+  // long as the journal survived. MUTANT: compare against Date.now().
+  const spawn = '2026-07-26T09:00:00.000Z';
+  assert.equal(spawnStaleness(spawn, '2026-07-26T12:59:00.000Z').stale, false, 'under 4 h');
+  assert.equal(spawnStaleness(spawn, '2026-07-26T13:00:00.000Z').stale, true, 'AT the threshold is stale');
+  assert.equal(spawnStaleness(spawn, '2026-07-26T13:00:00.000Z').ageHours, 4);
+  assert.equal(spawnStaleness(spawn, '2026-07-26T11:00:00.000Z', 2).stale, true, 'the threshold is a parameter');
+  assert.equal(DEFAULT_STALE_HOURS, 4);
+});
+
+test('an unreadable or absent reference is not a staleness verdict', () => {
+  // MUTANT: default ageHours to 0, or treat null as stale. A journal whose
+  // last timestamp cannot be parsed knows nothing about how long anything has
+  // been open, and guessing either way is worse than saying so.
+  for (const reference of [null, undefined, 'not-a-timestamp']) {
+    const r = spawnStaleness('2026-07-26T09:00:00.000Z', reference);
+    assert.equal(r.ageHours, null, `reference ${JSON.stringify(reference)}`);
+    assert.equal(r.stale, false, 'no reference is "unknown", never "stale"');
+  }
+  assert.equal(spawnStaleness('nonsense', '2026-07-26T09:00:00.000Z').stale, false);
+});
+
+test('exactly one checkpoint phase closes an initiative', () => {
+  // `phase` is free text — it carries epic labels and lifecycle notes — so the
+  // one value that MEANS something is compared trimmed and case-insensitively,
+  // and everything else is left alone.
+  for (const yes of ['closed', 'CLOSED', 'Closed', '  closed  ']) assert.equal(isClosingPhase(yes), true, yes);
+  for (const no of ['closing', 'close', 'E2', 'resumed', 'usage-limit-pause', '', null, undefined, 3]) {
+    assert.equal(isClosingPhase(no), false, JSON.stringify(no));
+  }
 });

--- a/tests/unit/project.test.mjs
+++ b/tests/unit/project.test.mjs
@@ -1299,3 +1299,179 @@ test('writeAllAtomic leaves no orphaned .tmp when a RENAME fails', () => {
   const leftovers = readdirSync(out).filter((f) => f.endsWith('.tmp'));
   assert.deepEqual(leftovers, [], `orphaned temp files: ${leftovers}`);
 });
+
+// --- staleness, closure, refusals and report prose ----------------------
+
+/** A spawn/checkpoint pair at chosen times, for the staleness rules below. */
+const spawnAt = (ts, agent = 'impl-1', over = {}) =>
+  ev({ ev: 'spawn', ts, data: { agent, role: 'implementer', ticket: 'T-1', ...over } });
+
+test('an agent the initiative moved on without is stale, not running', () => {
+  // MUTANT: drop the `stale` term from the state expression in boardOf. The
+  // strip goes back to reporting `running` for an agent that never reported,
+  // which is what let a week-old ghost be counted as live work — while doctor,
+  // reading the same journal, had been calling it abandoned the whole time.
+  const { events } = { events: [
+    T('T-1'),
+    spawnAt('2026-07-26T09:00:00.000Z'),
+    // The journal moves on five hours without that agent: past the 4 h default.
+    ev({ ev: 'checkpoint', ts: '2026-07-26T14:00:00.000Z' }),
+  ] };
+  const board = boardOf(fold({ events }));
+  assert.equal(board.agents.length, 1, 'still listed — stale is not hidden');
+  assert.equal(board.agents[0].state, 'stale');
+  assert.equal(board.agents[0].stale, true);
+  assert.equal(board.agents[0].open_hours, 5);
+});
+
+test('staleness is JOURNAL time, so the same journal reads the same forever', () => {
+  // MUTANT: measure against Date.now() instead of state.lastTs. The fixture
+  // below is years old in wall-clock terms and would be stale under any
+  // real-time rule — but its own journal moved only one hour, so it is not.
+  // This is also what keeps board.json byte-exact under `--check`.
+  const board = boardOf(fold({ events: [
+    T('T-1'),
+    spawnAt('2026-07-26T09:00:00.000Z'),
+    ev({ ev: 'checkpoint', ts: '2026-07-26T10:00:00.000Z' }),
+  ] }));
+  assert.equal(board.agents[0].stale, false, 'one hour of journal movement is not stale');
+  assert.equal(board.agents[0].state, 'running');
+});
+
+test('a blocked agent keeps saying blocked even once it is stale', () => {
+  // MUTANT: reorder the state expression so `stale` wins. `blocked` is the
+  // agent's own account of why it stopped and it is what the needs-a-human
+  // tile counts, so a staleness verdict must not swallow it.
+  const board = boardOf(fold({ events: [
+    T('T-1'),
+    spawnAt('2026-07-26T09:00:00.000Z'),
+    ev({ ev: 'progress', ts: '2026-07-26T09:05:00.000Z', data: { agent: 'impl-1', state: 'blocked', detail: 'needs the lease' } }),
+    ev({ ev: 'checkpoint', ts: '2026-07-26T18:00:00.000Z' }),
+  ] }));
+  assert.equal(board.agents[0].state, 'blocked', 'the agent said why it stopped');
+  assert.equal(board.agents[0].stale, true, 'and it is ALSO stale — both are true, both are carried');
+});
+
+test('the board and doctor answer staleness with the same predicate', () => {
+  // ADR-21, enforced rather than asserted in prose: the two consumers must not
+  // drift. Reading the threshold through boardOf's own option proves the board
+  // is calling the shared rule and not a copy that happens to agree today.
+  const events = [T('T-1'), spawnAt('2026-07-26T09:00:00.000Z'), ev({ ev: 'checkpoint', ts: '2026-07-26T12:00:00.000Z' })];
+  assert.equal(boardOf(fold({ events })).agents[0].stale, false, '3 h is under the 4 h default');
+  assert.equal(boardOf(fold({ events }), { staleHours: 2 }).agents[0].stale, true, 'and over a 2 h threshold');
+});
+
+test('a closing checkpoint closes the spawns it leaves open', () => {
+  // MUTANT: delete the isClosingPhase branch in the checkpoint fold. An
+  // initiative could then be explicitly wound up with three agents that never
+  // reported still `running` in every artefact, forever — nothing else in
+  // EVENT_TYPES closes an initiative, so nothing would ever correct it.
+  const state = fold({ events: [
+    T('T-1'),
+    spawnAt('2026-07-26T09:00:00.000Z', 'impl-1'),
+    spawnAt('2026-07-26T09:01:00.000Z', 'impl-2'),
+    ev({ ev: 'report', ts: '2026-07-26T09:30:00.000Z', data: { agent: 'impl-2', verdict: 'done', ticket: 'T-1' } }),
+    ev({ ev: 'checkpoint', ts: '2026-07-26T09:40:00.000Z', data: { phase: 'closed', next_steps: [] } }),
+  ] });
+  assert.equal(boardOf(state).agents.length, 0, 'nothing is still running after the close');
+  const closed = state.agents.find((a) => a.agent === 'impl-1');
+  assert.match(closed.status, /closed with the initiative/);
+  assert.equal(closed.verdict, null, 'a close is not a report — no verdict it never earned');
+  assert.equal(state.agents.find((a) => a.agent === 'impl-2').status, 'reported', 'its own report stands');
+  // Counted and named, never tidied away (ADR-19 correction 1).
+  assert.equal(state.closedBySpawn.length, 1);
+  assert.match(warnings(state).join('\n'), /impl-1.*still open when the initiative closed/);
+});
+
+test('a spawn AFTER the close keeps its own lifecycle', () => {
+  // MUTANT: close open spawns from the whole journal rather than the ones
+  // folded so far. The pass runs in event order for a reason — an agent
+  // spawned after the checkpoint is a new incarnation, not a ghost.
+  const state = fold({ events: [
+    T('T-1'),
+    ev({ ev: 'checkpoint', ts: '2026-07-26T09:00:00.000Z', data: { phase: 'closed', next_steps: [] } }),
+    spawnAt('2026-07-26T09:10:00.000Z', 'impl-late'),
+  ] });
+  assert.equal(state.agents.find((a) => a.agent === 'impl-late').status, 'running');
+  assert.equal(state.closedBySpawn.length, 0);
+});
+
+test('only the reserved phase closes anything', () => {
+  // `phase` is free text and carries epic labels (`E2`), `resumed` and
+  // `usage-limit-pause`. Exactly one value may mean "this is over".
+  for (const phase of ['E2', 'resumed', 'usage-limit-pause', 'closing', '']) {
+    const state = fold({ events: [
+      T('T-1'),
+      spawnAt('2026-07-26T09:00:00.000Z'),
+      ev({ ev: 'checkpoint', ts: '2026-07-26T09:40:00.000Z', data: { phase, next_steps: [] } }),
+    ] });
+    assert.equal(state.agents[0].status, 'running', `phase ${JSON.stringify(phase)} must not close a spawn`);
+  }
+  // Written by hand, so compared trimmed and case-insensitively.
+  for (const phase of ['closed', 'CLOSED', '  Closed  ']) {
+    const state = fold({ events: [
+      T('T-1'),
+      spawnAt('2026-07-26T09:00:00.000Z'),
+      ev({ ev: 'checkpoint', ts: '2026-07-26T09:40:00.000Z', data: { phase, next_steps: [] } }),
+    ] });
+    assert.match(state.agents[0].status, /closed with the initiative/, `phase ${JSON.stringify(phase)}`);
+  }
+});
+
+test('a gate that passes after denying does not erase the denial', () => {
+  // MUTANT: drop `lastRefusal` from the gate fold. Gate results are keyed by
+  // kind, so the re-run wins the slot — and "security denied this, then someone
+  // re-ran it green" then renders identically to "security has only ever
+  // passed". The second reading is the one an operator takes away.
+  const state = fold({ events: [
+    ev({ ev: 'gate', ts: '2026-07-26T09:00:00.000Z', data: { kind: 'security', result: 'deny', evidence: 'CVE-1' } }),
+    ev({ ev: 'gate', ts: '2026-07-26T09:30:00.000Z', data: { kind: 'security', result: 'pass' } }),
+  ] });
+  const gate = state.gates.get('security');
+  assert.equal(gate.result, 'pass', 'the latest result is still the latest result');
+  assert.equal(gate.count, 2, 'the counter is untouched — volume was never the thing that was lost');
+  assert.equal(gate.lastRefusal.result, 'deny');
+  assert.equal(gate.lastRefusal.ts, '2026-07-26T09:00:00.000Z');
+  assert.equal(gate.lastRefusal.evidence, 'CVE-1', 'the evidence for the refusal survives with it');
+  assert.match(renderProjections({ events: [
+    ev({ ev: 'gate', ts: '2026-07-26T09:00:00.000Z', data: { kind: 'security', result: 'deny' } }),
+    ev({ ev: 'gate', ts: '2026-07-26T09:30:00.000Z', data: { kind: 'security', result: 'pass' } }),
+  ] }).files[STATE_FILE], /Last refusal/, 'and it reaches the document');
+});
+
+test('a gate that has not answered yet has refused nothing', () => {
+  // MUTANT: define a refusal as "not a pass". `open` and `WAITING_ON_OPERATOR`
+  // are gates that have not run and gates awaiting a human — neither has
+  // objected to anything, and a mark that fires on every pending gate says
+  // nothing at all.
+  const state = fold({ events: [
+    ev({ ev: 'gate', ts: '2026-07-26T09:00:00.000Z', data: { kind: 'plan-approval', result: 'open' } }),
+    ev({ ev: 'gate', ts: '2026-07-26T09:01:00.000Z', data: { kind: 'Q-1', result: 'WAITING_ON_OPERATOR' } }),
+    ev({ ev: 'gate', ts: '2026-07-26T09:02:00.000Z', data: { kind: 'tests', result: 'pass' } }),
+  ] });
+  for (const kind of ['plan-approval', 'Q-1', 'tests']) {
+    assert.equal(state.gates.get(kind).lastRefusal, null, `${kind} has refused nothing`);
+  }
+});
+
+test('a report carries WHAT the agent said, not only its verdict', () => {
+  // MUTANT: drop `text` from the report fold. `decision` folds data.text and
+  // `gate` folds evidence_ref ?? evidence; a report was the one carrier of
+  // description that wrote to nowhere, so a `changes-needed` card arrived with
+  // the reason it came back silently discarded.
+  const card = (data) => {
+    const board = boardOf(fold({ events: [
+      T('T-1'),
+      ev({ ev: 'report', ts: '2026-07-26T09:30:00.000Z', data: { agent: 'impl-1', verdict: 'changes-needed', ticket: 'T-1', ...data } }),
+    ] }));
+    return [...board.lanes.values()].flat().find((c) => c.id === 'T-1');
+  };
+  assert.equal(card({ text: 'the migration is not reversible' }).report_text, 'the migration is not reversible');
+  // Agents improvise the key; one field reads all three rather than three rows
+  // saying the same thing in three places (ADR-21).
+  assert.equal(card({ note: 'from note' }).report_text, 'from note');
+  assert.equal(card({ evidence: ['tests green', 'lint clean'] }).report_text, 'tests green · lint clean');
+  assert.equal(card({ text: 'wins', note: 'loses' }).report_text, 'wins', 'text outranks note');
+  assert.equal(card({ text: '   ', note: 'used' }).report_text, 'used', 'blank is not text');
+  assert.equal(card({}).report_text, null, 'and a report with no prose says nothing rather than empty');
+});


### PR DESCRIPTION
Four projection defects, each one a question an operator asked the board, got
a confident answer to, and the answer was wrong in the same direction:
everything looked fine.

## Stale agents (O-1)

Nothing in the projection ever downgraded a spawn, so an agent that never
reported stayed `running` in every artefact for as long as the journal
survived — and `totals.agents` counted week-old ghosts as live work. Doctor
had been calling those same spawns abandoned the whole time, from the same
events. Two answers to one question.

One predicate now, `journal.spawnStaleness`, called by both consumers;
doctor's copy is **deleted**, not kept in sync. It could not live in doctor,
which imports the projection, so it sits beside `pairSpawns` — whose own
comment records this repository solving the identical problem once already
for the adjacent question of who is still working.

The threshold is **journal time**, measured against the initiative's own
latest event. That is what `spawn-stale` has always meant, and it is the only
version that keeps `board.json` byte-exact under `--check`. `blocked` still
outranks `stale`, so `totals.blocked` is unchanged.

**The one design call worth reviewing:** `board.html` already had a staleness
vocabulary — `age-fresh/warm/cold/dead` — and it is deliberately wall-clock
and client-side, because the artefact may not read a clock. Rather than
overload it, the server verdict marks the whole chip in brass and both the
code and the docs say why: an agent can be quiet for hours without being
stale, and stale while chattering every minute.

## Closing checkpoints (O-2)

No event type closes an initiative, so one could be explicitly wound up with
agents that never reported still running forever. `checkpoint` with
`phase: closed` now closes that initiative's open spawns at fold time — only
those folded before it, without inventing a verdict, each named in the
warnings rather than tidied away.

**Flagging honestly:** `phase` is free text and nothing in the repo emits
`closed` today (it carries `E2`, `resumed`, `usage-limit-pause`). So this
lands as a reserved value with the fold and the docs in place, and it is
inert until a closer writes it — most naturally the retro/run skills, which
are outside this PR's file scope.

## Gate refusals (O-3)

Results are keyed by `kind`, so a re-run won the slot and *"security denied
this, then someone re-ran it green"* rendered identically to *"security has
only ever passed"*. The last refusal is kept beside the current result, with
its evidence, and gets its own `STATE.md` column. The counter is untouched —
volume was never what was lost.

A refusal is a **named set**, not "anything that is not a pass". The first
draft was the latter and the demo fixture caught it immediately, marking every
`open` gate as carrying a permanent objection it had never raised.

## Report prose (O-6)

`decision` folds its `text` and `gate` folds its `evidence`; `report` was the
one carrier of description that wrote to nowhere, so a `changes-needed` card
reached the board with the reason it came back discarded at fold time.

## Verification

- 1432/1432 pass, 0 skipped (+15 tests)
- `scan-control-chars` clean over 262 tracked files
- `desc-budget` 4352/5000; all three templates validate
- site builds; `check-base-prefix` 533/533
- **doctor's 103 tests pass unchanged** — that is the refactor's proof
- docs updated on **both** surfaces per CLAUDE.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)