### PR TITLE
feat(onboarding): one command, one restart, one paste — and the board opens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,42 @@
 
 ## Unreleased
 
+### Installation reaches the dashboard now
+
+Install was four steps, a restart, and then a board nobody opened. Every one
+of those is a place to stop, and the last one mattered most: `--serve` printed
+a URL to a terminal and **nothing ever launched a browser**, so the screen
+where Tyran becomes legible was the one thing installation never reached.
+
+`install.sh` does everything a machine can:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/jjanczur/tyran/main/install.sh | sh
+```
+
+Node version check first, because every hook shells out to `node` and an old
+one does not fail at install time — it fails later as a gate that cannot run,
+which is the hardest thing for a non-technical operator to read. Then the
+plugin, then the pinned scanner, then the prompt to paste after the restart.
+
+The restart is the one step that stays manual and it is not a shortcut not
+taken: Claude Code loads plugins at startup and nothing inside a session can
+make the app reload itself. So it is stated plainly and put last.
+
+`board.mjs --serve --open` launches the browser, best-effort and never fatal —
+a headless machine or an SSH session leaves the server running and the URL
+printed, exactly where things were before. `--open` without `--serve` is a
+usage error, like `--write`.
+
+Setup gained two steps: install the scanner before anything needs it, and
+**look for pre-existing secrets before the operator hits them**. A repository
+whose history already holds a key is common, and the gate handles it badly by
+surprise — nothing is scanned until someone edits that file, and then every
+commit touching it is refused, permanently, for a reason years old. Setup now
+says what is there and explains the choice, including the part that is easy to
+leave out: a tracked baseline makes the tool quiet, it does not make the key
+safe, and if the repo is public that key is already burned.
+
 ### The knowledge store was write-only, and nothing said so
 
 Measured on a real install: `knowledge.mjs brief '**'` returned **1 of 31

--- a/README.md
+++ b/README.md
@@ -176,7 +176,17 @@ count, not the price of a model.
 
 ## Install
 
-Inside Claude Code:
+One command, then one restart, then one paste:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/jjanczur/tyran/main/install.sh | sh
+```
+
+It checks Node, installs the plugin, installs the secrets scanner the write
+gate needs, and prints the prompt to paste after you restart — which runs
+setup and opens the dashboard in your browser.
+
+Or do it by hand, inside Claude Code:
 
 ```text
 /plugin marketplace add jjanczur/tyran
@@ -297,7 +307,7 @@ enforces the cap (4352 of 5000 characters). What each one assumes, when it
 fires and who invokes it, is in
 [skills and agents](https://jjanczur.github.io/tyran/skills/); the prompts
 themselves are in [`skills/`](skills/) and [`agents/`](agents/). Behind all of
-it: 1464 unit tests, run with `node --test "tests/**/*.test.mjs"`.
+it: 1467 unit tests, run with `node --test "tests/**/*.test.mjs"`.
 
 ## Documentation
 

--- a/bin/tyran.mjs
+++ b/bin/tyran.mjs
@@ -56,6 +56,14 @@ export const COMMANDS = {
     'scan-repo.mjs',
     'Deterministic repo scan for /tyran:setup — establishes what it can, marks what needs confirmation, never guesses.',
   ],
+  'ensure-gitleaks': [
+    'ensure-gitleaks.mjs',
+    'Install the pinned, checksummed gitleaks the secrets gate needs, for a machine that has none.',
+  ],
+  migrate: [
+    'migrate.mjs',
+    'Move a pre-0.1.9 .tyran/initiatives/ directory under state/. Previews by default; never overwrites.',
+  ],
   tiers: [
     'tiers.mjs',
     'Resolve a Tyran role to a model alias via .tyran/config.yaml, the one place model names are allowed to live.',

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -2,6 +2,29 @@
 
 ## Install
 
+**One command, then one restart, then one paste.** That is the whole of it,
+and the restart is the only part no script can do — Claude Code loads plugins
+at startup and nothing inside a session can make the app reload itself.
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/jjanczur/tyran/main/install.sh | sh
+```
+
+It checks Node, installs the plugin, installs the secrets scanner the write
+gate needs, and then prints the prompt to paste after you restart. That last
+prompt runs setup, proves the install works, and **opens the dashboard in your
+browser** — because everything before that point is files on disk, and the
+board is where any of it becomes something you can look at.
+
+You do not need to know what a gate, a tier or an autonomy class is to use
+this. Setup works out what it can from the repository and asks you at most one
+question in ordinary words. Everything it decides is written down with the
+reason, and all of it is editable later from the dashboard's **Settings** tab
+rather than by hand.
+
+## Install, step by step
+
+
 **Paste this into Claude Code and let it install itself.** `/plugin` is a
 slash command a human has to type, so this asks for the same steps through
 the `claude` CLI instead, which Claude Code can run on its own — followed by

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,83 @@
+#!/bin/sh
+# Tyran installer — everything a machine can do without a human in the loop.
+#
+# One restart cannot be automated: Claude Code loads plugins at startup, and
+# nothing inside a session can make the app reload itself. So this does every
+# other step, and ends by printing the ONE thing left to paste afterwards.
+# Telling someone "and now run four more commands" is where installs are
+# abandoned; telling them "restart, then paste this" is not.
+#
+#   curl -fsSL https://raw.githubusercontent.com/jjanczur/tyran/main/install.sh | sh
+#
+# It is deliberately POSIX sh with no dependencies beyond node and the claude
+# CLI, because the people this exists for are the ones least likely to have a
+# working toolchain to fix it with.
+#
+# Nothing here is irreversible: the plugin install is undone with
+# `claude plugin uninstall`, and the scanner is one file under ~/.tyran/bin.
+set -eu
+
+say() { printf '%s\n' "$*"; }
+fail() { printf 'tyran: %s\n' "$*" >&2; exit 1; }
+
+say ""
+say "  Tyran — setting up everything that does not need you"
+say ""
+
+# ---------------------------------------------------------------- node
+# Checked FIRST and by version, because every hook shells out to `node`: an
+# old one does not fail at install time, it fails later as a gate that cannot
+# run, which is the hardest possible thing for a non-technical user to read.
+command -v node >/dev/null 2>&1 || fail "node is not installed. Tyran needs Node 22 or newer — https://nodejs.org"
+NODE_MAJOR=$(node -p 'process.versions.node.split(".")[0]' 2>/dev/null || echo 0)
+[ "$NODE_MAJOR" -ge 22 ] 2>/dev/null || fail "node $(node -v 2>/dev/null) is too old — Tyran needs 22 or newer."
+say "  ✓ node $(node -v)"
+
+# ---------------------------------------------------------------- claude CLI
+command -v claude >/dev/null 2>&1 || fail "the claude CLI is not installed — see https://claude.com/claude-code"
+say "  ✓ claude CLI"
+
+# ---------------------------------------------------------------- the plugin
+# Both commands are idempotent: re-running the installer on a machine that
+# already has Tyran is a no-op that re-verifies, not a second copy.
+say "  … installing the plugin"
+claude plugin marketplace add jjanczur/tyran >/dev/null 2>&1 || true
+claude plugin install tyran@tyran >/dev/null 2>&1 || true
+say "  ✓ plugin installed"
+
+# ---------------------------------------------------------------- the scanner
+# The secrets gate refuses every commit and push until gitleaks exists. Doing
+# this now, rather than letting the first commit fail, is the difference
+# between a tool that works and a tool that says no on day one for a reason
+# the user cannot act on.
+say "  … checking the secrets scanner"
+if npx --yes @jjanczur/tyran ensure-gitleaks >/dev/null 2>&1; then
+  say "  ✓ secrets scanner ready"
+else
+  say "  ! could not install gitleaks automatically."
+  say "    Tyran still works; the first commit will explain what to do."
+fi
+
+say ""
+say "  Done. One step left, and only you can do it:"
+say ""
+say "  1. Restart Claude Code (quit and reopen — it loads plugins at startup)."
+say "  2. Paste this into a Claude Code session in the repo you want to use:"
+say ""
+say "  ─────────────────────────────────────────────────────────────────"
+cat <<'PROMPT'
+  Set Tyran up for this repository and show me the dashboard.
+
+  Run /tyran:setup. Work out what you can from the repo itself and ask me
+  at most one question, in plain language, about anything you genuinely
+  cannot establish. Then run /tyran:doctor to prove the install works, and
+  start the dashboard with:
+
+    node "${CLAUDE_PLUGIN_ROOT}/scripts/board.mjs" --dir .tyran --serve --write --open
+
+  Tell me in plain words what you set up and what the dashboard shows me.
+  If this repo already contains secrets in its history, say so and explain
+  my options before changing anything.
+PROMPT
+say "  ─────────────────────────────────────────────────────────────────"
+say ""

