### PR TITLE
fix(knowledge): the store was write-only and nothing said so

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,37 @@
 
 ## Unreleased
 
+### The knowledge store was write-only, and nothing said so
+
+Measured on a real install: `knowledge.mjs brief '**'` returned **1 of 31
+entries**. The other thirty were dropped by the 4000-codepoint budget, and
+104,178 codepoints of hard-won detail — migration-number races, TEST/PROD
+schema drift, a deploy gate that silently blocks on the commit author — had
+been accumulating for months and reaching nobody.
+
+That is the opposite of the failure people expect from a growing store. It is
+not expensive to read; it is **unread**, while growing without bound.
+
+Every piece of the machinery was already correct and none of it added up. The
+budget is deliberately the pressure that keeps entries scoped. Each brief
+already names what it omitted. `doctor` already warned per oversized entry —
+five times on that install. What nobody had was the total, and five local
+tidy-up notes are not the same message as "your knowledge store is 97%
+unread". Only the second one gets acted on.
+
+`knowledge.mjs audit` reports it: how many entries could reach ONE brief, how
+many could not, and — the diagnostic that matters most — which entries are so
+wide they cannot appear **even alone**, where no budget any caller passes will
+ever reach them. Eight of that install's thirty-one are in that state; the
+widest is 10,210 codepoints, two and a half times the whole budget.
+`doctor --state` carries the same number as `knowledge-store-unreachable`
+(`info` — a store outgrows the budget in the ordinary course of being useful).
+
+It measures and never edits. Which of two overlapping entries is the true one
+is a judgement, and a script that guessed would delete exactly the detail the
+store exists to hold — so consolidation is a retrospective step that writes a
+**new** file for review and leaves the original untouched.
+
 ### The prerequisite that blocked day one
 
 The secrets gate refuses every commit and push until `gitleaks` exists, and

