### PR TITLE
feat: the prerequisite that blocked day one, and four fixes it uncovered

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,89 @@
 # Changelog
 
+## Unreleased
+
+### The prerequisite that blocked day one
+
+The secrets gate refuses every commit and push until `gitleaks` exists, and
+it refuses rather than warning for a reason that has not changed. What had
+been left with the operator is the *installing*: some people adopting Tyran
+have no Homebrew, no admin rights, or are on Windows, and their realistic
+answer to "install it and re-run" is not a safer repository — it is switching
+the hook off. A gate nobody can satisfy protects nothing, which is the same
+argument that made `.tyran/config.yaml` AUTO.
+
+`scripts/ensure-gitleaks.mjs` fetches it: pinned version **and** pinned
+SHA-256 per platform, taken from the release's own checksums, which is the
+thing `ci.yml` has always done moved to where a user can reach it. A mismatch
+deletes the download and installs nothing — this writes an executable that
+something else later runs, and a scanner that has been replaced reports clean
+on everything.
+
+It installs to `~/.tyran/bin/`. The first version of this put it under
+`<repo>/.tyran/bin/`, which is worse in a way worth recording: a path inside
+the repository travels with a clone, so a planted binary reporting clean on
+everything would arrive **with the checkout** — the attack the tracked-only
+rule for `.gitleaksignore` already prevents, reopened through a file that is
+not even in a diff. Under HOME the scanner is the operator's machine, exactly
+like PATH, and one install serves every repository on it. PATH is still
+consulted first: a gitleaks you installed yourself is never silently
+displaced by whatever version this repo pins.
+
+### Writing a prompt is now a top-tier job
+
+`retro` was routed at `work` and reached `deep` only under `--profile full`,
+so the agent that writes skills, agents and prompts — the text every later
+session obeys — ran on the middle model, and `--profile eco` kept it there.
+
+A new `authoring` role sits at `top` at every profile, with `top` and `max`
+floors under it. Separated from `retro` rather than raising the whole of it,
+because retro does two unlike things with one agent: folding a ledger, which
+the middle model does fine, and authoring. The argument is `security-review`'s
+in a stronger form — a bad security verdict costs one merge, while a bad
+prompt misroutes every run that reads it for as long as it ships, and it is
+the one output nothing downstream checks, because a skill that reads plausibly
+passes review.
+
+### A duplicate ledger id is refused
+
+Measured in the field: two implementers running in parallel each worked out an
+id for themselves, both were honoured, and the ledger kept two `F-7`s. History
+is append-only, so "see F-7" stays ambiguous forever and nothing detects it
+later.
+
+`append` now refuses a caller-supplied `id` that is **already used for that
+event type**. Deliberately not the broader fix of refusing every explicit id:
+that removes a documented capability — an explicit id still wins, and a test
+pins it — to prevent a failure that only occurs on collision. A fresh explicit
+id still passes, `ticket.created` is unaffected because its ids come from the
+plan, and the check runs under the write lock so two concurrent writers cannot
+both pass it.
+
+### Refusals you can paste
+
+The multi-remote push refusal is correct — excluding commits present on ANY
+remote let a key held on a private upstream reach a public origin unscanned —
+but it was reported twice, from two installs, as a false positive, and both
+reporters routed around it instead of satisfying it. The old text handed over
+`git push <remote> <branch>`, a shape to translate rather than a line to run.
+
+Everything needed to write the real command was already in hand, so it is
+written: one runnable line per remote, with the branch filled in.
+
+### Reviewers stop retyping evidence
+
+`tyran:reviewer` has no MCP tools, so a database row or an API response
+someone else fetched reaches it as text in a handoff — and text in a handoff
+gets retyped. Measured on a production run: **1.6% of hand-copied values were
+silently wrong**, which makes a reviewer that mistranscribes evidence worse
+than no reviewer, because the verdict carries authority the numbers do not.
+
+The roster is unchanged, because it cannot express the fix: `tools:` is a
+static list shipped in the plugin and MCP tool names differ on every install.
+The prompt closes it instead — require the raw bytes on disk and `Read` them,
+rather than reasoning about a retyped copy. A value read from a file is
+evidence; a value pasted into a sentence is a claim about evidence.
+
 ## 0.1.31 — 2026-08-17
 
 Seven things the journal had recorded and nothing was reading. The theme is