--- a/scripts/board.mjs
+++ b/scripts/board.mjs
@@ -21,11 +21,12 @@
  *
  * CLI:
  *   node board.mjs [--dir <.tyran>] [--check]
- *                  [--serve [--port <n>] [--write] [--transcripts <dir>]...]
+ *                  [--serve [--port <n>] [--write] [--open] [--transcripts <dir>]...]
  * Exit: 0 ok · 1 drift (--check) · 2 usage/IO
  */
 import { existsSync, readdirSync, statSync, readFileSync } from 'node:fs';
 import { createServer } from 'node:http';
+import { spawn as spawnProcess } from 'node:child_process';
 import { basename, join, resolve } from 'node:path';
 import { realpathSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
@@ -51,6 +52,42 @@ import { runState } from './overnight.mjs';
 import { answerOne, answerProblem, classify, openAsks, partitionAsks, reRender, sortAsks } from './answer.mjs';
 
 export const BOARD_HTML_FILE = 'board.html';
+
+/**
+ * Open the served board in the operator's browser.
+ *
+ * The board was a URL printed to a terminal that nothing ever opened, and for
+ * the people this matters most to that is several steps — keep this window
+ * running, now type that address somewhere else — each one a place to stop.
+ * The dashboard is where Tyran becomes legible, and it was the one thing
+ * installation never actually reached.
+ *
+ * Best-effort and never fatal: a failure here leaves the server running and
+ * the URL printed, which is exactly where things were before. Headless
+ * machines, SSH sessions and locked-down desktops all land in that branch and
+ * none of them is an error worth taking a working server down for.
+ *
+ * The argument vector is fixed and the URL is the only variable — it is built
+ * from a port this process is already listening on, never from user text —
+ * and `shell: false` (the default) means nothing here reaches a shell.
+ */
+export function openInBrowser(url, { platform = process.platform, spawn = spawnProcess } = {}) {
+  const [command, args] =
+    platform === 'darwin' ? ['open', [url]]
+      : platform === 'win32' ? ['cmd', ['/c', 'start', '', url]]
+        : ['xdg-open', [url]];
+  try {
+    const child = spawn(command, args, { stdio: 'ignore', detached: true });
+    // A missing `open`/`xdg-open` arrives as an async error event, not a
+    // throw, so the catch below would never see it — and an unhandled one
+    // would take the server down, which is the opposite of best-effort.
+    child.on?.('error', () => { /* no browser here; the printed URL still works */ });
+    child.unref?.();
+    return true;
+  } catch {
+    return false;
+  }
+}
 
 /** Same ceiling as the evidence gate's journal locator — a deliberate
  * duplicate: scripts must not import from hook files (direction is
@@ -570,14 +607,14 @@ function handleSettingsWrite(dir, route, body) {
 
 // ------------------------------------------------------------------- CLI
 
-const BOOLEAN_FLAGS = ['check', 'serve', 'write'];
+const BOOLEAN_FLAGS = ['check', 'serve', 'write', 'open'];
 const VALUE_FLAGS = ['dir', 'port'];
 // Repeatable, unlike VALUE_FLAGS: sources are the union over every directory
 // given, exactly like cost.mjs's own `--transcripts`.
 const REPEATABLE_FLAGS = ['transcripts'];
 
 function parseArgs(argv) {
-  const flags = { dir: '.tyran', port: 4173, check: false, serve: false, write: false, transcripts: [] };
+  const flags = { dir: '.tyran', port: 4173, check: false, serve: false, write: false, open: false, transcripts: [] };
   for (let i = 0; i < argv.length; i += 1) {
     const arg = argv[i];
     if (!arg.startsWith('--')) throw new UsageError(`unexpected argument "${arg}"`);
@@ -616,6 +653,13 @@ function main() {
   }
   if (flags.write && !flags.serve) {
     console.error('board: --write only means anything with --serve (it is what the served page may edit)');
+    process.exit(2);
+  }
+  if (flags.open && !flags.serve) {
+    // Same refusal as --write and --transcripts, for the same reason: there is
+    // no URL to open without a server, and a flag that silently does nothing
+    // reads as configuration.
+    console.error('board: --open only means anything with --serve (there is no URL to open without it)');
     process.exit(2);
   }
   if (flags.transcripts.length > 0 && !flags.serve) {
@@ -796,10 +840,12 @@ function main() {
       process.exitCode = 2;
     });
     server.listen(flags.port, '127.0.0.1', () => {
+      const url = `http://127.0.0.1:${flags.port}/`;
       console.log(
-        `board: serving http://127.0.0.1:${flags.port}/ ` +
+        `board: serving ${url} ` +
           `(${flags.write ? 'Settings can edit config.yaml and autonomy.yaml' : 'read-only'}; Ctrl-C to stop)`,
       );
+      if (flags.open) openInBrowser(url);
     });
     return;
   }

--- a/site/src/content/docs/getting-started.mdx
+++ b/site/src/content/docs/getting-started.mdx
@@ -6,6 +6,29 @@ import { Aside, Steps, Tabs, TabItem } from '@astrojs/starlight/components';
 
 ## Install
 
+**One command, then one restart, then one paste.** That is the whole of it,
+and the restart is the only part no script can do — Claude Code loads plugins
+at startup and nothing inside a session can make the app reload itself.
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/jjanczur/tyran/main/install.sh | sh
+```
+
+It checks Node, installs the plugin, installs the secrets scanner the write
+gate needs, and then prints the prompt to paste after you restart. That last
+prompt runs setup, proves the install works, and **opens the dashboard in your
+browser** — because everything before that point is files on disk, and the
+board is where any of it becomes something you can look at.
+
+You do not need to know what a gate, a tier or an autonomy class is to use
+this. Setup works out what it can from the repository and asks you at most one
+question in ordinary words. Everything it decides is written down with the
+reason, and all of it is editable later from the dashboard's **Settings** tab
+rather than by hand.
+
+## Install, step by step
+
+
 **Paste this into Claude Code and let it install itself.** `/plugin` is a
 slash command a human has to type, so this asks for the same steps through
 the `claude` CLI instead, which Claude Code can run on its own — followed by

--- a/skills/setup/SKILL.md
+++ b/skills/setup/SKILL.md
@@ -106,6 +106,56 @@ still lives in the plugin and updates keep reaching it. Mention that it lands
 in their repo and will show up in their next commit — a file appearing in
 someone's working tree unannounced is a bad way to meet a tool.
 
+## 4b. Make the secrets gate satisfiable, and say what it found
+
+The gate refuses every commit and push until `gitleaks` exists. Install it
+before anything needs it, rather than letting the first commit fail with a
+prerequisite the operator may not be able to meet:
+
+```bash
+node "${CLAUDE_PLUGIN_ROOT}/scripts/ensure-gitleaks.mjs"
+```
+
+Pinned and checksummed, into `~/.tyran/bin/`; it is a no-op when the machine
+already has one, and PATH still wins.
+
+**Then look, before they hit it.** A repository whose history already contains
+a secret is common and the gate handles it badly by surprise: nothing is
+scanned until someone EDITS the file that holds it, and then every commit
+touching that file is refused, permanently, with no hint that the cause is
+years old. Run a scan and say plainly what is there.
+
+If there are pre-existing findings, explain the choice in the operator's
+words, and do not make it for them:
+
+- a tracked `.gitleaks-baseline.json` tells the gate "these exact findings are
+  known" — new secrets are still caught, and because it is tracked the
+  suppression appears in a diff instead of being an invisible local file;
+- **but a baseline makes the tool quiet, it does not make the key safe.** If
+  the repository is public, that key is already burned and the real fix is
+  rotating it. Say this once, here, rather than letting them discover it after
+  they have relied on the baseline.
+
+## 4c. Turn the dashboard on
+
+Setup is not finished until they have SEEN something. Everything above is
+files on disk; the board is where any of it becomes legible, and it was the
+one thing installation never actually reached.
+
+```bash
+node "${CLAUDE_PLUGIN_ROOT}/scripts/board.mjs" --dir .tyran --serve --write --open
+```
+
+`--open` launches their browser; `--write` is what makes the **Settings** tab
+able to edit `config.yaml` and the autonomy policy from the page. Tell them
+that tab exists and what it covers — profile, autonomy class, tiers,
+validation commands, shared zones, overnight limits — because for someone who
+would rather not hand-edit YAML in their own repository, that tab is the
+entire configuration story and they will not guess it is there.
+
+It holds the terminal while it serves. Say so, and say that Ctrl-C stops it
+and the board is still there next time.
+
 ## 5. Validate and report
 
 ```bash

--- a/tests/unit/board.test.mjs
+++ b/tests/unit/board.test.mjs
@@ -30,6 +30,7 @@ import {
   readInitiativeBoards,
   renderAll,
   renderCrossMd,
+  openInBrowser,
 } from '../../scripts/board.mjs';
 import { renderBoardError, renderBoardHtml } from '../../scripts/board-html.mjs';
 import { BOARD_FILE, BOARD_JSON_FILE, LANES } from '../../scripts/project.mjs';
@@ -826,4 +827,52 @@ test('the stale mark is a SERVER verdict, kept apart from the wall-clock colours
   assert.match(html, /journal time/, 'the chip says which clock it used');
   assert.match(html, /\.agent\.stale\{/, 'and it is styled as its own thing');
   assert.doesNotMatch(html, /ageClass\(\s*a\.open_hours/, 'never coloured by the wall-clock scale');
+});
+
+// --- opening the board, which nothing used to do ------------------------
+
+test('--open launches the platform opener with the served URL', () => {
+  // The board was a URL printed to a terminal and nothing ever opened it: for
+  // a non-technical operator that is "keep this window running, now type that
+  // address somewhere else", and each step is a place to stop. MUTANT: drop
+  // the call — installation then never reaches the one screen that makes
+  // Tyran legible.
+  const calls = [];
+  const fake = (command, args, options) => {
+    calls.push({ command, args, options });
+    return { on() {}, unref() {} };
+  };
+  openInBrowser('http://127.0.0.1:4173/', { platform: 'darwin', spawn: fake });
+  assert.deepEqual(calls[0].command, 'open');
+  assert.deepEqual(calls[0].args, ['http://127.0.0.1:4173/']);
+  openInBrowser('http://127.0.0.1:4173/', { platform: 'linux', spawn: fake });
+  assert.equal(calls[1].command, 'xdg-open');
+  openInBrowser('http://127.0.0.1:4173/', { platform: 'win32', spawn: fake });
+  assert.equal(calls[2].command, 'cmd');
+  assert.deepEqual(calls[2].args, ['/c', 'start', '', 'http://127.0.0.1:4173/']);
+  // Never through a shell: the URL is the only variable and it must not be
+  // able to become a command.
+  for (const call of calls) assert.notEqual(call.options.shell, true);
+});
+
+test('a machine with no browser does not take the server down', () => {
+  // Headless boxes, SSH sessions and locked-down desktops all land here. The
+  // server is already listening and the URL is already printed, so a failure
+  // to open one leaves things exactly where they were. MUTANT: let the throw
+  // escape, or leave the async error unhandled — either kills a working board.
+  const thrower = () => { throw new Error('ENOENT'); };
+  assert.equal(openInBrowser('http://127.0.0.1:4173/', { platform: 'linux', spawn: thrower }), false);
+  // An absent opener reports asynchronously rather than throwing, so the
+  // handler has to be attached, not merely the call wrapped.
+  let handled = false;
+  const asyncFail = () => ({ on(event) { if (event === 'error') handled = true; }, unref() {} });
+  assert.equal(openInBrowser('http://127.0.0.1:4173/', { platform: 'linux', spawn: asyncFail }), true);
+  assert.equal(handled, true, 'the error event must be handled or it takes the process down');
+});
+
+test('--open without --serve is a usage error, like --write', () => {
+  // A flag that silently does nothing reads as configuration.
+  const r = run(['--open']);
+  assert.equal(r.code, 2);
+  assert.match(r.stderr, /--open only means anything with --serve/);
 });

--- a/tests/unit/scan-control-chars.test.mjs
+++ b/tests/unit/scan-control-chars.test.mjs
@@ -898,6 +898,7 @@ test('THIS repository scans clean end to end', () => {
     "hooks/scripts/session-start.mjs",
     "hooks/scripts/usage-gate.mjs",
     "hooks/scripts/write-guard.mjs",
+    "install.sh",
     "package.json",
     "scripts/answer.mjs",
     "scripts/board-html.mjs",


### PR DESCRIPTION
Install was four steps, a restart, and then a board nobody opened. Every one
is a place to stop, and the last mattered most: `--serve` printed a URL to a
terminal and **nothing ever launched a browser**, so the screen where Tyran
becomes legible was the one thing installation never reached.

```bash
curl -fsSL https://raw.githubusercontent.com/jjanczur/tyran/main/install.sh | sh
```

Node version check **first**, because every hook shells out to `node` and an
old one doesn't fail at install time — it fails later as a gate that cannot
run, which is the hardest thing for a non-technical operator to read. Then the
plugin, then the pinned scanner, then the prompt to paste after the restart.

**The restart stays manual**, and that isn't a shortcut not taken: Claude Code
loads plugins at startup and nothing inside a session can make the app reload
itself. So it's stated plainly and put last.

## The board opens itself

`board.mjs --serve --open`. Best-effort and never fatal — a headless box or an
SSH session leaves the server running and the URL printed, exactly where
things were before. The async spawn error is **handled** rather than wrapped,
because a missing `xdg-open` arrives as an event and not a throw, and an
unhandled one takes a working board down. `--open` without `--serve` is a
usage error, like `--write`.

This also makes the **Settings** tab reachable, which already shipped in
0.1.24 and edits `profile`, `autonomy`, `tiers`, `validation`, `shared_zones`
and the `limits` block. Someone who would rather not hand-edit YAML in their
own repository never has to — they just had no way to get to the page.

## Setup looks for pre-existing secrets

A repository whose history already holds a key is common, and the gate handles
it badly *by surprise*: nothing is scanned until someone **edits** that file,
and then every commit touching it is refused, permanently, for a reason years
old. Setup now says what is there and explains the choice — including the part
that is easy to leave out: **a tracked baseline makes the tool quiet, it does
not make the key safe.** If the repo is public, that key is already burned.

## Verification

- 1467/1467 pass, 0 skipped (+3)
- control-chars clean over 266 tracked files; `install.sh` added to the pinned
  list by name
- desc-budget 4352/5000; site builds, check-base-prefix 533/533
- docs on **both** surfaces

🤖 Generated with [Claude Code](https://claude.com/claude-code)