--- a/README.md
+++ b/README.md
@@ -297,7 +297,7 @@ enforces the cap (4352 of 5000 characters). What each one assumes, when it
 fires and who invokes it, is in
 [skills and agents](https://jjanczur.github.io/tyran/skills/); the prompts
 themselves are in [`skills/`](skills/) and [`agents/`](agents/). Behind all of
-it: 1459 unit tests, run with `node --test "tests/**/*.test.mjs"`.
+it: 1464 unit tests, run with `node --test "tests/**/*.test.mjs"`.
 
 ## Documentation
 

--- a/docs/doctor.md
+++ b/docs/doctor.md
@@ -83,6 +83,7 @@ possible to change one and keep the suite green.
 | `policies-unreadable` | error | `policies/` could not be listed (errno printed) — **not** "zero policies" |
 | `knowledge-not-a-directory` · `policies-not-a-directory` | warning | the path exists but is not a directory, so nothing in it was checked |
 | `knowledge-entry-oversized` | warning | an entry's `text` exceeds the size a budgeted brief can carry — it validates, but it crowds out every other entry `knowledge.mjs brief` would select |
+| `knowledge-store-unreachable` | info | how many entries can reach ONE budgeted brief, and how many cannot. The aggregate of the line above: measured on a real install the per-entry warning fired five times while `brief` was returning 1 of 31 entries and 104,178 codepoints reached nobody. Info, because a store outgrows the budget in the ordinary course of being useful — but the ratio is the number that gets acted on |
 | `policy-kernel-downgrade` | error | a rule that tries to lower a protected kernel path |
 | `policy-rule-dead` | warning | a rule glob that can never match any path |
 | `policy-rule-overruled` | warning | a rule that quietly fails to cover part of what it looks like it covers |

--- a/docs/self-improvement.md
+++ b/docs/self-improvement.md
@@ -113,6 +113,27 @@ received. The retrospective folds those verdicts into the counters at close
 (the procedure lives in the retro skill, its one home). An entry nobody
 reports as helpful is a retirement candidate on evidence, not on taste.
 
+**The budget is pressure, and somebody has to look at the total.** The brief
+names what it omitted on every run, but nothing added those omissions up —
+and measured on a real install the store had reached the state where
+`brief '**'` returned **1 of 31 entries**: 104,178 codepoints of hard-won
+detail, read by nobody, while a per-entry oversize warning fired five times
+and read as a small untidiness each time.
+
+```bash
+node scripts/knowledge.mjs audit --dir .tyran/knowledge
+```
+
+It answers the aggregate question — how many entries could reach ONE brief,
+how many could not, and which are so wide they cannot appear even alone, where
+no budget a caller passes will ever reach them. `doctor --state` carries the
+same number as `knowledge-store-unreachable`.
+
+It is a MEASUREMENT and never an edit. Which of two overlapping entries is the
+true one is a judgement, and a script that guessed would delete exactly the
+detail the store exists to hold — so consolidation is a retrospective step
+that writes a **new** file for you to review, leaving the original untouched.
+
 ## Where a lesson lands: four stores, four questions
 
 A fourth store is only defensible if it answers a question none of the others

--- a/scripts/doctor.mjs
+++ b/scripts/doctor.mjs
@@ -62,6 +62,7 @@ import {
   STATE_FILE,
 } from './project.mjs';
 import { classifyPath, normalizePath, validateFile, knowledgeWarnings, MANDATORY_KERNEL_PATHS } from './schema.mjs';
+import { auditEntries, loadEntries as loadKnowledgeEntries } from './knowledge.mjs';
 import { gitRunner } from './scan-repo.mjs';
 import { parseMistakes, countSignatures, fenceState, KNOWLEDGE_THRESHOLD, MISTAKES_FILE, CLAUDE_MD_FILE } from './mistakes.mjs';
 
@@ -202,6 +203,11 @@ export const SEVERITY_BY_CODE = Object.freeze(
     'knowledge-unreadable': 'error',
     'knowledge-not-a-directory': 'warning',
     'knowledge-entry-oversized': 'warning',
+    // The AGGREGATE of the line above. `info`, not `warning`: nothing is
+    // broken and a store outgrows the budget in the ordinary course of being
+    // useful — but "1 of 31 entries reaches a brief" is the number that gets
+    // acted on, and five per-entry notes never added up to it for anyone.
+    'knowledge-store-unreachable': 'info',
     // Not `info`, which is what it was: with `.tyran/` on disk and no policy
     // under it the gate refuses every write in the repository. A severity that
     // does not fail the check reports a locked-out repo as a note.
@@ -722,6 +728,45 @@ function closeSpawnHint(journalPath, init, agent) {
   return String(agent).startsWith('-')
     ? `node scripts/journal.mjs close-spawn ${sq(journalPath)} --reason "<why>" ${sq(slug)} -- ${sq(agent)}`
     : `node scripts/journal.mjs close-spawn ${sq(journalPath)} ${sq(slug)} ${sq(agent)} --reason "<why>"`;
+}
+
+/**
+ * Is the knowledge store actually READABLE, as a whole?
+ *
+ * Every failure returns [] rather than throwing: this is advisory, it runs
+ * after the checks that decide whether the repo works at all, and a store
+ * that cannot be listed is already reported by `yamlFilesIn` above.
+ */
+function knowledgeReachability(knowledgeDir) {
+  let entries;
+  try {
+    if (!isDirectory(knowledgeDir)) return [];
+    ({ entries } = loadKnowledgeEntries(knowledgeDir));
+  } catch {
+    return [];
+  }
+  if (!Array.isArray(entries) || entries.length === 0) return [];
+  const report = auditEntries(entries);
+  // Silent while the store still fits: pressure that is being obeyed is not a
+  // finding, and a check that is red on every healthy repo is one people skip.
+  if (report.unreachable === 0) return [];
+  const stuck = report.aloneTooBig;
+  const detail =
+    stuck.length === 0
+      ? ''
+      : ` ${stuck.length} of them cannot appear in ANY brief even alone (widest: ` +
+        `${show(stuck[0].id)} at ${stuck[0].cost}), so no budget a caller passes will reach them.`;
+  return [
+    finding(
+      'knowledge-store-unreachable',
+      show(knowledgeDir),
+      `${report.reachable} of ${report.entries} knowledge entries can reach one brief at the ` +
+        `${report.budget}-codepoint budget; ${report.unreachable} cannot.${detail} The store is written ` +
+        'by every retrospective and read through that budget, so what does not fit is not merely ' +
+        'crowded — it reaches nobody',
+      `node scripts/knowledge.mjs audit --dir ${sq(knowledgeDir)}   # the full list, widest first`,
+    ),
+  ];
 }
 
 /** How many unread keys are named before the rest are counted instead. */
@@ -1699,6 +1744,15 @@ export function runStateChecks({ dir = '.tyran', now = null, staleHours = DEFAUL
     }
   }
   checked.push(`knowledge/: ${knowledge.files.length} file(s)`);
+  // The AGGREGATE, which the per-entry warning above cannot show.
+  //
+  // `knowledge-entry-oversized` fires once per fat entry and each one reads as
+  // a small, local untidiness. Measured on a real install it fired five times
+  // while the true state was that `brief` returned ONE of thirty-one entries:
+  // 104,178 codepoints of hard-won detail, reaching nobody. Five tidy-up notes
+  // and "your knowledge store is 97% unread" are not the same message, and
+  // only the second one gets acted on.
+  findings.push(...knowledgeReachability(join(dir, 'knowledge')));
 
   const policies = yamlFilesIn(join(dir, 'policies'), 'policies');
   findings.push(...policies.findings);

--- a/scripts/knowledge.mjs
+++ b/scripts/knowledge.mjs
@@ -143,6 +143,60 @@ export function renderBrief(selected, matched, { budget = DEFAULT_BUDGET, dir = 
   return [header, ...lines, ...tail].join('\n') + '\n';
 }
 
+/**
+ * Which entries can never reach a handoff, and why.
+ *
+ * The budget is deliberately the pressure that keeps entries scoped, and the
+ * omission line names the cost of every individual brief. What nothing did
+ * was AGGREGATE that: measured on a real install, `brief '**'` returned **1
+ * of 31 entries** and the other thirty were dropped by the 4000-codepoint
+ * budget. Ninety kilobytes of measured detail — migration-number races,
+ * TEST/PROD schema drift — accumulated for months and reached nobody.
+ *
+ * That is the opposite of the failure people expect. The store is not
+ * expensive to read; it is unread, while growing without bound, and the
+ * pressure the budget applies lands on nothing because no one is looking at
+ * the total.
+ *
+ * So this reports the whole store against the budget at once. It is a
+ * MEASUREMENT, never an edit: pruning needs judgement about which of two
+ * overlapping entries is the true one, and a script that guessed would delete
+ * exactly the hard-won detail this exists to protect.
+ *
+ * `alone` is the diagnostic that matters most: an entry that does not fit the
+ * budget even as the ONLY entry can never appear in any brief, under any
+ * paths, ever. It is not competing for space — it is unreachable.
+ */
+export function auditEntries(entries, { budget = DEFAULT_BUDGET } = {}) {
+  const sized = entries.map((entry) => {
+    const cost = Array.from(entryLine(entry)).length + 1;
+    return { id: entry.id, kind: entry.kind, confidence: entry.confidence, cost, alone: cost > budget };
+  });
+  // Ranked the way `brief` ranks, so "would reach a brief" means what a brief
+  // would actually do rather than what this function finds convenient.
+  const ranked = [...sized].sort((a, b) => (b.confidence ?? 0) - (a.confidence ?? 0));
+  let used = 0;
+  let reachable = 0;
+  for (const entry of ranked) {
+    if (used + entry.cost > budget && reachable > 0) break;
+    used += entry.cost;
+    reachable += 1;
+  }
+  const total = sized.reduce((sum, e) => sum + e.cost, 0);
+  return {
+    budget,
+    entries: sized.length,
+    // How many a single widest-possible brief could carry.
+    reachable,
+    unreachable: sized.length - reachable,
+    // Entries too large to appear even alone — the ones pruning must address
+    // first, because no budget any caller passes will rescue them.
+    aloneTooBig: sized.filter((e) => e.alone).map((e) => ({ id: e.id, cost: e.cost })),
+    totalCost: total,
+    widest: sized.slice().sort((a, b) => b.cost - a.cost).slice(0, 5).map((e) => ({ id: e.id, cost: e.cost })),
+  };
+}
+
 // ---------------------------------------------------------------- CLI
 
 const VALUE_FLAGS = ['dir', 'kinds', 'limit', 'budget'];
@@ -190,8 +244,10 @@ function parseArgs(argv) {
 
 function main() {
   const [command, ...rest] = process.argv.slice(2);
-  const usage = 'usage: knowledge.mjs brief [<path>...] [--dir <knowledge-dir>] [--kinds k,k] [--limit N] [--budget CHARS] [--json]';
-  if (command !== 'brief') {
+  const usage =
+    'usage: knowledge.mjs brief [<path>...] [--dir <knowledge-dir>] [--kinds k,k] [--limit N] [--budget CHARS] [--json]\n' +
+    '       knowledge.mjs audit [--dir <knowledge-dir>] [--budget CHARS] [--json]';
+  if (command !== 'brief' && command !== 'audit') {
     console.error(usage);
     process.exit(2);
   }
@@ -229,6 +285,37 @@ function main() {
     }
     console.error('knowledge: refusing to brief from a store that does not validate — a partial brief reads as a complete one');
     process.exitCode = 1;
+    return;
+  }
+
+  if (command === 'audit') {
+    const report = auditEntries(entries, { budget: flags.budget });
+    if (flags.json) {
+      console.log(jsonEscapeInvisible(JSON.stringify(report, null, 2)));
+      process.exitCode = 0;
+      return;
+    }
+    const out = [
+      `knowledge audit (${escapeInvisible(flags.dir)})`,
+      `  ${report.entries} entries, ${report.totalCost} codepoints total`,
+      `  ${report.reachable} could reach one brief at the ${report.budget}-codepoint budget; ` +
+        `${report.unreachable} could not`,
+    ];
+    if (report.aloneTooBig.length > 0) {
+      const n = report.aloneTooBig.length;
+      out.push(`  ${n} entr${n === 1 ? 'y' : 'ies'} cannot appear in ANY brief, even alone:`);
+      for (const e of report.aloneTooBig) out.push(`    ${escapeInvisible(e.id)} — ${e.cost} codepoints`);
+    }
+    if (report.widest.length > 0) {
+      out.push('  widest:');
+      for (const e of report.widest) out.push(`    ${escapeInvisible(e.id)} — ${e.cost}`);
+    }
+    // A measurement, never an edit: which of two overlapping entries is the
+    // true one is a judgement, and a script that guessed would delete the
+    // hard-won detail this exists to protect.
+    out.push('  This reports; it never edits. /tyran:retro consolidates, writing a NEW file for review.');
+    process.stdout.write(out.join('\n') + '\n');
+    process.exitCode = 0;
     return;
   }
 

--- a/site/src/content/docs/doctor.mdx
+++ b/site/src/content/docs/doctor.mdx
@@ -90,6 +90,7 @@ possible to change one and keep the suite green.
 | `policies-unreadable` | error | `policies/` could not be listed (errno printed) — **not** "zero policies" |
 | `knowledge-not-a-directory` · `policies-not-a-directory` | warning | the path exists but is not a directory, so nothing in it was checked |
 | `knowledge-entry-oversized` | warning | an entry's `text` exceeds the size a budgeted brief can carry — it validates, but it crowds out every other entry `knowledge.mjs brief` would select |
+| `knowledge-store-unreachable` | info | how many entries can reach ONE budgeted brief, and how many cannot. The aggregate of the line above: measured on a real install the per-entry warning fired five times while `brief` was returning 1 of 31 entries and 104,178 codepoints reached nobody. Info, because a store outgrows the budget in the ordinary course of being useful — but the ratio is the number that gets acted on |
 | `policy-kernel-downgrade` | error | a rule that tries to lower a protected kernel path |
 | `policy-rule-dead` | warning | a rule glob that can never match any path |
 | `policy-rule-overruled` | warning | a rule that quietly fails to cover part of what it looks like it covers |

--- a/site/src/content/docs/self-improvement.mdx
+++ b/site/src/content/docs/self-improvement.mdx
@@ -115,6 +115,27 @@ received. The retrospective folds those verdicts into the counters at close
 (the procedure lives in the retro skill, its one home). An entry nobody
 reports as helpful is a retirement candidate on evidence, not on taste.
 
+**The budget is pressure, and somebody has to look at the total.** The brief
+names what it omitted on every run, but nothing added those omissions up —
+and measured on a real install the store had reached the state where
+`brief '**'` returned **1 of 31 entries**: 104,178 codepoints of hard-won
+detail, read by nobody, while a per-entry oversize warning fired five times
+and read as a small untidiness each time.
+
+```bash
+node scripts/knowledge.mjs audit --dir .tyran/knowledge
+```
+
+It answers the aggregate question — how many entries could reach ONE brief,
+how many could not, and which are so wide they cannot appear even alone, where
+no budget a caller passes will ever reach them. `doctor --state` carries the
+same number as `knowledge-store-unreachable`.
+
+It is a MEASUREMENT and never an edit. Which of two overlapping entries is the
+true one is a judgement, and a script that guessed would delete exactly the
+detail the store exists to hold — so consolidation is a retrospective step
+that writes a **new** file for you to review, leaving the original untouched.
+
 ## Where a lesson lands: four stores, four questions
 
 A fourth store is only defensible if it answers a question none of the others

--- a/tests/unit/doctor.test.mjs
+++ b/tests/unit/doctor.test.mjs
@@ -1673,6 +1673,7 @@ const EXPECTED_SEVERITY = {
   'knowledge-unreadable': 'error',
   'knowledge-not-a-directory': 'warning',
   'knowledge-entry-oversized': 'warning',
+  'knowledge-store-unreachable': 'info',
   'tyran-dir-untracked': 'warning',
   'policy-missing': 'error',
   'policy-invalid': 'error',

--- a/tests/unit/knowledge.test.mjs
+++ b/tests/unit/knowledge.test.mjs
@@ -11,6 +11,7 @@ import {
   selectEntries,
   renderBrief,
   knowledgeFiles,
+  auditEntries,
   DEFAULT_BUDGET,
 } from '../../scripts/knowledge.mjs';
 
@@ -242,4 +243,58 @@ test('--dir naming a FILE is exit 2 — an empty brief must not claim the store 
   const r = cli(['brief', 'x', '--dir', join(d, 'k.yaml')]);
   assert.equal(r.code, 2);
   assert.match(r.stderr, /not a directory/);
+});
+
+// --- is the store readable AS A WHOLE? ----------------------------------
+
+const sized = (id, chars, confidence = 0.9) => ({
+  id, kind: 'gotcha', confidence, text: 'x'.repeat(chars), applies_to: ['**'], file: 'k.yaml',
+});
+
+test('the audit reports how many entries can reach ONE brief', () => {
+  // The per-entry oversize warning fires once per fat entry and each reads as
+  // a small local untidiness. Measured on a real install it fired five times
+  // while `brief` was returning 1 of 31 entries — 104,178 codepoints reaching
+  // nobody. MUTANT: report only the count of oversized entries; the ratio is
+  // the number that gets acted on and the per-entry note never added up to it.
+  const report = auditEntries([sized('a', 1500), sized('b', 1500), sized('c', 1500)], { budget: 4000 });
+  assert.equal(report.entries, 3);
+  assert.equal(report.reachable, 2, 'two fit the budget; the third does not');
+  assert.equal(report.unreachable, 1);
+});
+
+test('an entry too big to appear ALONE is called out separately', () => {
+  // The diagnostic that matters most: this entry is not competing for space,
+  // it is unreachable under any budget a caller passes. MUTANT: fold it into
+  // the plain unreachable count and the remedy becomes "raise the budget",
+  // which cannot work.
+  const report = auditEntries([sized('small', 100), sized('huge', 9000)], { budget: 4000 });
+  assert.deepEqual(report.aloneTooBig.map((e) => e.id), ['huge']);
+  assert.ok(report.aloneTooBig[0].cost > 4000);
+});
+
+test('a store that fits reports nothing unreachable', () => {
+  // Pressure that is being obeyed is not a finding — a check red on every
+  // healthy repo is one people learn to skip.
+  const report = auditEntries([sized('a', 100), sized('b', 100)], { budget: 4000 });
+  assert.equal(report.unreachable, 0);
+  assert.deepEqual(report.aloneTooBig, []);
+});
+
+test('reachability is counted the way brief actually ranks', () => {
+  // MUTANT: count in file order. `brief` ranks by confidence, so an audit that
+  // counted differently would report a reachability no brief ever delivers.
+  const report = auditEntries([sized('low', 3000, 0.1), sized('high', 3000, 0.99)], { budget: 4000 });
+  assert.equal(report.reachable, 1);
+  assert.equal(report.widest.length, 2, 'both are still measured and listed');
+});
+
+test('the audit never edits — it returns a measurement', () => {
+  // Which of two overlapping entries is the true one is a judgement, and a
+  // script that guessed would delete exactly the hard-won detail the store
+  // exists to hold. Consolidation is a retro step that writes a NEW file.
+  const entries = [sized('a', 9000)];
+  const before = JSON.stringify(entries);
+  auditEntries(entries, { budget: 4000 });
+  assert.equal(JSON.stringify(entries), before, 'inputs are untouched');
 });


### PR DESCRIPTION
Measured on a real install: `knowledge.mjs brief '**'` returns **1 of 31
entries**. The other thirty are dropped by the 4000-codepoint budget, and
104,178 codepoints of hard-won detail — migration-number races, TEST/PROD
schema drift, a deploy gate that silently blocks on the commit author — have
been accumulating for months and reaching nobody.

That is the opposite of the failure a growing store is expected to cause. It
isn't expensive to read; it is **unread**, while growing without bound.

## Why nothing caught it

Every piece was already correct and none of it added up:

- the budget is deliberately the pressure that keeps entries scoped
- every brief already names what it omitted
- `doctor` already warned per oversized entry — **five times** on that install

Nobody had the total. Five local tidy-up notes and *"97% of your knowledge
store is unread"* are not the same message, and only the second gets acted on.

## What this adds

`knowledge.mjs audit` reports the aggregate, and separates the diagnostic that
matters most: entries too wide to appear **even alone**, which no budget any
caller passes will ever reach. Eight of that install's thirty-one are in that
state; the widest is 10,210 codepoints — 2.5× the whole budget.

```
31 entries, 104178 codepoints total
1 could reach one brief at the 4000-codepoint budget; 30 could not
8 entries cannot appear in ANY brief, even alone
```

`doctor --state` carries the same number as `knowledge-store-unreachable`,
at `info`: a store outgrows the budget in the ordinary course of being useful,
and a check red on every healthy repo is one people learn to skip.

## What it deliberately does not do

It measures and **never edits**. Which of two overlapping entries is the true
one is a judgement, and a script that guessed would delete exactly the detail
the store exists to hold. Consolidation is a retrospective step that writes a
**new** file and leaves the original untouched — the same property that makes
the dreams pipeline safe to run unattended.

## Verification

- 1464/1464 pass, 0 skipped (+5)
- control-chars clean over 265 tracked files; desc-budget 4352/5000
- site builds, check-base-prefix 533/533
- severity row in `SEVERITY_BY_CODE`, `EXPECTED_SEVERITY`, and **both** doc
  surfaces

🤖 Generated with [Claude Code](https://claude.com/claude-code)