--- a/README.md
+++ b/README.md
@@ -297,7 +297,7 @@ enforces the cap (4352 of 5000 characters). What each one assumes, when it
 fires and who invokes it, is in
 [skills and agents](https://jjanczur.github.io/tyran/skills/); the prompts
 themselves are in [`skills/`](skills/) and [`agents/`](agents/). Behind all of
-it: 1451 unit tests, run with `node --test "tests/**/*.test.mjs"`.
+it: 1459 unit tests, run with `node --test "tests/**/*.test.mjs"`.
 
 ## Documentation
 

--- a/agents/reviewer.md
+++ b/agents/reviewer.md
@@ -14,6 +14,17 @@ ends up approving their own patch. This removes the easy path, not every path
 — `Bash` can still write — so treat it as a boundary you keep, not a wall
 that keeps you.
 
+**Never retype evidence. Ask for the file.** You also have no MCP tools, so a
+database row or an API response someone else fetched can only reach you as
+text in the handoff — and text in a handoff gets retyped. Measured on a
+production run: 1.6% of hand-copied values were silently wrong, which makes a
+reviewer that mistranscribes evidence worse than no reviewer, because the
+verdict carries authority the numbers do not deserve. When a claim rests on
+output you cannot obtain yourself, require the raw bytes on disk and `Read`
+them: reply asking for the path, do not reason about the retyped copy. A
+value you read from a file is evidence; a value someone pasted into a
+sentence is a claim about evidence.
+
 1. **Read the whole diff** plus the story file that holds the acceptance
    criteria. **Follow the `code-review` skill for the sweep** — it carries the
    dimensions a diff is read against and the rule that you try to refute your

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -106,8 +106,17 @@ Roles down the side, cost profile across the top:
 | arbitration | **top** | **top** | **top** |
 | acceptance | deep | top | top |
 | retro | work | work | deep |
+| authoring (a skill, an agent, a prompt) | **top** | **top** | **top** |
 | bookkeeping | cheap | cheap | cheap |
 | conductor (**advisory**) | deep | top | top |
+
+`authoring` is separated from `retro` because retro does two unlike things
+with one agent: folding a ledger, which the middle model does fine, and
+writing the text every future session will obey. It sits at `top` with a
+`max` effort floor on a stronger version of the security-review argument — a
+bad security verdict costs one merge, while a bad prompt misroutes every run
+that reads it, for as long as it ships, and it is the one output nothing
+downstream checks. A skill that reads plausibly passes review.
 
 `conductor` is the one row nothing can enforce: the conductor is your own
 session, and no plugin can change a running session's model. The row records

--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -178,6 +178,38 @@ does not unburn it.
 
 ### The invariant, and why it is the invariant
 
+### The scanner, and who installs it
+
+This gate needs `gitleaks` and refuses everything until it has one, which is
+correct and has a cost the design used to leave with the operator: some people
+adopting Tyran have no Homebrew, no admin rights, or are on Windows, and their
+realistic answer to "install it and re-run" is to switch the hook off. A gate
+nobody can satisfy protects nothing.
+
+So setup fetches it:
+
+```bash
+node scripts/ensure-gitleaks.mjs          # install if missing
+node scripts/ensure-gitleaks.mjs --check  # say whether one is reachable, install nothing
+```
+
+Pinned version **and** pinned SHA-256, per platform, from the release's own
+checksums — the same thing `ci.yml` has always done, moved to where a user can
+reach it. A digest mismatch deletes the download and installs nothing: this
+writes an executable that something else later runs, and a scanner that has
+been replaced reports clean on everything.
+
+It lands in `~/.tyran/bin/`, under the HOME directory and deliberately not
+inside the repository. A path in the repo travels with a clone, so a planted
+binary reporting clean on everything would arrive with the checkout — the
+attack the tracked-only rule for `.gitleaksignore` already prevents, reopened
+through a file that is not even in a diff. One install serves every repo on
+the machine.
+
+Resolution order is `TYRAN_GITLEAKS_BIN`, then PATH, then the managed copy:
+a gitleaks you installed yourself is your decision and is never silently
+displaced by whatever version Tyran happens to pin.
+
 The first version of this gate asked **"did the scan break?"** — scanner
 missing, killed, crashed, report unreadable — and answered all four correctly.
 It never asked **"did the scan cover what is about to be published?"**, and

--- a/docs/journal.md
+++ b/docs/journal.md
@@ -1,6 +1,6 @@
 # Journal reference
 
-`scripts/journal.mjs` · 77 unit tests
+`scripts/journal.mjs` · 81 unit tests
 
 This page is the schema contract; extending the event set is a reviewed core
 change.
@@ -115,6 +115,12 @@ renders and still closes.
   number twice; an id taken from `journal.mjs next-id <file> D` and appended
   later still can, because another writer may append in between — prefer
   letting `append` issue it whenever the caller does not need the value first.
+  An explicit id is still honoured, but one that is **already used for that
+  event type** is REFUSED: two implementers running in parallel each worked
+  out a number for themselves and both were written, and "see F-7" is
+  ambiguous forever once two events carry it. The check is per event type
+  (a `D-1` and an `F-1` never collide) and it runs under the write lock, so
+  two concurrent writers cannot both pass it.
 - **Resume surface:** `journal.mjs tail <file>` returns the latest
   `checkpoint` and all unreleased leases — exactly what the `SessionStart`
   hook re-injects.

--- a/hooks/scripts/secrets-gate.mjs
+++ b/hooks/scripts/secrets-gate.mjs
@@ -62,9 +62,9 @@
  * It is never interpolated into another command and never expanded.
  */
 import { spawn } from 'node:child_process';
-import { realpathSync } from 'node:fs';
+import { realpathSync, statSync } from 'node:fs';
 import { mkdtemp, readFile, rm, stat } from 'node:fs/promises';
-import { tmpdir } from 'node:os';
+import { homedir, tmpdir } from 'node:os';
 import { basename, dirname, join, resolve as resolvePath } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
@@ -110,8 +110,83 @@ const MAX_FINDINGS_SHOWN = 10;
 export const MAX_PATH_CHARS = 120;
 export const MAX_RULE_CHARS = 60;
 
-/** Where the scanner lives. An operator may point at a pinned build. */
-export const GITLEAKS_BIN = () => process.env.TYRAN_GITLEAKS_BIN || 'gitleaks';
+/**
+ * Where the scanner lives, in order of authority.
+ *
+ *   1. TYRAN_GITLEAKS_BIN — the operator pointing at a build they chose.
+ *   2. `gitleaks` on PATH — the machine's own, if it has one.
+ *   3. ~/.tyran/bin/gitleaks — the pinned build `scripts/ensure-gitleaks.mjs`
+ *      fetched and checksummed, for a machine that had none.
+ *
+ * Step 3 exists because the prerequisite was the wall. This gate refuses
+ * every commit and push until a scanner exists, and it refuses rather than
+ * warning for a reason that has not changed — but the design assumed the
+ * operator could install a binary, and for the people now adopting Tyran that
+ * is often false: no Homebrew, no admin rights, Windows. Their realistic
+ * response to "install gitleaks and re-run" is to switch this hook off, and a
+ * gate nobody can satisfy protects nothing.
+ *
+ * It is the HOME directory and deliberately not `<repo>/.tyran/bin/`, which
+ * was the first shape of this and is worse in a way worth recording: a path
+ * inside the repository travels with a clone, so a planted binary that
+ * reports clean on everything would arrive with the checkout — an attack the
+ * tracked-only rule for `.gitleaksignore` already exists to prevent, reopened
+ * through a file that is not even in a diff. Under the home directory the
+ * scanner is the operator's machine, exactly like PATH, and one install
+ * serves every repository on it.
+ *
+ * PATH is consulted BEFORE it: a gitleaks the operator installed themselves
+ * is their decision, and a newer one should not be silently displaced by
+ * whatever version Tyran happens to pin.
+ */
+export function gitleaksBin() {
+  const explicit = process.env.TYRAN_GITLEAKS_BIN;
+  if (typeof explicit === 'string' && explicit !== '') return explicit;
+  if (onPath('gitleaks')) return 'gitleaks';
+  return managedScanner() ?? 'gitleaks';
+}
+
+/** Backwards-compatible alias: this was a zero-argument arrow. */
+export const GITLEAKS_BIN = gitleaksBin;
+
+/**
+ * Is a name resolvable through PATH? Checked by looking rather than by
+ * spawning: this runs before every scan, and a spawn to answer "does a spawn
+ * work" costs more than the lookup it is standing in for.
+ */
+function onPath(name) {
+  const entries = String(process.env.PATH ?? '').split(process.platform === 'win32' ? ';' : ':');
+  const names = process.platform === 'win32' ? [`${name}.exe`, `${name}.cmd`, name] : [name];
+  for (const dir of entries) {
+    if (dir === '') continue;
+    for (const candidate of names) {
+      try {
+        if (statSync(join(dir, candidate)).isFile()) return true;
+      } catch { /* not here; keep looking */ }
+    }
+  }
+  return false;
+}
+
+/**
+ * The pinned build under the operator's home, or null.
+ *
+ * Every failure returns null rather than throwing: this runs inside a gate
+ * whose refusal is the product, and an unreadable home directory must degrade
+ * to the ordinary "gitleaks is not installed" refusal — which already carries
+ * instructions — never take the session down with an unhandled error.
+ */
+function managedScanner() {
+  try {
+    const home = homedir();
+    if (typeof home !== 'string' || home === '') return null;
+    const name = process.platform === 'win32' ? 'gitleaks.exe' : 'gitleaks';
+    const path = join(home, '.tyran', 'bin', name);
+    return statSync(path).isFile() ? path : null;
+  } catch {
+    return null;
+  }
+}
 
 /** Suppression files, honoured ONLY when git tracks them. See `suppression`. */
 export const SUPPRESSION_FILES = Object.freeze({
@@ -1028,6 +1103,23 @@ export async function isTracked(repo, path, { runner, timeoutMs }) {
  * unexamined. Reproduced on the first attempt: the range counted 0 commits
  * while origin held none of them.
  */
+/**
+ * The branch HEAD is on, or null when git cannot say (detached HEAD, a repo
+ * with no commits, git unavailable). Null becomes a placeholder in the remedy
+ * rather than a wrong branch name: a command that looks runnable and is not
+ * is worse than one that visibly needs a word filled in.
+ */
+async function currentBranch(repo, { runner, timeoutMs }) {
+  try {
+    const r = await runner('git', ['-C', repo, 'symbolic-ref', '--quiet', '--short', 'HEAD'], { timeoutMs });
+    if (r.spawned !== true || r.timedOut === true || r.code !== 0) return null;
+    const name = String(r.stdout ?? '').trim();
+    return name === '' ? null : name;
+  } catch {
+    return null;
+  }
+}
+
 export async function pushRange(repo, remote, refs, { runner, timeoutMs }) {
   const listed = await git(['-C', repo, 'remote'], { runner, timeoutMs, what: 'listing remotes' });
   const remotes = String(listed).trim().split('\n').filter((r) => r !== '');
@@ -1036,11 +1128,28 @@ export async function pushRange(repo, remote, refs, { runner, timeoutMs }) {
     if (remotes.length === 1) target = remotes[0];
     else if (remotes.length === 0) target = null;
     else {
+      // Hand over the command, do not describe its shape.
+      //
+      // This refusal is CORRECT — excluding commits present on any remote let
+      // a key held on a private upstream reach a public origin unscanned — but
+      // it was reported twice from two installs as a false positive, and both
+      // reporters worked around it rather than satisfying it. The reason is
+      // visible in the old text: `git push <remote> <branch>` is a template,
+      // and the operator has to work out both halves while being told no.
+      //
+      // Everything needed to write the real line is already in hand here, so
+      // it is written. A remedy you can paste is a different object from a
+      // remedy you have to translate, and this gate's whole cost is paid in
+      // the moments people spend deciding whether to route around it.
+      const branch = await currentBranch(repo, { runner, timeoutMs });
+      const ref = branch === null ? '<branch>' : branch;
+      const lines = remotes.map((r) => `    git push ${r} HEAD:refs/heads/${ref}`).join('\n');
       throw new ScanFailure(
         `this push does not name which of ${remotes.length} remotes it targets (${remotes.join(', ')})`,
-        'name the remote explicitly (`git push <remote> <branch>`). Excluding commits that exist ' +
-          'on ANY remote would let a commit held on a private remote be published to a public one ' +
-          'without ever being scanned — measured, not hypothetical.',
+        'name the remote — one of these is the command you meant:\n' +
+          `${lines}\n` +
+          'Excluding commits that exist on ANY remote would let a commit held on a private remote ' +
+          'be published to a public one without ever being scanned — measured, not hypothetical.',
       );
     }
   }

--- a/scripts/ensure-gitleaks.mjs
+++ b/scripts/ensure-gitleaks.mjs
@@ -1,0 +1,254 @@
+#!/usr/bin/env node
+/**
+ * ensure-gitleaks — remove the one prerequisite that blocks day one.
+ *
+ * The secrets gate refuses every commit and push until `gitleaks` exists, and
+ * it refuses rather than warning for a reason that has not changed: a check
+ * that passes when its scanner is missing is a check you disable by
+ * uninstalling a package.
+ *
+ * The unstated assumption in that design is that the operator can install a
+ * binary. Measured against the people actually adopting this: some have no
+ * Homebrew, no admin rights, or are on Windows. For them the realistic
+ * outcome of "install gitleaks and re-run" is not a safer repository — it is
+ * switching the hook off, or abandoning the tool. A gate nobody can satisfy
+ * protects nothing, which is the same argument `.tyran/config.yaml` being
+ * AUTO already rests on.
+ *
+ * So this fetches the scanner instead of asking someone else to. It is the
+ * same thing `.github/workflows/ci.yml` has always done — pinned version,
+ * pinned checksum — moved to where a user can reach it.
+ *
+ * ## Why a checksum table and not "download the latest"
+ *
+ * This writes an executable and something else later runs it. Version alone
+ * is not integrity: a tag can be moved, a mirror can lie, and a scanner that
+ * has been replaced reports clean on everything. The digests below are the
+ * ones GitHub publishes for 8.30.1, and a mismatch DELETES the download and
+ * refuses. The linux_x64 line is the same digest ci.yml already pins, which
+ * is the cross-check that this table was transcribed and not invented.
+ *
+ * Usage:
+ *   node scripts/ensure-gitleaks.mjs [--check]
+ *
+ * Exit: 0 present or installed · 1 unavailable (reason printed) · 2 usage.
+ */
+import { createHash } from 'node:crypto';
+import { chmodSync, existsSync, mkdirSync, readFileSync, rmSync, statSync, writeFileSync } from 'node:fs';
+import { execFileSync } from 'node:child_process';
+import { join } from 'node:path';
+import { homedir, tmpdir } from 'node:os';
+
+/** The version this table describes. Bumping it means re-fetching every digest. */
+export const GITLEAKS_VERSION = '8.30.1';
+
+/**
+ * SHA-256 per platform, from the release's own `checksums.txt`.
+ *
+ * Keyed `<process.platform>-<process.arch>` so the lookup cannot drift from
+ * what Node reports. A platform absent from this table is a REFUSAL with
+ * instructions, never a silent skip — an unknown platform is exactly where a
+ * "best effort" download would install something unverified.
+ */
+export const GITLEAKS_SHA256 = Object.freeze({
+  'darwin-arm64': 'b40ab0ae55c505963e365f271a8d3846efbc170aa17f2607f13df610a9aeb6a5',
+  'darwin-x64': 'dfe101a4db2255fc85120ac7f3d25e4342c3c20cf749f2c20a18081af1952709',
+  'linux-arm64': 'e4a487ee7ccd7d3a7f7ec08657610aa3606637dab924210b3aee62570fb4b080',
+  // The digest ci.yml pins. If these two ever disagree, one of them is wrong.
+  'linux-x64': '551f6fc83ea457d62a0d98237cbad105af8d557003051f41f3e7ca7b3f2470eb',
+  'win32-arm64': 'b95f5e4f5c425cedca7ee203d9afd29597e692c4924a12ed42f970537c72cc0f',
+  'win32-x64': 'd29144deff3a68aa93ced33dddf84b7fdc26070add4aa0f4513094c8332afc4e',
+});
+
+/**
+ * Where a managed scanner lives: under the operator's HOME, never the repo.
+ *
+ * The first shape of this put it in `<repo>/.tyran/bin/`, which is worse in a
+ * way worth recording: a path inside the repository travels with a clone, so
+ * a planted binary that reports clean on everything would arrive with the
+ * checkout — the attack the tracked-only rule for `.gitleaksignore` already
+ * exists to prevent, reopened through a file that is not even in a diff.
+ * Under the home directory the scanner is the operator's machine, exactly
+ * like anything on PATH, and one install serves every repository on it.
+ */
+export const MANAGED_DIR = join(homedir(), '.tyran', 'bin');
+
+const ASSET_ARCH = Object.freeze({ arm64: 'arm64', x64: 'x64' });
+
+/** The release asset name for a platform key, or null if unsupported. */
+export function assetFor(platform = process.platform, arch = process.arch) {
+  const a = ASSET_ARCH[arch];
+  if (a === undefined) return null;
+  if (platform === 'darwin') return `gitleaks_${GITLEAKS_VERSION}_darwin_${a}.tar.gz`;
+  if (platform === 'linux') return `gitleaks_${GITLEAKS_VERSION}_linux_${a}.tar.gz`;
+  if (platform === 'win32') return `gitleaks_${GITLEAKS_VERSION}_windows_${a}.zip`;
+  return null;
+}
+
+export const managedBinPath = (platform = process.platform) =>
+  join(MANAGED_DIR, platform === 'win32' ? 'gitleaks.exe' : 'gitleaks');
+
+/** SHA-256 of a file on disk, hex. */
+export function digestOf(path) {
+  return createHash('sha256').update(readFileSync(path)).digest('hex');
+}
+
+/**
+ * Is a usable `gitleaks` already reachable? Checks the operator's override
+ * first, then PATH — the two the gate itself consults, in the gate's order.
+ */
+export function alreadyAvailable({ run = defaultRun } = {}) {
+  const explicit = process.env.TYRAN_GITLEAKS_BIN;
+  if (typeof explicit === 'string' && explicit !== '') {
+    return run(explicit, ['version']) === null ? null : { path: explicit, why: 'TYRAN_GITLEAKS_BIN' };
+  }
+  const version = run('gitleaks', ['version']);
+  return version === null ? null : { path: 'gitleaks', why: 'on PATH', version: version.trim() };
+}
+
+function defaultRun(bin, args) {
+  try {
+    return execFileSync(bin, args, { encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'], timeout: 10_000 });
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Download one URL to a path, following redirects. GitHub answers a release
+ * asset with a 302 to a CDN, so a client that does not follow them downloads
+ * an HTML document and hashes it — which fails the digest check rather than
+ * installing anything, but reports the wrong reason.
+ */
+async function download(url, dest, { redirects = 5 } = {}) {
+  const { get } = await import('node:https');
+  const { createWriteStream } = await import('node:fs');
+  return new Promise((resolvePromise, reject) => {
+    get(url, { headers: { 'user-agent': 'tyran-ensure-gitleaks' } }, (res) => {
+      const { statusCode, headers } = res;
+      if (statusCode !== undefined && statusCode >= 300 && statusCode < 400 && headers.location) {
+        res.resume();
+        if (redirects === 0) return reject(new Error('too many redirects'));
+        return resolvePromise(download(headers.location, dest, { redirects: redirects - 1 }));
+      }
+      if (statusCode !== 200) {
+        res.resume();
+        return reject(new Error(`HTTP ${statusCode} from ${url}`));
+      }
+      const file = createWriteStream(dest);
+      res.pipe(file);
+      file.on('finish', () => file.close(() => resolvePromise(undefined)));
+      file.on('error', reject);
+    }).on('error', reject);
+  });
+}
+
+/**
+ * Fetch, verify and unpack the pinned scanner into `<dir>/bin/`.
+ *
+ * The digest is checked BEFORE anything is unpacked and before the file is
+ * made executable: an archive that fails is deleted and nothing it contained
+ * ever reaches the disk as a program.
+ *
+ * `tar` does the unpacking on every platform — bsdtar reads zip, and Windows
+ * has shipped it since 10 — so this needs no archive library and no
+ * dependency, which is the property that lets it ship inside a plugin.
+ */
+export async function installGitleaks({ platform = process.platform, arch = process.arch, run = defaultRun } = {}) {
+  const key = `${platform}-${arch}`;
+  const asset = assetFor(platform, arch);
+  const expected = GITLEAKS_SHA256[key];
+  if (asset === null || expected === undefined) {
+    return { ok: false, reason: `no pinned build for ${key}`, unsupported: true };
+  }
+  const target = managedBinPath(platform);
+  if (existsSync(target) && digestOf(target) !== '' && run(target, ['version']) !== null) {
+    return { ok: true, path: target, already: true };
+  }
+  const url = `https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/${asset}`;
+  const staging = join(tmpdir(), `tyran-gitleaks-${process.pid}`);
+  mkdirSync(staging, { recursive: true });
+  const archive = join(staging, asset);
+  try {
+    await download(url, archive);
+    const actual = digestOf(archive);
+    if (actual !== expected) {
+      rmSync(staging, { recursive: true, force: true });
+      return {
+        ok: false,
+        reason: `checksum mismatch for ${asset}: expected ${expected}, got ${actual}. Nothing was installed.`,
+      };
+    }
+    execFileSync('tar', ['-xf', archive, '-C', staging], { stdio: 'ignore', timeout: 60_000 });
+    const unpacked = join(staging, platform === 'win32' ? 'gitleaks.exe' : 'gitleaks');
+    if (!existsSync(unpacked)) {
+      rmSync(staging, { recursive: true, force: true });
+      return { ok: false, reason: `the archive did not contain a gitleaks binary` };
+    }
+    mkdirSync(MANAGED_DIR, { recursive: true });
+    writeFileSync(target, readFileSync(unpacked));
+    if (platform !== 'win32') chmodSync(target, 0o755);
+    rmSync(staging, { recursive: true, force: true });
+    if (run(target, ['version']) === null) {
+      return { ok: false, reason: 'the installed binary did not run — the platform build may not match this machine' };
+    }
+    return { ok: true, path: target, installed: true, digest: expected };
+  } catch (error) {
+    rmSync(staging, { recursive: true, force: true });
+    return { ok: false, reason: String(error.message ?? error) };
+  }
+}
+
+const MANUAL =
+  'Install it by hand and re-run:\n' +
+  '    macOS      brew install gitleaks\n' +
+  '    Linux      see https://github.com/gitleaks/gitleaks/releases (or your package manager)\n' +
+  'or point TYRAN_GITLEAKS_BIN at an existing binary.';
+
+function usage(message) {
+  if (message) console.error(`ensure-gitleaks: ${message}`);
+  console.error('usage: node scripts/ensure-gitleaks.mjs [--check]');
+  process.exit(2);
+}
+
+async function main(argv) {
+  const args = argv.slice(2);
+  for (const arg of args) {
+    if (arg.startsWith('--') && arg !== '--check') usage(`unknown flag ${arg}`);
+  }
+
+  const found = alreadyAvailable();
+  if (found !== null) {
+    console.log(`ensure-gitleaks: already available (${found.why})${found.version ? ` — ${found.version}` : ''}`);
+    process.exit(0);
+  }
+  const local = managedBinPath();
+  if (existsSync(local) && defaultRun(local, ['version']) !== null) {
+    console.log(`ensure-gitleaks: present at ${local}`);
+    process.exit(0);
+  }
+  if (args.includes('--check')) {
+    console.error('ensure-gitleaks: NOT available — the secrets gate refuses every commit and push until it is.');
+    console.error(MANUAL);
+    process.exit(1);
+  }
+
+  console.log(`ensure-gitleaks: fetching gitleaks ${GITLEAKS_VERSION} for ${process.platform}-${process.arch}…`);
+  const result = await installGitleaks();
+  if (!result.ok) {
+    console.error(`ensure-gitleaks: could not install it (${result.reason})`);
+    console.error(MANUAL);
+    process.exit(1);
+  }
+  console.log(`ensure-gitleaks: installed ${result.path}`);
+  console.log(`ensure-gitleaks: verified sha256 ${result.digest}`);
+  console.log('ensure-gitleaks: the secrets gate finds this automatically — nothing to add to your shell.');
+  process.exit(0);
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main(process.argv).catch((error) => {
+    console.error(`ensure-gitleaks: ${error.message}`);
+    process.exit(1);
+  });
+}

--- a/scripts/journal.mjs
+++ b/scripts/journal.mjs
@@ -685,6 +685,35 @@ function appendUnderLock(file, event, preread = null) {
   if (issuePrefix !== undefined && isDataObject(stamped.data) && (stamped.data.id === undefined || stamped.data.id === '')) {
     // a fresh object: the `data` the caller passed in stays the caller's
     stamped.data = { ...stamped.data, id: nextIdFrom(read().events, issuePrefix) };
+  } else if (issuePrefix !== undefined && isDataObject(stamped.data) && typeof stamped.data.id === 'string') {
+    // A caller-supplied id that is ALREADY TAKEN is refused.
+    //
+    // Measured in the field: two implementers running in parallel each passed
+    // an id they had worked out for themselves, and both were honoured — the
+    // ledger then held two `F-7`s, and "see F-7" is ambiguous forever, because
+    // history is append-only and nothing detects it later.
+    //
+    // The narrow fix, not the broad one. Refusing EVERY caller-supplied id was
+    // the first proposal and it removes a documented capability — the comment
+    // above says an explicit id still wins, and a test pins it — to prevent a
+    // failure that only ever occurs on COLLISION. So collision is what this
+    // refuses, and a fresh explicit id still passes untouched.
+    //
+    // Inside the lock, on the same read as the mint above: a check outside it
+    // would let two concurrent writers both pass and both append, which is the
+    // exact race being closed.
+    const taken = read().events.some(
+      (e) => e?.ev === stamped.ev && typeof e?.data?.id === 'string' && e.data.id === stamped.data.id,
+    );
+    if (taken) {
+      throw new Error(
+        `invalid event: ${q(stamped.ev)} id ${q(stamped.data.id)} is already used in ${q(file)}.\n` +
+          '  Two events under one id make every later reference to it ambiguous, and the journal is\n' +
+          '  append-only, so nothing can disambiguate them afterwards.\n' +
+          `  Omit "id" and ${q('append')} issues the next free one, which is what it is for — or run\n` +
+          `  node scripts/journal.mjs next-id ${q(file)} ${q(issuePrefix)}`,
+      );
+    }
   }
   const errors = validateEvent(stamped);
   if (errors.length > 0) {

--- a/scripts/tiers.mjs
+++ b/scripts/tiers.mjs
@@ -73,6 +73,11 @@ export const EFFORT_BY_TIER = Object.freeze({
 export const ROLE_EFFORT_FLOOR = Object.freeze({
   'security-review': 'max',
   arbitration: 'high',
+  // Authoring a prompt is the one output nothing downstream checks: a skill
+  // that reads plausibly passes review, and a weak one misroutes every run
+  // that obeys it, quietly, for as long as it ships. Thinking harder is the
+  // cheapest correction available and it is paid once per skill, not per run.
+  authoring: 'max',
 });
 
 /**
@@ -92,6 +97,21 @@ export const ROLE_TIERS = Object.freeze({
   arbitration: { eco: 'top', balanced: 'top', full: 'top' },
   acceptance: { eco: 'deep', balanced: 'top', full: 'top' },
   retro: { eco: 'work', balanced: 'work', full: 'deep' },
+  // Writing a PROMPT — a skill, an agent, the conductor's own instructions.
+  //
+  // Separated from `retro` because retro does two unlike things with one
+  // agent: reading a ledger and folding counters, which the middle model does
+  // fine, and authoring the text that every future session will obey. Routing
+  // the whole of retro at `top` would spend the tier on bookkeeping; routing
+  // the authoring at `work` is the failure this row exists to prevent.
+  //
+  // `top` at EVERY profile, with a floor under it, on the same argument
+  // `security-review` already makes and a stronger version of it: a bad
+  // security verdict costs one merge, while a bad prompt misroutes every run
+  // that reads it, for as long as it ships. It is also the one output nothing
+  // downstream checks — a skill that reads plausibly passes review, and the
+  // cost surfaces later as work done slightly wrong, everywhere, quietly.
+  authoring: { eco: 'top', balanced: 'top', full: 'top' },
   bookkeeping: { eco: 'cheap', balanced: 'cheap', full: 'cheap' },
   // ADVISORY. The conductor is the operator's own session, and no plugin can
   // change a running session's model — so this row records the choice in the
@@ -112,6 +132,10 @@ export const ROLE_TIERS = Object.freeze({
 export const ROLE_FLOOR = Object.freeze({
   'security-review': 'top',
   arbitration: 'top',
+  // So `--profile eco --risk low` cannot quietly write the next skill on the
+  // cheap tier. Every other floor here protects a judgement made once; this
+  // one protects a judgement every later session inherits.
+  authoring: 'top',
   // One weak coordinator spends a whole team's budget on the wrong plan, and
   // the floor is what `--profile eco --risk low` cannot shift out of.
   conductor: 'deep',

--- a/site/src/content/docs/agents.mdx
+++ b/site/src/content/docs/agents.mdx
@@ -114,8 +114,17 @@ Roles down the side, cost profile across the top:
 | arbitration | **top** | **top** | **top** |
 | acceptance | deep | top | top |
 | retro | work | work | deep |
+| authoring (a skill, an agent, a prompt) | **top** | **top** | **top** |
 | bookkeeping | cheap | cheap | cheap |
 | conductor (**advisory**) | deep | top | top |
+
+`authoring` is separated from `retro` because retro does two unlike things
+with one agent: folding a ledger, which the middle model does fine, and
+writing the text every future session will obey. It sits at `top` with a
+`max` effort floor on a stronger version of the security-review argument — a
+bad security verdict costs one merge, while a bad prompt misroutes every run
+that reads it, for as long as it ships, and it is the one output nothing
+downstream checks. A skill that reads plausibly passes review.
 
 `conductor` is the one row nothing can enforce: the conductor is your own
 session, and no plugin can change a running session's model. The row records

--- a/site/src/content/docs/hooks.mdx
+++ b/site/src/content/docs/hooks.mdx
@@ -225,6 +225,38 @@ does not unburn it.
 
 ### The invariant, and why it is the invariant
 
+### The scanner, and who installs it
+
+This gate needs `gitleaks` and refuses everything until it has one, which is
+correct and has a cost the design used to leave with the operator: some people
+adopting Tyran have no Homebrew, no admin rights, or are on Windows, and their
+realistic answer to "install it and re-run" is to switch the hook off. A gate
+nobody can satisfy protects nothing.
+
+So setup fetches it:
+
+```bash
+node scripts/ensure-gitleaks.mjs          # install if missing
+node scripts/ensure-gitleaks.mjs --check  # say whether one is reachable, install nothing
+```
+
+Pinned version **and** pinned SHA-256, per platform, from the release's own
+checksums — the same thing `ci.yml` has always done, moved to where a user can
+reach it. A digest mismatch deletes the download and installs nothing: this
+writes an executable that something else later runs, and a scanner that has
+been replaced reports clean on everything.
+
+It lands in `~/.tyran/bin/`, under the HOME directory and deliberately not
+inside the repository. A path in the repo travels with a clone, so a planted
+binary reporting clean on everything would arrive with the checkout — the
+attack the tracked-only rule for `.gitleaksignore` already prevents, reopened
+through a file that is not even in a diff. One install serves every repo on
+the machine.
+
+Resolution order is `TYRAN_GITLEAKS_BIN`, then PATH, then the managed copy:
+a gitleaks you installed yourself is your decision and is never silently
+displaced by whatever version Tyran happens to pin.
+
 The first version of this gate asked **"did the scan break?"** — scanner
 missing, killed, crashed, report unreadable — and answered all four correctly.
 It never asked **"did the scan cover what is about to be published?"**, and

--- a/site/src/content/docs/journal.mdx
+++ b/site/src/content/docs/journal.mdx
@@ -6,7 +6,7 @@ import { FileTree } from '@astrojs/starlight/components';
 import Provenance from '../../components/Provenance.astro';
 
 <Provenance>
-`scripts/journal.mjs` · 77 unit tests
+`scripts/journal.mjs` · 81 unit tests
 </Provenance>
 
 This page is the schema contract; extending the event set is a reviewed core
@@ -167,6 +167,12 @@ flowchart TB
   number twice; an id taken from `journal.mjs next-id <file> D` and appended
   later still can, because another writer may append in between — prefer
   letting `append` issue it whenever the caller does not need the value first.
+  An explicit id is still honoured, but one that is **already used for that
+  event type** is REFUSED: two implementers running in parallel each worked
+  out a number for themselves and both were written, and "see F-7" is
+  ambiguous forever once two events carry it. The check is per event type
+  (a `D-1` and an `F-1` never collide) and it runs under the write lock, so
+  two concurrent writers cannot both pass it.
 - **Resume surface:** `journal.mjs tail <file>` returns the latest
   `checkpoint` and all unreleased leases — exactly what the `SessionStart`
   hook re-injects.

--- a/tests/unit/hook-secrets-gate.test.mjs
+++ b/tests/unit/hook-secrets-gate.test.mjs
@@ -1522,3 +1522,94 @@ test('a dash-prefixed value is still a value: setting the hooks path with it is 
     DENIAL_CODES.HOOKS_PATH,
   ]);
 });
+
+// --- which scanner, and why that order ----------------------------------
+
+test('the operator override outranks everything', () => {
+  // Unchanged behaviour, pinned because the two lookups below were added
+  // underneath it: an operator who pointed at a build they chose must keep
+  // getting it, whatever else is on the machine.
+  const prior = process.env.TYRAN_GITLEAKS_BIN;
+  try {
+    process.env.TYRAN_GITLEAKS_BIN = '/opt/pinned/gitleaks';
+    assert.equal(GITLEAKS_BIN(), '/opt/pinned/gitleaks');
+  } finally {
+    if (prior === undefined) delete process.env.TYRAN_GITLEAKS_BIN;
+    else process.env.TYRAN_GITLEAKS_BIN = prior;
+  }
+});
+
+test('a gitleaks on PATH is preferred over the one Tyran manages', () => {
+  // MUTANT: consult the managed copy first. An operator who installed their
+  // own — very likely a newer one — must not have it silently displaced by
+  // whatever version this repo happens to pin.
+  const home = mkdtempSync(join(tmpdir(), 'tyran-home-'));
+  const onPath = mkdtempSync(join(tmpdir(), 'tyran-path-'));
+  mkdirSync(join(home, '.tyran', 'bin'), { recursive: true });
+  writeFileSync(join(home, '.tyran', 'bin', 'gitleaks'), '#!/bin/sh\n');
+  writeFileSync(join(onPath, 'gitleaks'), '#!/bin/sh\n');
+  const prior = { home: process.env.HOME, path: process.env.PATH, bin: process.env.TYRAN_GITLEAKS_BIN };
+  try {
+    delete process.env.TYRAN_GITLEAKS_BIN;
+    process.env.HOME = home;
+    process.env.PATH = onPath;
+    assert.equal(GITLEAKS_BIN(), 'gitleaks', 'PATH wins while it has one');
+    // With PATH emptied, the managed copy is what stands between this gate
+    // and refusing every commit on a machine that could not install one.
+    process.env.PATH = mkdtempSync(join(tmpdir(), 'tyran-empty-'));
+    assert.equal(GITLEAKS_BIN(), join(home, '.tyran', 'bin', 'gitleaks'));
+  } finally {
+    if (prior.home === undefined) delete process.env.HOME; else process.env.HOME = prior.home;
+    if (prior.path === undefined) delete process.env.PATH; else process.env.PATH = prior.path;
+    if (prior.bin !== undefined) process.env.TYRAN_GITLEAKS_BIN = prior.bin;
+    rmSync(home, { recursive: true, force: true });
+    rmSync(onPath, { recursive: true, force: true });
+  }
+});
+
+test('no scanner anywhere still resolves to the name that produces the refusal', () => {
+  // MUTANT: return null or throw when nothing is found. The ENOENT from
+  // spawning `gitleaks` is what carries INSTALL_INSTRUCTIONS to the operator;
+  // a resolver that fails earlier loses the one message that says what to do.
+  const home = mkdtempSync(join(tmpdir(), 'tyran-home-'));
+  const empty = mkdtempSync(join(tmpdir(), 'tyran-empty-'));
+  const prior = { home: process.env.HOME, path: process.env.PATH, bin: process.env.TYRAN_GITLEAKS_BIN };
+  try {
+    delete process.env.TYRAN_GITLEAKS_BIN;
+    process.env.HOME = home;
+    process.env.PATH = empty;
+    assert.equal(GITLEAKS_BIN(), 'gitleaks');
+  } finally {
+    if (prior.home === undefined) delete process.env.HOME; else process.env.HOME = prior.home;
+    if (prior.path === undefined) delete process.env.PATH; else process.env.PATH = prior.path;
+    if (prior.bin !== undefined) process.env.TYRAN_GITLEAKS_BIN = prior.bin;
+    rmSync(home, { recursive: true, force: true });
+    rmSync(empty, { recursive: true, force: true });
+  }
+});
+
+test('the managed scanner is under HOME, never inside the repository', () => {
+  // The first shape of this put it in <repo>/.tyran/bin/, which a clone
+  // carries — so a planted binary reporting clean on everything would arrive
+  // WITH the checkout, and unlike a tracked .gitleaksignore it would not even
+  // appear in a diff. MUTANT: resolve it relative to the repo.
+  const home = mkdtempSync(join(tmpdir(), 'tyran-home-'));
+  const repo = mkdtempSync(join(tmpdir(), 'tyran-repo-'));
+  mkdirSync(join(repo, '.tyran', 'bin'), { recursive: true });
+  writeFileSync(join(repo, '.tyran', 'bin', 'gitleaks'), '#!/bin/sh\necho planted\n');
+  const empty = mkdtempSync(join(tmpdir(), 'tyran-empty-'));
+  const prior = { home: process.env.HOME, path: process.env.PATH, bin: process.env.TYRAN_GITLEAKS_BIN, cwd: process.cwd() };
+  try {
+    delete process.env.TYRAN_GITLEAKS_BIN;
+    process.env.HOME = home;
+    process.env.PATH = empty;
+    process.chdir(repo);
+    assert.equal(GITLEAKS_BIN(), 'gitleaks', 'a scanner inside the repo is never picked up');
+  } finally {
+    process.chdir(prior.cwd);
+    if (prior.home === undefined) delete process.env.HOME; else process.env.HOME = prior.home;
+    if (prior.path === undefined) delete process.env.PATH; else process.env.PATH = prior.path;
+    if (prior.bin !== undefined) process.env.TYRAN_GITLEAKS_BIN = prior.bin;
+    for (const d of [home, repo, empty]) rmSync(d, { recursive: true, force: true });
+  }
+});

--- a/tests/unit/journal.test.mjs
+++ b/tests/unit/journal.test.mjs
@@ -1389,3 +1389,61 @@ test("Tyran's OWN writers produce no unread keys", () => {
   assert.deepEqual([...unread.keys()], [], 'a key Tyran itself writes is not an unread key');
   assert.deepEqual(nearMisses, []);
 });
+
+// --- a caller-supplied id that is already taken -------------------------
+
+test('a caller-supplied id that COLLIDES is refused', () => {
+  // Measured in the field: two implementers running in parallel each worked
+  // out an id for themselves and both were honoured, so the ledger held two
+  // F-7s. "See F-7" is then ambiguous forever, because history is append-only
+  // and nothing detects it later. MUTANT: drop the collision check.
+  const f = tmp();
+  append(f, ev({ ev: 'decision', data: { id: 'D-1', text: 'first' } }));
+  assert.throws(
+    () => append(f, ev({ ts: '2026-07-26T10:05:00.000Z', ev: 'decision', data: { id: 'D-1', text: 'second' } })),
+    /already used/,
+    'a second event under one id must not be written',
+  );
+  // The refusal has to be actionable, not just correct.
+  try {
+    append(f, ev({ ts: '2026-07-26T10:06:00.000Z', ev: 'decision', data: { id: 'D-1', text: 'again' } }));
+    assert.fail('expected a refusal');
+  } catch (error) {
+    assert.match(error.message, /next-id/, 'the message names the command that issues a free one');
+  }
+  assert.equal(readJournal(f).events.length, 1, 'nothing was appended by the refused calls');
+});
+
+test('a FRESH explicit id still wins — the capability is not removed', () => {
+  // The narrow fix, pinned. Refusing every caller-supplied id was the broader
+  // proposal; it removes a documented capability to prevent a failure that
+  // only occurs on collision. An id nobody has used is not a collision.
+  const f = tmp();
+  append(f, ev({ ev: 'decision', data: { id: 'D-1', text: 'first' } }));
+  const mine = append(f, ev({ ts: '2026-07-26T10:05:00.000Z', ev: 'decision', data: { id: 'D-99', text: 'mine' } }));
+  assert.equal(mine.data.id, 'D-99');
+  // And an omitted id is still minted, past the explicit one.
+  const issued = append(f, ev({ ts: '2026-07-26T10:06:00.000Z', ev: 'decision', data: { text: 'issued' } }));
+  assert.equal(issued.data.id, 'D-100');
+});
+
+test('the collision check is per EVENT TYPE, not across the journal', () => {
+  // `decision` and `finding` mint from different prefixes, so a D-1 and an
+  // F-1 are not the same id and never collide. MUTANT: compare ids globally —
+  // the second write here would be refused for no reason.
+  const f = tmp();
+  append(f, ev({ ev: 'decision', data: { id: 'X-1', text: 'a decision' } }));
+  const finding = append(f, ev({ ts: '2026-07-26T10:05:00.000Z', ev: 'finding', data: { id: 'X-1', area: 'a', claim: 'c' } }));
+  assert.equal(finding.data.id, 'X-1');
+});
+
+test('an id collision on a type that does not mint ids is not this check', () => {
+  // `ticket.created` carries `data.id` and is deliberately absent from
+  // ID_ISSUED_FOR: ticket ids come from the plan, which numbers its own
+  // stories, and a plan may legitimately restate one. MUTANT: apply the check
+  // to every event carrying an id.
+  const f = tmp();
+  append(f, ev({ ev: 'ticket.created', data: { id: 'T-1', title: 'first' } }));
+  const again = append(f, ev({ ts: '2026-07-26T10:05:00.000Z', ev: 'ticket.created', data: { id: 'T-1', title: 'restated' } }));
+  assert.equal(again.data.id, 'T-1');
+});

--- a/tests/unit/scan-control-chars.test.mjs
+++ b/tests/unit/scan-control-chars.test.mjs
@@ -905,6 +905,7 @@ test('THIS repository scans clean end to end', () => {
     "scripts/cost.mjs",
     "scripts/desc-budget.mjs",
     "scripts/doctor.mjs",
+    "scripts/ensure-gitleaks.mjs",
     "scripts/hooks-check.mjs",
     "scripts/invisible.mjs",
     "scripts/journal.mjs",


### PR DESCRIPTION
## The gitleaks wall

The secrets gate refuses everything until a scanner exists — correct, and
unchanged. What the design left with the operator was the **installing**, and
some people adopting Tyran have no Homebrew, no admin rights, or are on
Windows. Their realistic answer to "install it and re-run" is switching the
hook off, and a gate nobody can satisfy protects nothing.

`scripts/ensure-gitleaks.mjs` fetches it: pinned version **and** pinned
SHA-256 per platform, from the release's own `checksums.txt` (the linux-x64
line cross-checks against what `ci.yml` already pins). A mismatch deletes the
download and installs nothing. Verified end to end with a temp HOME and
gitleaks stripped from PATH.

**The location is the security argument.** My first version put it in
`<repo>/.tyran/bin/` and that was wrong: a repo path travels with a clone, so
a planted binary reporting clean on everything would arrive **with the
checkout** — the attack the tracked-only rule for `.gitleaksignore` already
prevents, reopened through a file that is not even in a diff. `~/.tyran/bin/`
makes it the operator's machine, like PATH, and one install serves every repo.
PATH is still consulted first, so nobody's own newer gitleaks is displaced.

## Writing a prompt is now a top-tier job

`retro` ran at `work` and **never reached `top` at any profile**, so the agent
that writes skills, agents and prompts ran on the middle model. New `authoring`
role at `top` everywhere with `top`/`max` floors, kept separate from `retro` so
ledger bookkeeping doesn't burn the tier. `security-review`'s argument in
stronger form: a bad verdict costs one merge; a bad prompt misroutes every run
that reads it, and nothing downstream checks it.

## Duplicate ledger ids

Two parallel implementers each passed an id, both were honoured, and "see F-7"
is ambiguous forever. `append` now refuses a caller-supplied id **already used
for that event type** — narrow on purpose: refusing every explicit id removes a
documented capability (a test pins it) to prevent a failure that only occurs on
collision. Per event type, under the write lock.

## Refusals you can paste

The multi-remote push refusal is **correct** — excluding commits on ANY remote
let a key on a private upstream reach a public origin unscanned — but it was
reported twice as a false positive because it handed over `git push <remote>
<branch>`, a shape to translate. It now prints one runnable line per remote
with the branch filled in.

## Reviewers stop retyping evidence

`tyran:reviewer` has no MCP tools, so evidence arrives as text and gets
retyped — measured at **1.6% silently wrong**. The roster cannot express the
fix (`tools:` is static; MCP names differ per install), so the prompt closes
it: require the raw bytes on disk and `Read` them.

## Verification

- 1459/1459 pass, 0 skipped (+8)
- control-chars clean over 265 tracked files; new script added to the pinned
  scan list by name
- desc-budget 4352/5000; templates validate
- site builds, check-base-prefix 533/533
- docs updated on **both** surfaces

🤖 Generated with [Claude Code](https://claude.com/claude-code)