### PR TITLE
feat(spend): a window you choose, a series over time — and the Spend tab unbroken

### DIFF
--- a/README.md
+++ b/README.md
@@ -309,7 +309,7 @@ enforces the cap (4352 of 5000 characters). What each one assumes, when it
 fires and who invokes it, is in
 [skills and agents](https://jjanczur.github.io/tyran/skills/); the prompts
 themselves are in [`skills/`](skills/) and [`agents/`](agents/). Behind all of
-it: 1504 unit tests, run with `node --test "tests/**/*.test.mjs"`.
+it: 1509 unit tests, run with `node --test "tests/**/*.test.mjs"`.
 
 ## Documentation
 

--- a/docs/cost.md
+++ b/docs/cost.md
@@ -51,6 +51,38 @@ carry the split. A long agent run caches for an hour, so the distinction is
 not a corner — measured on 1.8 B tokens of real transcripts, the 1-hour line
 was $175 against the 5-minute line's $70.
 
+## The period a total describes
+
+A plan is billed **monthly**, so a total summed over every transcript on the
+machine has nothing to compare against. `--window` picks the period, and the
+board offers the same three as buttons:
+
+| window | what it covers |
+|---|---|
+| `30d` | the last 30 days, inclusive of today. The board's DEFAULT — it needs nothing from the account, so it means the same thing on every machine. |
+| `period` | the current billing period, from the most recent anniversary of the subscription start. Offered only when that date is readable; a period guessed from an assumed anniversary is wrong for almost everyone. |
+| `all` | everything, and the only window under which no multiple against the plan price is shown. |
+
+The window is printed on the line under the total, and the board states it
+beside the figure, for the same reason the rate card travels with every
+amount: a number that cannot say what period it covers is not a measurement.
+
+Transcripts whose records carry no usable timestamp cannot be placed in a
+window. They are counted and named — `N transcript(s) with no dates omitted`
+— rather than folded into whichever window happens to be showing.
+
+Under a month-shaped window the board also shows the plan price beside the
+API-equivalent. Under `all` it does not: measured on real data, an all-time
+total read as "6.9x what you pay" where the honest monthly figure was about
+11x, and a comparison off by however long the machine has been running is
+worse than no comparison.
+
+The **By day** chart on the Spend tab is the same daily buckets drawn as a
+series, and it deliberately shows the FULL history whatever window is chosen
+— a chart that shrank with the window could not show you that last month was
+worse, which is the comparison worth having. Days are UTC, so two machines in
+different time zones attribute the same request to the same day.
+
 Overriding the shipped card, its shape, the accepted ranges and the rule that
 all four base rate keys are required are in
 [the configuration reference](configuration.md#the-rate-card).

--- a/scripts/board-html.mjs
+++ b/scripts/board-html.mjs
@@ -1,5 +1,11 @@
 #!/usr/bin/env node
 import { FORBIDDEN } from './invisible.mjs';
+// Interpolated into the client script below rather than typed there as a
+// literal. It was a literal `1`, cost.mjs bumped to 2, and the Spend tab
+// started rejecting the very payload its own server was sending — the whole
+// tab replaced by "a format this page does not know". ADR-21 exactly: one
+// answer, one place. No cycle: cost.mjs does not import this file.
+import { COST_SCHEMA } from './cost.mjs';
 /**
  * board-html — the one page an operator stares at overnight.
  *
@@ -189,6 +195,13 @@ pre.how .c{color:var(--muted)}
    input against the 5-minute write's 1.25x. Without a distinct colour the
    most expensive caching decision on the page is invisible. */
 .comp .s-cache_write_1h{background:var(--ink)}
+/* ---- the per-day series ---- */
+.days{display:flex;align-items:flex-end;gap:2px;height:74px;margin:.5rem 0 .3rem;
+  overflow-x:auto;padding-bottom:2px}
+.day{flex:1 0 6px;min-width:6px;height:100%;display:flex;align-items:flex-end}
+.day i{display:block;width:100%;background:var(--brass);border-radius:1px 1px 0 0}
+/* Outside the chosen window: context, not absence. */
+.day.out i{background:var(--line)}
 .comp .s-output{background:var(--sage)}
 .comp .s-input{background:var(--muted)}
 .compkey{display:flex;flex-wrap:wrap;gap:.85rem;font-family:var(--mono);font-size:.66rem;color:var(--muted);margin-top:.3rem}
@@ -287,6 +300,18 @@ if (data.schema !== 1) {
   var errors = data.errors || [];
   var cost = null;
   var costError = null;
+  var spendWindow = '30d';
+
+  // How the period reads to a person. The window carries machine dates; a
+  // reader wants "last 30 days", and for the billing period the actual start
+  // date, because that is the number they can check against their invoice.
+  var windowLabel = function (payload) {
+    var w = payload && payload.window;
+    if (!w) return 'all time';
+    if (w.name === 'period') return 'this billing period, since ' + w.from;
+    if (w.name === '30d') return 'last 30 days';
+    return w.from + ' to ' + w.to;
+  };
 
   // The queue count, in the browser tab. The whole point of this page is that
   // you can leave it open while agents work overnight, and a background tab
@@ -947,6 +972,25 @@ if (data.schema !== 1) {
       toggle.appendChild(button);
     });
     header.appendChild(toggle);
+
+    // The period the numbers describe. A plan is billed MONTHLY, so an
+    // all-time total has nothing to compare against; these two windows do.
+    // "this period" is offered only when the subscription date was readable,
+    // because a period guessed from an assumed anniversary is wrong for
+    // almost everyone.
+    var periods = [['30d', 'last 30 days'], ['all', 'all time']];
+    if (cost.subscription && cost.subscription.created_at) {
+      periods.splice(1, 0, ['period', 'this billing period']);
+    }
+    var picker = el('div', 'toggle');
+    periods.forEach(function (pair) {
+      var button = el('button', null, pair[1]);
+      button.setAttribute('type', 'button');
+      button.setAttribute('aria-pressed', spendWindow === pair[0] ? 'true' : 'false');
+      button.addEventListener('click', function () { loadCost(pair[0], metric); });
+      picker.appendChild(button);
+    });
+    header.appendChild(picker);
     into.appendChild(header);
 
     var tiles = el('div', 'tiles');
@@ -958,22 +1002,23 @@ if (data.schema !== 1) {
     // above is true of the API and false of the operator's bank account —
     // shown alone it invites exactly the wrong conclusion. Rendered only when
     // the plan is known; a guess here would be worse than the silence.
+    var w = cost.window;
     var sub = cost.subscription;
     if (sub && typeof sub.monthly_usd === 'number') {
-      // NO multiple is shown against the raw total. A subscription is billed
-      // monthly and the total above covers however long this machine has been
-      // running Claude Code, so "6.9x what you pay" would be off by exactly
-      // that ratio. The span is stated instead, and the comparison waits for
-      // a window the operator has chosen.
-      var covers = cost.covers;
-      tiles.appendChild(tile(
-        'you pay',
-        fmtUsd(sub.monthly_usd) + '/mo',
-        sub.label + (covers && covers.days
-          ? ' — the total above covers ' + covers.days + ' day' + (covers.days === 1 ? '' : 's')
-          : ''),
-        'lead'
-      ));
+      // The multiple is shown ONLY under a month-shaped window. Against an
+      // all-time total it would be off by however long this machine has been
+      // running Claude Code — measured at 6.9x when the honest figure was
+      // about 11x — so under "all time" the tile states the span and stops.
+      var monthly = w && (w.name === '30d' || w.name === 'period') && typeof t.usd === 'number';
+      var note = sub.label;
+      if (monthly && sub.monthly_usd > 0) {
+        note += ' — the API cost of ' + windowLabel(cost) + ' is ' +
+          (t.usd / sub.monthly_usd).toFixed(1) + 'x that';
+      } else if (cost.covers && cost.covers.days) {
+        note += ' — the total above covers ' + cost.covers.days +
+          ' day' + (cost.covers.days === 1 ? '' : 's');
+      }
+      tiles.appendChild(tile('you pay', fmtUsd(sub.monthly_usd) + '/mo', note, 'lead'));
     }
     tiles.appendChild(tile('conductor overhead', (t.conductor_token_share || 0) + '%', 'of tokens, no ticket'));
     tiles.appendChild(tile('attributed', (cov.attributed || 0) + ' / ' + (cov.agent_transcripts || 0),
@@ -1007,6 +1052,40 @@ if (data.schema !== 1) {
       });
       into.appendChild(bar);
       into.appendChild(key);
+    }
+
+    // The series. Every other view on this tab is a snapshot, so nothing has
+    // ever been able to answer "am I getting cheaper" — the single question a
+    // spend page exists for. Always the FULL history regardless of the window:
+    // a chart that shrank with the window could not show you that last month
+    // was worse, which is the comparison worth having.
+    var series = cost.per_day || [];
+    if (series.length > 1) {
+      into.appendChild(el('h3', null, 'By day'));
+      var peak = 0;
+      series.forEach(function (d) {
+        var v = metric === 'usd' ? (d.usd || 0) : d.tokens;
+        if (v > peak) peak = v;
+      });
+      var days = el('div', 'days');
+      series.forEach(function (d) {
+        var value = metric === 'usd' ? (d.usd || 0) : d.tokens;
+        var col = el('div', 'day');
+        var bar = el('i');
+        bar.style.height = (peak > 0 ? Math.max(2, (value / peak) * 100) : 0) + '%';
+        // Inside the window is the emphasis; outside it is context, not
+        // absence — the days either side are exactly what makes the window
+        // legible as a choice.
+        if (w && (d.day < w.from || d.day > w.to)) col.className = 'day out';
+        col.appendChild(bar);
+        col.setAttribute('title', d.day + ' \u2014 ' + fmtTokens(d.tokens) + ' tokens' +
+          (typeof d.usd === 'number' ? ' \u00b7 ' + fmtUsd(d.usd) : ''));
+        days.appendChild(col);
+      });
+      into.appendChild(days);
+      into.appendChild(el('div', 'hint',
+        series[0].day + ' to ' + series[series.length - 1].day + ' \u00b7 ' +
+        series.length + ' day(s) with recorded activity \u00b7 hover a bar for its total'));
     }
 
     [['By model', cost.by_model || [], 'model', []],
@@ -1065,8 +1144,13 @@ if (data.schema !== 1) {
     clear(spBody);
     spBody.appendChild(el('div', 'err', why));
   };
-  if (typeof fetch === 'function') {
-    fetch('cost.json', { headers: { accept: 'application/json' } })
+  // Re-fetches with a chosen window. The server recomputes rather than the
+  // page filtering, because only the server has the per-day buckets and a
+  // page that filtered a total it was handed could only ever subtract wrong.
+  var loadCost = function (window, metric) {
+    if (typeof fetch !== 'function') return;
+    spendWindow = window;
+    fetch('cost.json?window=' + encodeURIComponent(window), { headers: { accept: 'application/json' } })
       .then(function (r) {
         // 404 is not a failure, it is an ANSWER: no such route, so this page
         // is not being served by the board server — a copy on a docs site, a
@@ -1085,7 +1169,7 @@ if (data.schema !== 1) {
           showCostFailure('Spend could not be read: ' + ((payload && payload.error) || 'the server refused the request') + '.');
           return;
         }
-        if (!payload || payload.schema !== 1) {
+        if (!payload || payload.schema !== ${COST_SCHEMA}) {
           showCostFailure('Spend was served in a format this page does not know (schema ' +
             ((payload && payload.schema) || 'absent') + ') — regenerate the board with the Tyran that served it.');
           return;
@@ -1106,11 +1190,14 @@ if (data.schema !== 1) {
           return;
         }
         cost = payload;
-        renderSpend(spBody, 'tokens');
+        renderSpend(spBody, metric || 'tokens');
         var t = cost.totals || {};
+        // CLEARED first: this runs again on every window change, and appending
+        // left one "Spend" heading and one tile stacked up per click.
+        clear(ovSpend);
         var strip = el('div', 'tiles');
         strip.appendChild(tile('spend so far', fmtUsd(t.usd),
-          fmtTokens(t.tokens || 0) + ' tokens · see the Spend tab'));
+          fmtTokens(t.tokens || 0) + ' tokens · ' + windowLabel(cost) + ' · see the Spend tab'));
         ovSpend.appendChild(el('h2', null, 'Spend'));
         ovSpend.appendChild(strip);
       })
@@ -1120,7 +1207,12 @@ if (data.schema !== 1) {
         if (String(location.protocol) === 'file:') return;
         showCostFailure('Spend could not be read: the board server did not answer. It is served, never embedded — start it with: npx @jjanczur/tyran board --dir .tyran --serve');
       });
-  }
+  };
+
+  // The DEFAULT is 30 days, not all time: a plan is billed monthly, so a
+  // month-shaped window is the only one an operator can compare against the
+  // price without doing arithmetic. All time remains one click away.
+  loadCost('30d', 'tokens');
 
   // ---- settings ---------------------------------------------------------
   //

--- a/scripts/board.mjs
+++ b/scripts/board.mjs
@@ -45,7 +45,7 @@ import {
 } from './project.mjs';
 import { jsonEscapeInvisible } from './invisible.mjs';
 import { renderBoardError, renderBoardHtml } from './board-html.mjs';
-import { COST_SCHEMA, costJson, costReport } from './cost.mjs';
+import { COST_SCHEMA, WINDOWS, costJson, costReport } from './cost.mjs';
 import { SettingsError, applyPolicyClass, applySetting, readSettings } from './settings.mjs';
 import { checkStopAt } from './stop-check.mjs';
 import { runState } from './overnight.mjs';
@@ -787,14 +787,20 @@ function main() {
         // journal disagree and break the byte-exact `--check` contract. The
         // page fetches this route and simply omits the section when the fetch
         // fails, which is what happens over file://.
-        if (req.url === '/cost.json') {
+        if (req.url === '/cost.json' || req.url.startsWith('/cost.json?')) {
           let body;
           try {
+            // The window is the ONLY query parameter, and it is validated
+            // against a closed list rather than passed through — an unknown
+            // value falls back to `all` instead of reaching the report, so a
+            // hand-typed URL cannot produce a window nobody defined.
+            const asked = new URLSearchParams(req.url.slice(req.url.indexOf('?') + 1)).get('window');
+            const window = WINDOWS.includes(asked) ? asked : 'all';
             // `flags.transcripts` is [] unless the operator started this
             // server with `--transcripts`; costReport falls through to
             // `spend.transcript_dirs` and then the derived directory on its
             // own, so an empty array here changes nothing for the common case.
-            body = costJson(costReport({ tyranDir: dir, transcriptDirs: flags.transcripts }));
+            body = costJson(costReport({ tyranDir: dir, transcriptDirs: flags.transcripts, window }));
           } catch (err) {
             // A cost failure must never take the board down with it: the
             // board answers "what is going on", and that answer does not

--- a/scripts/cost.mjs
+++ b/scripts/cost.mjs
@@ -45,7 +45,7 @@ import { StringDecoder } from 'node:string_decoder';
 import { fileURLToPath } from 'node:url';
 import { parse } from './yaml-lite.mjs';
 import { pricingOf, PRICING_RATE_KEYS } from './schema.mjs';
-import { defaultRateCard, RATE_CARD_ID, planOfTier, PLAN_LABELS, SUBSCRIPTION_USD } from './pricing.mjs';
+import { defaultRateCard, RATE_CARD_ID, planOfTier, PLAN_LABELS, SUBSCRIPTION_USD, periodStart } from './pricing.mjs';
 import { jsonEscapeInvisible } from './invisible.mjs';
 
 export const COST_FILE = 'cost.json';
@@ -63,8 +63,9 @@ export const COST_FILE = 'cost.json';
  * one, and it would have made a monthly comparison off by a factor of 19.
  *
  * 2: sources carry `first_ts`; counters split `cache_write` by TTL.
+ * 3: sources carry `by_day`, without which every windowed figure reads zero.
  */
-export const COST_SCHEMA = 2;
+export const COST_SCHEMA = 3;
 
 /** Read buffer for the chunked line reader. Transcripts reach tens of MB. */
 const CHUNK_BYTES = 1 << 20;
@@ -296,6 +297,16 @@ export function forEachLine(path, onLine, { maxBytes = Infinity } = {}) {
  */
 export function scanTranscript(path) {
   const byModel = Object.create(null);
+  // The same counters, bucketed by UTC day. This is what makes a window
+  // possible at all — a subscription is billed monthly, and a total summed
+  // over every transcript on the machine cannot be compared against a monthly
+  // price. It is also the per-day series, which nothing else could produce
+  // from a fold that only ever kept running totals.
+  //
+  // UTC, not local: two machines in different zones must attribute the same
+  // request to the same day, or the same journal produces two different
+  // series. The boundary is stated in the docs rather than left to be found.
+  const byDay = Object.create(null);
   const seen = new Set();
   let malformed = 0;
   let firstTs = null;
@@ -325,14 +336,34 @@ export function scanTranscript(path) {
     }
     const model = typeof field(message, 'model') === 'string' ? field(message, 'model') : 'unknown';
     if (byModel[model] === undefined) byModel[model] = emptyCounters();
-    const into = byModel[model];
-    into.requests += 1;
-    into.input += finiteCount(field(usage, 'input_tokens'));
-    addCacheWrites(into, usage);
-    into.cache_read += finiteCount(field(usage, 'cache_read_input_tokens'));
-    into.output += finiteCount(field(usage, 'output_tokens'));
+    // Written into BOTH tables from one read of the record, so the two can
+    // never disagree about a request. A record with no usable timestamp is
+    // counted in the total and omitted from the day buckets — the alternative
+    // is inventing a day for it, and a windowed figure built on an invented
+    // date is worse than one that is honestly short.
+    const day = dayOf(ts);
+    const into = [byModel[model]];
+    if (day !== null) {
+      if (byDay[day] === undefined) byDay[day] = Object.create(null);
+      if (byDay[day][model] === undefined) byDay[day][model] = emptyCounters();
+      into.push(byDay[day][model]);
+    }
+    for (const counters of into) {
+      counters.requests += 1;
+      counters.input += finiteCount(field(usage, 'input_tokens'));
+      addCacheWrites(counters, usage);
+      counters.cache_read += finiteCount(field(usage, 'cache_read_input_tokens'));
+      counters.output += finiteCount(field(usage, 'output_tokens'));
+    }
   });
-  return { byModel, malformed, skippedLines, firstTs, lastTs };
+  return { byModel, byDay, malformed, skippedLines, firstTs, lastTs };
+}
+
+/** The UTC day of an ISO timestamp, `YYYY-MM-DD`, or null if unusable. */
+export function dayOf(ts) {
+  if (typeof ts !== 'string' || ts.length < 10) return null;
+  const day = ts.slice(0, 10);
+  return /^\d{4}-\d{2}-\d{2}$/.test(day) && Number.isFinite(Date.parse(ts)) ? day : null;
 }
 
 /**
@@ -550,6 +581,7 @@ export function scanAll(sources, cache) {
         mtime_ms: stat.mtimeMs,
         size: stat.size,
         by_model: before.by_model,
+        by_day: before.by_day ?? null,
         last_ts: before.last_ts ?? null,
         first_ts: before.first_ts ?? null,
         // Carried through the cache too: a damaged transcript stays damaged,
@@ -572,6 +604,7 @@ export function scanAll(sources, cache) {
       mtime_ms: stat.mtimeMs,
       size: stat.size,
       by_model: result.byModel,
+      by_day: result.byDay,
       last_ts: result.lastTs,
       first_ts: result.firstTs,
       malformed: result.malformed,
@@ -622,16 +655,28 @@ export function rollup(scanned, pricing, extra = {}) {
   const byAgentType = Object.create(null);
   const byTicket = Object.create(null);
   const unpriced = new Set();
+  // Per-UTC-day model counters across every source. This is both the series
+  // the Spend tab draws and the raw material any window is summed from.
+  const perDay = Object.create(null);
+  const window = extra.window ?? null;
   let agentTranscripts = 0;
   let attributed = 0;
   let newestTs = null;
   let oldestTs = null;
   let malformed = 0;
   let skippedLines = 0;
+  let undated = 0;
 
   for (const source of scanned) {
     malformed += source.malformed ?? 0;
     skippedLines += source.skipped_lines ?? 0;
+    for (const [day, byDayModel] of Object.entries(source.by_day ?? {})) {
+      if (perDay[day] === undefined) perDay[day] = Object.create(null);
+      for (const [model, counters] of Object.entries(byDayModel)) {
+        if (perDay[day][model] === undefined) perDay[day][model] = emptyCounters();
+        addCounters(perDay[day][model], counters);
+      }
+    }
     if (source.kind === 'agent') agentTranscripts += 1;
     if (source.kind === 'agent' && source.ticket !== null) attributed += 1;
     // The OLDEST record, not just the newest. Without it the report cannot say
@@ -643,7 +688,9 @@ export function rollup(scanned, pricing, extra = {}) {
     if (typeof source.last_ts === 'string' && (newestTs === null || source.last_ts > newestTs)) {
       newestTs = source.last_ts;
     }
-    for (const [model, counters] of Object.entries(source.by_model)) {
+    const restricted = windowedModels(source, window);
+    undated += restricted.undated;
+    for (const [model, counters] of Object.entries(restricted.models)) {
       addCounters(totals, counters);
       if (totalsByModel[model] === undefined) totalsByModel[model] = emptyCounters();
       addCounters(totalsByModel[model], counters);
@@ -679,6 +726,23 @@ export function rollup(scanned, pricing, extra = {}) {
     // invites a comparison that is off by however long the operator has been
     // using the tool. Named, not implied.
     covers: spanOf(oldestTs, newestTs),
+    // The window applied, or null for everything. `undated` is the count of
+    // sources a window could not place in time — reported rather than folded
+    // in, because a windowed total that quietly includes undatable spend is
+    // the error this feature exists to remove.
+    window: window === null ? null : { ...window, undated },
+    // The per-day series, priced. Ordered oldest first so a renderer can draw
+    // it without sorting, and always the FULL series regardless of the window
+    // — the window selects what the totals describe, not what the chart may
+    // show, and a chart that shrinks with the window cannot show you that
+    // last month was worse.
+    per_day: Object.keys(perDay)
+      .sort()
+      .map((day) => ({
+        day,
+        tokens: tokensOf(Object.values(perDay[day]).reduce(addCounters, emptyCounters())),
+        usd: costOfTable(perDay[day], models),
+      })),
     totals: {
       ...totals,
       tokens: tokensOf(totals),
@@ -755,10 +819,28 @@ function table(headers, body) {
 }
 
 /** The human report. */
+/** The one line that says what period the total above describes. */
+function periodLine(report) {
+  const window = report.window;
+  const covers = report.covers;
+  if (window === null) {
+    return covers === null
+      ? 'all time'
+      : `all time — ${covers.from.slice(0, 10)} to ${covers.to.slice(0, 10)}, ${covers.days} day(s)`;
+  }
+  const undated = window.undated > 0 ? `, ${window.undated} transcript(s) with no dates omitted` : '';
+  const name = window.name === 'period' ? 'this billing period' : 'last 30 days';
+  return `${name} — ${window.from} to ${window.to}${undated}`;
+}
+
 export function renderReport(report) {
   const out = [];
   const card = report.rate_card === null ? 'no rate card — tokens only' : `rate card ${report.rate_card}`;
   out.push(`Spend — ${tokens(report.totals.tokens)} tokens, ${money(report.totals.usd)} (${card})`);
+  // The period, on the line with the number. Everything below is a breakdown
+  // of a total, and a total whose window is only visible in a flag someone
+  // typed a minute ago gets quoted without it.
+  out.push(periodLine(report));
   out.push('');
   out.push(
     table(
@@ -842,6 +924,32 @@ function pricingOfDoc(doc) {
 /** Where Claude Code stores the account it is signed in as. */
 export const CLAUDE_CONFIG_RELPATH = '.claude.json';
 
+/** The windows the ledger can describe. `30d` is the default — see below. */
+export const WINDOWS = Object.freeze(['30d', 'period', 'all']);
+
+/**
+ * A named window as `{ name, from, to }` in UTC days, or null for `all`.
+ *
+ * `30d` is the DEFAULT rather than `period`, and deliberately: it needs
+ * nothing from the account, so it means the same thing on every machine, and
+ * it is directly comparable to a monthly price without the reader knowing
+ * when their subscription renews. `period` is the more precise answer and is
+ * offered only when the subscription date is actually readable — a period
+ * window guessed from a default anniversary would be wrong for 29 operators
+ * in 30.
+ */
+export function resolveWindow(name, { now = new Date().toISOString(), subscriptionCreatedAt = null } = {}) {
+  const today = dayOf(now);
+  if (name === 'all' || today === null) return null;
+  if (name === 'period') {
+    const from = periodStart(subscriptionCreatedAt, now);
+    return from === null ? null : { name: 'period', from, to: today };
+  }
+  // 30 days INCLUSIVE of today, so the window is 30 days long rather than 31.
+  const from = dayOf(new Date(Date.parse(today) - 29 * 86_400_000).toISOString());
+  return from === null ? null : { name: '30d', from, to: today };
+}
+
 /**
  * The subscription this machine is signed in on, or null when it cannot be
  * established. Never throws — every figure on the Spend tab must survive an
@@ -860,17 +968,24 @@ export const CLAUDE_CONFIG_RELPATH = '.claude.json';
  */
 export function subscriptionOf({ home = homedir(), readFile = readFileSync } = {}) {
   let tier = null;
+  let createdAt = null;
   try {
     const doc = JSON.parse(readFile(join(home, CLAUDE_CONFIG_RELPATH), 'utf8'));
     const account = doc !== null && typeof doc === 'object' ? doc.oauthAccount : null;
-    if (account !== null && typeof account === 'object') tier = account.organizationRateLimitTier ?? null;
+    if (account !== null && typeof account === 'object') {
+      tier = account.organizationRateLimitTier ?? null;
+      // The billing anniversary, and the only thing that makes a "this
+      // period" window mean the operator's actual period rather than a
+      // calendar month someone assumed.
+      createdAt = typeof account.subscriptionCreatedAt === 'string' ? account.subscriptionCreatedAt : null;
+    }
   } catch {
     // Not signed in, no config, unreadable, or not JSON. All the same answer.
     return null;
   }
   const plan = planOfTier(tier);
   if (plan === null) return null;
-  return { plan, label: PLAN_LABELS[plan], monthly_usd: SUBSCRIPTION_USD[plan] };
+  return { plan, label: PLAN_LABELS[plan], monthly_usd: SUBSCRIPTION_USD[plan], created_at: createdAt };
 }
 
 /**
@@ -901,6 +1016,33 @@ export function spanOf(from, to) {
   const end = Date.parse(to);
   if (!Number.isFinite(start) || !Number.isFinite(end) || end < start) return null;
   return { from, to, days: Math.max(1, Math.round((end - start) / 86_400_000)) };
+}
+
+/**
+ * One source's counters, restricted to a window — or its whole `by_model`
+ * when there is no window.
+ *
+ * A source whose `by_day` is missing (an older cache, or records with no
+ * usable timestamp) contributes NOTHING to a windowed figure, and the count
+ * of such sources is reported as `undated`. The alternative — falling back to
+ * the unwindowed totals — would silently put a year of spend inside a
+ * thirty-day window, which is the exact error this whole feature exists to
+ * remove.
+ */
+function windowedModels(source, window) {
+  if (window === null) return { models: source.by_model, undated: 0 };
+  if (source.by_day === null || source.by_day === undefined) {
+    return { models: Object.create(null), undated: 1 };
+  }
+  const models = Object.create(null);
+  for (const [day, byModel] of Object.entries(source.by_day)) {
+    if (day < window.from || day > window.to) continue;
+    for (const [model, counters] of Object.entries(byModel)) {
+      if (models[model] === undefined) models[model] = emptyCounters();
+      addCounters(models[model], counters);
+    }
+  }
+  return { models, undated: 0 };
 }
 
 /** Every model id these scanned transcripts name, in no particular order. */
@@ -959,10 +1101,17 @@ function writeAtomic(path, text) {
  * served board benefits too — cannot drift between the derived-dir path and
  * the explicit-dirs path below.
  */
-function finishReport({ sources, pricing, tyranDir, session, transcriptDirsUsed, transcriptDirsMissing }) {
+function finishReport({ sources, pricing, tyranDir, session, transcriptDirsUsed, transcriptDirsMissing, window: windowName }) {
   const cachePath = join(tyranDir, 'state', COST_FILE);
   const { scanned, unreadable, reused } = scanAll(sources, readCache(cachePath));
-  const report = rollup(scanned, pricing, { unreadable, reused, subscription: subscriptionOf() });
+  const subscription = subscriptionOf();
+  // Resolved HERE, where the subscription is already in hand: a `period`
+  // window needs the billing anniversary, and asking every caller to fetch it
+  // first would put the same read in three places.
+  const window = resolveWindow(windowName ?? 'all', {
+    subscriptionCreatedAt: subscription?.created_at ?? null,
+  });
+  const report = rollup(scanned, pricing, { unreadable, reused, subscription, window });
   report.transcripts_found = true;
   report.transcript_dirs = transcriptDirsUsed;
   report.transcript_dirs_missing = transcriptDirsMissing;
@@ -983,6 +1132,7 @@ function finishReport({ sources, pricing, tyranDir, session, transcriptDirsUsed,
     malformed: s.malformed ?? 0,
     skipped_lines: s.skipped_lines ?? 0,
     by_model: s.by_model,
+    by_day: s.by_day ?? null,
   }));
   // Persisting is the whole point of the cache, and it has to happen HERE
   // rather than only in the `--json` branch: the board server calls this per
@@ -1030,7 +1180,7 @@ function finishReport({ sources, pricing, tyranDir, session, transcriptDirsUsed,
  * missing the report reads exactly like "no transcripts found" — gaps are
  * reported, never zeroed (property 3 above).
  */
-export function costReport({ tyranDir, projectsRoot, session = null, repoRoot = null, transcriptDirs = [] } = {}) {
+export function costReport({ tyranDir, projectsRoot, session = null, repoRoot = null, transcriptDirs = [], window = 'all' } = {}) {
   const root = repoRoot ?? resolve(tyranDir, '..');
   // Read ONCE and handed to both readers below: `pricingOfDoc` and
   // `spendTranscriptDirsOf` used to each open and parse config.yaml
@@ -1063,6 +1213,7 @@ export function costReport({ tyranDir, projectsRoot, session = null, repoRoot = 
       session,
       transcriptDirsUsed: present,
       transcriptDirsMissing: missing,
+      window,
     });
   }
 
@@ -1081,11 +1232,12 @@ export function costReport({ tyranDir, projectsRoot, session = null, repoRoot = 
     session,
     transcriptDirsUsed: [dir],
     transcriptDirsMissing: [],
+    window,
   });
 }
 
 function parseArgs(argv) {
-  const flags = { dir: '.tyran', session: null, projects: null, json: false, transcripts: [] };
+  const flags = { dir: '.tyran', session: null, projects: null, json: false, transcripts: [], window: 'all' };
   for (let i = 0; i < argv.length; i += 1) {
     const arg = argv[i];
     if (arg === '--json') flags.json = true;
@@ -1094,6 +1246,14 @@ function parseArgs(argv) {
       if (value === undefined || value.startsWith('--')) throw new UsageError(`${arg} needs a value`);
       // Repeatable: sources are the union over every directory given.
       flags.transcripts.push(value);
+      i += 1;
+    } else if (arg === '--window') {
+      const value = argv[i + 1];
+      // Validated against the closed list HERE rather than deep in the report:
+      // an operator who mistypes a window should be told, not handed the
+      // all-time total under a name they thought meant something narrower.
+      if (!WINDOWS.includes(value)) throw new UsageError(`--window must be one of ${WINDOWS.join(' | ')}`);
+      flags.window = value;
       i += 1;
     } else if (arg === '--dir' || arg === '--session' || arg === '--projects') {
       const value = argv[i + 1];
@@ -1113,7 +1273,7 @@ function main(argv) {
     console.error(String(err.message ?? err));
     console.error(
       'usage: cost.mjs [--dir <.tyran>] [--session <id>] [--projects <dir>] ' +
-        '[--transcripts <dir>]... [--json]'
+        '[--transcripts <dir>]... [--window 30d|period|all] [--json]'
     );
     return 2;
   }
@@ -1127,6 +1287,7 @@ function main(argv) {
     projectsRoot: flags.projects,
     session: flags.session,
     transcriptDirs: flags.transcripts,
+    window: flags.window,
   });
   if (report.transcripts_found === false) {
     // Two different gaps, two different sentences: a `--transcripts` (or

--- a/scripts/pricing.mjs
+++ b/scripts/pricing.mjs
@@ -192,6 +192,58 @@ export const PLAN_LABELS = Object.freeze({
  * and strict about the multiplier, because the prefix is the platform's
  * business and the multiplier is the part that changes the price.
  */
+/**
+ * The start of the subscription period containing `now`, given the day the
+ * subscription was created — `YYYY-MM-DD`, or null when it cannot be derived.
+ *
+ * A plan is billed monthly on its anniversary, so "what have I spent this
+ * period" means "since the most recent anniversary at or before today". That
+ * is the only window whose comparison against the monthly price needs no
+ * arithmetic from the reader.
+ *
+ * SHORT MONTHS ARE THE WHOLE DIFFICULTY. A subscription created on the 31st
+ * has no 31st in February, and naive date maths rolls that into March 3rd —
+ * which lands in the FUTURE and produces a period that has not begun. Every
+ * overflowing day clamps to the last day of its month instead, which is what
+ * billing does. Tested at every boundary, because this is wrong once a year
+ * and silently.
+ */
+export function periodStart(createdAt, now) {
+  // Strings only. `new Date(null)` is epoch zero, not an invalid date, so a
+  // null subscription date would otherwise produce a confident 1970
+  // anniversary and a window sweeping in everything ever recorded.
+  if (typeof createdAt !== 'string' || typeof now !== 'string') return null;
+  const created = new Date(createdAt);
+  const at = new Date(now);
+  if (!Number.isFinite(created.getTime()) || !Number.isFinite(at.getTime())) return null;
+  if (at < created) return null;
+
+  const anniversary = created.getUTCDate();
+  // Candidate: the anniversary within the current month. If that is still in
+  // the future, the period began in the previous month.
+  let year = at.getUTCFullYear();
+  let month = at.getUTCMonth();
+  if (clampedDay(year, month, anniversary) > at.getUTCDate()) {
+    month -= 1;
+    if (month < 0) {
+      month = 11;
+      year -= 1;
+    }
+  }
+  const day = clampedDay(year, month, anniversary);
+  const iso = `${year}-${String(month + 1).padStart(2, '0')}-${String(day).padStart(2, '0')}`;
+  // Never earlier than the subscription itself: the first period starts the
+  // day it was created, not on an anniversary that predates it.
+  const createdDay = createdAt.slice(0, 10);
+  return iso < createdDay ? createdDay : iso;
+}
+
+/** `day`, or the last day of that month when the month is too short for it. */
+function clampedDay(year, month, day) {
+  const lastOfMonth = new Date(Date.UTC(year, month + 1, 0)).getUTCDate();
+  return Math.min(day, lastOfMonth);
+}
+
 export function planOfTier(tier) {
   if (typeof tier !== 'string') return null;
   const key = tier.trim().toLowerCase();

--- a/site/src/content/docs/cost.mdx
+++ b/site/src/content/docs/cost.mdx
@@ -54,6 +54,38 @@ carry the split. A long agent run caches for an hour, so the distinction is
 not a corner — measured on 1.8 B tokens of real transcripts, the 1-hour line
 was $175 against the 5-minute line's $70.
 
+## The period a total describes
+
+A plan is billed **monthly**, so a total summed over every transcript on the
+machine has nothing to compare against. `--window` picks the period, and the
+board offers the same three as buttons:
+
+| window | what it covers |
+|---|---|
+| `30d` | the last 30 days, inclusive of today. The board's DEFAULT — it needs nothing from the account, so it means the same thing on every machine. |
+| `period` | the current billing period, from the most recent anniversary of the subscription start. Offered only when that date is readable; a period guessed from an assumed anniversary is wrong for almost everyone. |
+| `all` | everything, and the only window under which no multiple against the plan price is shown. |
+
+The window is printed on the line under the total, and the board states it
+beside the figure, for the same reason the rate card travels with every
+amount: a number that cannot say what period it covers is not a measurement.
+
+Transcripts whose records carry no usable timestamp cannot be placed in a
+window. They are counted and named — `N transcript(s) with no dates omitted`
+— rather than folded into whichever window happens to be showing.
+
+Under a month-shaped window the board also shows the plan price beside the
+API-equivalent. Under `all` it does not: measured on real data, an all-time
+total read as "6.9x what you pay" where the honest monthly figure was about
+11x, and a comparison off by however long the machine has been running is
+worse than no comparison.
+
+The **By day** chart on the Spend tab is the same daily buckets drawn as a
+series, and it deliberately shows the FULL history whatever window is chosen
+— a chart that shrank with the window could not show you that last month was
+worse, which is the comparison worth having. Days are UTC, so two machines in
+different time zones attribute the same request to the same day.
+
 Overriding the shipped card, its shape, the accepted ranges and the rule that
 all four base rate keys are required are in
 [the configuration reference](../configuration/#the-rate-card).

--- a/tests/unit/board.test.mjs
+++ b/tests/unit/board.test.mjs
@@ -33,6 +33,7 @@ import {
   openInBrowser,
 } from '../../scripts/board.mjs';
 import { renderBoardError, renderBoardHtml } from '../../scripts/board-html.mjs';
+import { COST_SCHEMA } from '../../scripts/cost.mjs';
 import { BOARD_FILE, BOARD_JSON_FILE, LANES } from '../../scripts/project.mjs';
 import { readJournal, validateJournal } from '../../scripts/journal.mjs';
 
@@ -209,7 +210,9 @@ test('the page fetches spend rather than embedding it, so the artefacts stay byt
   // local, different in every clone — so embedding it would break the
   // byte-exact --check contract and make two people with one journal
   // disagree about what their own board says.
-  assert.ok(html.includes("fetch('cost.json'"), 'the page asks a server for spend');
+  // The URL now carries the chosen window, so match the route rather than a
+  // whole literal — the query string is exactly the part that varies.
+  assert.match(html, /fetch\('cost\.json\?window='/, 'the page asks a server for spend, by window');
   assert.ok(!html.includes('"conductor_token_share":'), 'no spend numbers are baked into the page');
   assert.ok(!files[BOARD_JSON_FILE].includes('conductor_token_share'), 'board.json carries no spend');
   // Over file:// there is no server: the request fails and the section never
@@ -875,4 +878,35 @@ test('--open without --serve is a usage error, like --write', () => {
   const r = run(['--open']);
   assert.equal(r.code, 2);
   assert.match(r.stderr, /--open only means anything with --serve/);
+});
+
+test('the page accepts exactly the cost schema its server sends', () => {
+  // MEASURED REGRESSION, shipped and caught the same day: the client script
+  // carried a literal `payload.schema !== 1`, cost.mjs bumped COST_SCHEMA to
+  // 2, and the whole Spend tab was replaced by "Spend was served in a format
+  // this page does not know (schema 2)" — served BY the page's own server.
+  //
+  // The number now interpolates from the constant, so this test exists to
+  // catch anyone typing it back in.
+  const html = renderBoardHtml(
+    JSON.stringify({
+      schema: 1,
+      as_of: null,
+      totals: { agents: 0, initiatives: 0, tickets: 0, merged: 0, percent: 0 },
+      asks: [], agents: [], paused: [], lanes: {}, errors: [],
+    }),
+  );
+  // Scoped to the cost fetch: `settings.json` has its OWN schema, also gated
+  // on a `payload.schema` literal, and it is legitimately 1. A whole-page
+  // substring search cannot tell the two apart.
+  const start = html.indexOf("fetch('cost.json?window='");
+  assert.ok(start > -1, 'the page must fetch cost.json');
+  const block = html.slice(start, start + 2000);
+  const gate = /payload\.schema !== (\d+)/.exec(block);
+  assert.ok(gate !== null, 'the cost fetch must check the schema it was served');
+  assert.equal(
+    Number(gate[1]),
+    COST_SCHEMA,
+    `the page gates cost on schema ${gate[1]} while its server sends ${COST_SCHEMA}`,
+  );
 });

--- a/tests/unit/pricing.test.mjs
+++ b/tests/unit/pricing.test.mjs
@@ -17,6 +17,7 @@ import {
   SUBSCRIPTION_USD,
   defaultRateCard,
   normalizeModel,
+  periodStart,
   planOfTier,
   ratesFor,
 } from '../../scripts/pricing.mjs';
@@ -157,4 +158,48 @@ test('an unknown, absent or reshaped tier yields null, never a default plan', ()
 test('every plan has both a price and a human label', () => {
   assert.deepEqual(Object.keys(SUBSCRIPTION_USD).sort(), Object.keys(PLAN_LABELS).sort());
   assert.deepEqual(SUBSCRIPTION_USD, { pro: 20, max_5x: 100, max_20x: 200 });
+});
+
+// --- the subscription period ------------------------------------------------
+
+test('the period starts on the most recent anniversary at or before today', () => {
+  const created = '2026-08-11T04:14:54.939Z';
+  // Measured account: created on the 11th, so mid-August is the 11th.
+  assert.equal(periodStart(created, '2026-08-17T12:00:00Z'), '2026-08-11');
+  // On the anniversary itself the new period has begun.
+  assert.equal(periodStart(created, '2026-09-11T00:00:01Z'), '2026-09-11');
+  // The day before, the previous period is still running.
+  assert.equal(periodStart(created, '2026-09-10T23:59:59Z'), '2026-08-11');
+  assert.equal(periodStart(created, '2026-12-31T00:00:00Z'), '2026-12-11');
+});
+
+test('a month too short for the anniversary clamps to its last day', () => {
+  // MUTANT: let the date roll over. A subscription created on the 31st has no
+  // 31st in February; naive maths yields March 3rd, which is in the FUTURE
+  // and produces a period that has not started. Billing clamps; so does this.
+  const created = '2026-01-31T00:00:00.000Z';
+  assert.equal(periodStart(created, '2026-02-28T12:00:00Z'), '2026-02-28');
+  // On March 30th the March anniversary (clamped to the 31st) has NOT
+  // arrived, so the running period is still February's.
+  assert.equal(periodStart(created, '2026-03-30T12:00:00Z'), '2026-02-28');
+  assert.equal(periodStart(created, '2026-03-31T12:00:00Z'), '2026-03-31');
+  // A leap February takes the 29th.
+  assert.equal(periodStart('2024-01-31T00:00:00.000Z', '2024-02-29T12:00:00Z'), '2024-02-29');
+});
+
+test('the first period starts when the subscription did, not before it', () => {
+  // MUTANT: return the anniversary unconditionally. Two days after signing up
+  // on the 20th, the "period" would start on the 20th of a month that ended
+  // before the account existed, and the window would sweep in spend from
+  // before there was anything to compare against.
+  const created = '2026-08-20T10:00:00.000Z';
+  assert.equal(periodStart(created, '2026-08-22T10:00:00Z'), '2026-08-20');
+  // A `now` before the subscription existed has no period at all.
+  assert.equal(periodStart(created, '2026-08-01T10:00:00Z'), null);
+});
+
+test('an unparseable date yields null rather than a wrong window', () => {
+  assert.equal(periodStart('not a date', '2026-08-17T00:00:00Z'), null);
+  assert.equal(periodStart('2026-08-11T00:00:00Z', 'not a date'), null);
+  assert.equal(periodStart(null, '2026-08-17T00:00:00Z'), null);
 });


### PR DESCRIPTION
**A regression I shipped this morning, caught and fixed here.** The client script carried a literal `payload.schema !== 1`; #75 bumped `COST_SCHEMA` to 2; the Spend tab then rejected the payload **its own server was sending**. Reproduced against a live server. The number now interpolates from the constant, with a test that reads the gate out of the rendered page.

**Windows.** A plan is billed monthly, so an all-time total had nothing to compare against.

| window | covers |
|---|---|
| `30d` | last 30 days — the default; needs nothing from the account |
| `period` | current billing period, from the subscription anniversary; offered only when that date is readable |
| `all` | everything; the one window that shows no multiple |

The anniversary arithmetic is tested at every boundary — a subscription created on the 31st has no 31st in February, and naive maths yields a period that hasn't begun.

**The multiple returns only where it means something.** Measured: an all-time total read as 6.9× where the honest monthly figure was ~11×.

**A series over time.** Every other view here is a snapshot, so nothing could answer *"am I getting cheaper"*. Daily buckets give the windows and the chart from one structure. The chart keeps the full history whatever window is selected, dimming out-of-window days — one that shrank with the window couldn't show you last month was worse. Days are UTC.

Both traps from this morning avoided by name: `by_day` is in the sources whitelist, and `COST_SCHEMA` is 3.

Live: 30d \$1412.50 · period (since 2026-08-11) \$1353.74 · all time \$1412.75 over 19 days. Unknown `?window=` falls back to `all`.

1509/1509 pass, 0 skipped · control-chars clean over 268 files · budget 4352/5000.

🤖 Generated with [Claude Code](https://claude.com/claude-code)