### PR TITLE
chore(release): 0.1.31

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
     {
       "name": "tyran",
       "description": "A task conductor for Claude Code: multi-agent orchestration with an enforced evidence contract, repo-specific learning, and update-safe local evolution.",
-      "version": "0.1.30",
+      "version": "0.1.31",
       "source": "./",
       "author": {
         "name": "Jacek Janczura",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "tyran",
-  "version": "0.1.30",
+  "version": "0.1.31",
   "description": "A task conductor for Claude Code: multi-agent orchestration with an enforced evidence contract, repo-specific learning, and update-safe local evolution.",
   "author": {
     "name": "Jacek Janczura",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Changelog
 
-## Unreleased
+## 0.1.31 — 2026-08-17
+
+Seven things the journal had recorded and nothing was reading. The theme is
+one defect wearing different clothes: an answer that was available, a
+consumer that never asked for it, and a surface that reported confidence
+instead of the gap.
 
 ### Four things the fold recorded and threw away
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jjanczur/tyran",
-  "version": "0.1.30",
+  "version": "0.1.31",
   "description": "Command-line scripts for the Tyran task conductor (doctor, journal, schema, and repo tooling) for CI and terminals outside Claude Code. Installing this package does NOT install the Claude Code plugin — add that separately with `/plugin marketplace add jjanczur/tyran` inside Claude Code.",
   "type": "module",
   "engines": {


### PR DESCRIPTION
Collects #68 and #69 — seven places where the journal had recorded something
and nothing read it back.

**#68** — an agent the initiative moved on without now reads `stale` rather
than `running` (one predicate, shared with doctor, measured in journal time so
`board.json` stays byte-exact under `--check`); a closing checkpoint closes the
spawns it leaves open; a gate that passes after refusing no longer erases the
refusal; a report carries what the agent said, not only its verdict.

**#69** — `scripts/migrate.mjs` for the finding that could only ever be
reported; `mistakes-file-missing` splitting an absence that was one thing; and
accept-then-ignore ended narrowly, with `journal-key-near-miss` as a warning
and `journal-key-unread` counted at info rather than turning a documented
contract into 130 rows of alarm.

Three version fields bumped in one commit because different tools cross-check
different ones.

Verified: 1451/1451 pass, 0 skipped; control-chars clean over 264 tracked
files; desc-budget 4352/5000; both plugin manifests validate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)