### PR TITLE
fix(cleanup): the three lifecycle leaks, each measured on real journals first

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -110,3 +110,14 @@ and you publish a site whose sandbox link 404s.
   `--ensure-policy` is the repair-only path.
 - Skill descriptions are summed into a context budget CI enforces. A new skill
   costs every session, whether it fires or not.
+- **When a change ADDS a file, `git add` before running the suite.** The
+  control-char scan builds its file list from `git ls-files`, so an untracked
+  file is invisible to it: the suite passes locally and CI — which only ever
+  sees committed files — is the first thing to look at the real set. Two
+  separate cycles have been lost to this.
+- **A field added to `cost.mjs`'s scan needs two more edits or it is silently
+  null forever.** `report.sources` is a WHITELIST projection, and `COST_SCHEMA`
+  is what discards caches written before the field existed. Missing either, an
+  unchanged transcript keeps its old record and the field reads null on every
+  later run — which produced a reported span of ONE day where the truth was
+  nineteen. A wrong number, not a missing one.

--- a/README.md
+++ b/README.md
@@ -309,7 +309,7 @@ enforces the cap (4352 of 5000 characters). What each one assumes, when it
 fires and who invokes it, is in
 [skills and agents](https://jjanczur.github.io/tyran/skills/); the prompts
 themselves are in [`skills/`](skills/) and [`agents/`](agents/). Behind all of
-it: 1509 unit tests, run with `node --test "tests/**/*.test.mjs"`.
+it: 1515 unit tests, run with `node --test "tests/**/*.test.mjs"`.
 
 ## Documentation
 

--- a/docs/doctor.md
+++ b/docs/doctor.md
@@ -1,6 +1,6 @@
 # Doctor reference
 
-`scripts/doctor.mjs --state` · 106 unit tests
+`scripts/doctor.mjs --state` · 112 unit tests
 
 Doctor **diagnoses, it never repairs.** Every finding carries a severity, a
 location and a command you can paste.
@@ -68,6 +68,7 @@ possible to change one and keep the suite green.
 | `lease-orphan` | warning | an open lease whose holder already reported — the resource is blocked by nobody |
 | `lease-expired` | warning | the acquiring event carried `expires` / `expires_at` / `until`, and it has passed |
 | `lease-release-by-non-holder` | warning | a release that did not free the lease |
+| `worktree-accumulating` | warning | more than eight git worktrees beside the main checkout — Tyran creates one per parallel agent and removes none |
 | `projection-drift` | warning | `STATE.md` / `PROGRESS.md` no longer match the journal, byte for byte |
 | `projection-absent` | info | neither projection generated yet — a repo that has not run the projector |
 | `projection-missing` | warning | one of the pair is gone while the other is there: a run stopped half way |

--- a/scripts/doctor.mjs
+++ b/scripts/doctor.mjs
@@ -187,6 +187,8 @@ export const SEVERITY_BY_CODE = Object.freeze(
     'lease-orphan': 'warning',
     'lease-expired': 'warning',
     'lease-release-by-non-holder': 'warning',
+    // worktrees
+    'worktree-accumulating': 'warning',
     // projections
     'projection-drift': 'warning',
     'projection-absent': 'info',
@@ -944,7 +946,17 @@ function askFindings(journalPath, at, read, reference) {
   return findings;
 }
 
-const EXPIRY_KEYS = Object.freeze(['expires', 'expires_at', 'until']);
+/**
+ * Every spelling an agent has actually used for a lease's expiry.
+ *
+ * `expiry` leads because it is what agents overwhelmingly write: measured
+ * across every journal on a real machine, 33 `expiry` against 3 `expires`, so
+ * this finding read 3 of 36 recorded expiries and `lease-expired` was
+ * effectively dead. A denylist of spellings is a poor mechanism, but the
+ * alternative — refusing the ones agents naturally reach for — trades a quiet
+ * miss for a loud one over a field that is advisory anyway.
+ */
+const EXPIRY_KEYS = Object.freeze(['expiry', 'expires', 'expires_at', 'until']);
 
 function leaseFindings(journalPath, at, events, reference) {
   const findings = [];
@@ -1461,6 +1473,64 @@ function absentMistakes(repoRoot, path, run) {
     checked: `${checked} — never existed`,
   };
 }
+/**
+ * How many git worktrees this repository is carrying, and whether that has
+ * become a problem nobody is looking at.
+ *
+ * Tyran's parallel model is a worktree per agent, and NOTHING removes one.
+ * There is no removal path in any skill, agent or script; the journal has no
+ * event that can even represent a worktree being destroyed; and doctor has
+ * never enumerated them. Measured on one real machine: 26 in one repository,
+ * 33 GB under another's `.worktrees/`, the oldest active for 68 days.
+ *
+ * REPORTS, never removes — and that restraint is the finding's whole design,
+ * not doctor's general rule applied by rote. Most of those worktrees turned
+ * out to hold work that never CONCLUDED rather than work that finished, so a
+ * tool deleting "merged" ones would clear almost nothing while being able, on
+ * a bad day, to delete something someone wanted. The operator gets the count,
+ * the ages, and a command they can read before running.
+ *
+ * The threshold is deliberately generous: a handful of worktrees is the system
+ * working as designed. This fires when they have stopped being cleaned up at
+ * all, which is what the measured installs look like.
+ */
+export const WORKTREE_CEILING = 8;
+
+export function worktreeFindings(repoRoot, run = null) {
+  const checked = 'git worktrees';
+  if (run === null) return { findings: [], checked: `${checked}: not checked (no git runner)` };
+  if (run(['rev-parse', '--is-inside-work-tree']).trim() !== 'true') {
+    return { findings: [], checked: `${checked}: no git here` };
+  }
+  const listing = run(['worktree', 'list', '--porcelain']);
+  if (listing.trim() === '') return { findings: [], checked: `${checked}: none reported` };
+  // One record per blank-line-separated block; the main checkout is one of
+  // them and is never a leak, so it is counted and then subtracted.
+  const blocks = listing.split(/\n\s*\n/).filter((b) => b.trim() !== '');
+  const extra = Math.max(0, blocks.length - 1);
+  const prunable = blocks.filter((b) => /^prunable /m.test(b)).length;
+  if (extra <= WORKTREE_CEILING) {
+    return { findings: [], checked: `${checked}: ${extra} beside the main checkout` };
+  }
+  return {
+    findings: [
+      finding(
+        'worktree-accumulating',
+        show(repoRoot),
+        `${extra} git worktrees beside the main checkout` +
+          (prunable > 0 ? `, ${prunable} of them already prunable` : '') +
+          ' — Tyran creates one per parallel agent and removes none, so they accumulate silently. ' +
+          'They cost disk, and a stale one has already cost a validation baseline: a lint run swept ' +
+          'leftover worktrees and reported 32,243 phantom errors. Nothing here is deleted for you; ' +
+          'read the list before removing anything, because an unmerged worktree may hold work that ' +
+          'was never finished rather than work that was',
+        `git -C ${sq(repoRoot)} worktree list   # then: git worktree remove <path>, after checking git -C <path> status`,
+      ),
+    ],
+    checked: `${checked}: ${extra} beside the main checkout`,
+  };
+}
+
 export function mistakesFindings(repoRoot, run = null) {
   const path = join(repoRoot, MISTAKES_FILE);
   if (!existsSync(path)) return absentMistakes(repoRoot, path, run);
@@ -1851,6 +1921,10 @@ export function runStateChecks({ dir = '.tyran', now = null, staleHours = DEFAUL
   const mistakes = mistakesFindings(repoRoot, gitRun);
   findings.push(...mistakes.findings);
   checked.push(mistakes.checked);
+
+  const worktrees = worktreeFindings(repoRoot, gitRun);
+  findings.push(...worktrees.findings);
+  checked.push(worktrees.checked);
 
   findings.push(...overnightFindings(dir, { now, configDoc }));
   checked.push('overnight: checked');

--- a/scripts/journal.mjs
+++ b/scripts/journal.mjs
@@ -129,8 +129,16 @@ export const DATA_KNOWN = Object.freeze({
   // normal operation back at itself.
   decision: Object.freeze(['id', 'text', 'ask', 'ticket', 'signature', 'occurrences', 'path']),
   finding: Object.freeze(['area', 'claim', 'proof', 'id', 'ticket', 'confidence']),
-  'lease.acquired': Object.freeze(['resource', 'holder', 'mode']),
-  'lease.released': Object.freeze(['resource', 'holder']),
+  // The expiry spellings doctor reads, plus the human description agents
+  // attach. Measured across every journal on a real machine, agents wrote
+  // `expiry` 33 times, `purpose` 28, `story` 21, `text` 21 — none of them
+  // known, so every lease an agent took the trouble to describe reported
+  // `journal-key-unread` back at its author. A schema that flags the fields
+  // its own agents naturally write is training them to write less.
+  'lease.acquired': Object.freeze([
+    'resource', 'holder', 'mode', 'expiry', 'expires', 'expires_at', 'until', 'purpose', 'story', 'text', 'note',
+  ]),
+  'lease.released': Object.freeze(['resource', 'holder', 'text', 'note']),
   checkpoint: Object.freeze(['phase', 'next_steps']),
   'retro.entry': Object.freeze(['kind', 'target', 'confidence']),
   error: Object.freeze(['class', 'detail', 'ticket']),

--- a/site/src/content/docs/doctor.mdx
+++ b/site/src/content/docs/doctor.mdx
@@ -6,7 +6,7 @@ import Provenance from '../../components/Provenance.astro';
 import Limit from '../../components/Limit.astro';
 
 <Provenance>
-`scripts/doctor.mjs --state` · 106 unit tests
+`scripts/doctor.mjs --state` · 112 unit tests
 </Provenance>
 
 Doctor **diagnoses, it never repairs.** Every finding carries a severity, a
@@ -75,6 +75,7 @@ possible to change one and keep the suite green.
 | `lease-orphan` | warning | an open lease whose holder already reported — the resource is blocked by nobody |
 | `lease-expired` | warning | the acquiring event carried `expires` / `expires_at` / `until`, and it has passed |
 | `lease-release-by-non-holder` | warning | a release that did not free the lease |
+| `worktree-accumulating` | warning | more than eight git worktrees beside the main checkout — Tyran creates one per parallel agent and removes none |
 | `projection-drift` | warning | `STATE.md` / `PROGRESS.md` no longer match the journal, byte for byte |
 | `projection-absent` | info | neither projection generated yet — a repo that has not run the projector |
 | `projection-missing` | warning | one of the pair is gone while the other is there: a run stopped half way |

--- a/tests/unit/doctor.test.mjs
+++ b/tests/unit/doctor.test.mjs
@@ -28,6 +28,8 @@ import {
   DEFAULT_STALE_HOURS,
   runHookChecks,
   mistakesFindings,
+  worktreeFindings,
+  WORKTREE_CEILING,
 } from '../../scripts/doctor.mjs';
 import {
   DEFAULT_PLUGIN_ROOT,
@@ -860,6 +862,34 @@ test('an expired lease is a warning even when its holder is still working', () =
   assert.match(expired[0].message, /2\.0 h ago/);
 });
 
+test('the expiry spelling agents actually use is the one doctor reads', () => {
+  // MEASURED across every journal on a real machine: agents wrote `expiry` 33
+  // times and `expires` 3, while this finding read only `expires`/`expires_at`
+  // /`until`. So 33 of 36 recorded expiries were invisible and `lease-expired`
+  // was effectively dead code that still looked alive.
+  //
+  // Recording one also used to trip `journal-key-unread`, because no expiry
+  // spelling was in DATA_KNOWN — the schema flagged the very field that would
+  // have made the finding work.
+  for (const key of ['expiry', 'expires', 'expires_at', 'until']) {
+    const root = repo();
+    const dir = scaffold(root);
+    const journal = journalPathFor(dir);
+    writeJournal(journal, [
+      ev('2026-07-26T09:00:00.000Z', 'spawn', { agent: 'impl-1', role: 'implementer' }),
+      ev('2026-07-26T09:01:00.000Z', 'lease.acquired', {
+        resource: 'worktree:a', holder: 'impl-1', [key]: '2026-07-26T10:00:00.000Z',
+      }),
+      ev('2026-07-26T12:00:00.000Z', 'checkpoint', { phase: 'x', next_steps: [] }),
+    ]);
+    regenerate(journal);
+    const result = runStateChecks({ dir });
+    assert.equal(byCode(result, 'lease-expired').length, 1, `${key} must reach lease-expired`);
+    assert.equal(byCode(result, 'journal-key-near-miss').length, 0, `${key} must not read as a typo`);
+    assert.equal(byCode(result, 'journal-key-unread').length, 0, `${key} must be a known data key`);
+  }
+});
+
 test('a release by a non-holder is raised from journal.tail(), leaving the lease open', () => {
   const root = repo();
   const dir = scaffold(root);
@@ -1659,6 +1689,7 @@ const EXPECTED_SEVERITY = {
   'lease-orphan': 'warning',
   'lease-expired': 'warning',
   'lease-release-by-non-holder': 'warning',
+  'worktree-accumulating': 'warning',
   'projection-drift': 'warning',
   'projection-absent': 'info',
   'projection-missing': 'warning',
@@ -2076,4 +2107,62 @@ test('where git cannot answer, absence says NOTHING rather than guessing', () =>
   assert.match(mistakesFindings(bare, gitRunnerFor(bare)).checked, /no git here/);
   // and with no runner at all — the pre-existing signature — it is silent too
   assert.deepEqual(mistakesFindings(bare).findings, []);
+});
+
+// --- worktrees, which nothing has ever removed ------------------------------
+
+/** A fake `git`, so the test does not depend on this checkout's worktrees. */
+const fakeWorktreeGit = (worktrees, inRepo = true) => (args) => {
+  if (args[0] === 'rev-parse') return inRepo ? 'true\n' : '';
+  if (args[0] === 'worktree') {
+    return worktrees
+      .map((w) => `worktree ${w.path}\nHEAD abc123\nbranch refs/heads/${w.branch}${w.prunable ? '\nprunable gone' : ''}\n`)
+      .join('\n');
+  }
+  return '';
+};
+
+const wt = (n, opts = {}) =>
+  Array.from({ length: n }, (_, i) => ({ path: `/repo${i === 0 ? '' : '-' + i}`, branch: `b${i}`, ...opts }));
+
+test('a handful of worktrees is the system working, not a finding', () => {
+  // MUTANT: fire on any worktree at all. Tyran's parallel model IS a worktree
+  // per agent, so a threshold of one would warn on every healthy run and
+  // teach operators to ignore the line.
+  const { findings } = worktreeFindings('/repo', fakeWorktreeGit(wt(WORKTREE_CEILING + 1)));
+  assert.deepEqual(findings, [], `${WORKTREE_CEILING} beside the main checkout must stay silent`);
+});
+
+test('worktrees that have stopped being cleaned up are reported, never removed', () => {
+  const { findings, checked } = worktreeFindings('/repo', fakeWorktreeGit(wt(WORKTREE_CEILING + 2)));
+  assert.equal(findings.length, 1);
+  assert.equal(findings[0].code, 'worktree-accumulating');
+  assert.match(findings[0].message, new RegExp(`${WORKTREE_CEILING + 1} git worktrees`));
+  assert.match(checked, new RegExp(`${WORKTREE_CEILING + 1} beside the main checkout`));
+  // MUTANT: emit `git worktree remove` as the remedy. Measured on a real
+  // machine, most of these hold work that never CONCLUDED rather than work
+  // that finished — a remedy someone pastes without reading would delete it.
+  assert.match(findings[0].fix, /worktree list/, 'the suggested command must be a LIST, not a removal');
+  assert.doesNotMatch(findings[0].fix, /^git -C \S+ worktree remove/m);
+});
+
+test('the main checkout is never counted as a leak', () => {
+  // `worktree list` always includes the checkout you ran it from. Counting it
+  // would report every repository as carrying one worktree it cannot lose.
+  const { checked } = worktreeFindings('/repo', fakeWorktreeGit(wt(1)));
+  assert.match(checked, /0 beside the main checkout/);
+});
+
+test('no git, or no runner, is not a worktree finding', () => {
+  // The distinction `absentMistakes` already draws: "there are none" and "I
+  // could not tell" must not produce the same silence for different reasons.
+  assert.deepEqual(worktreeFindings('/repo', null).findings, []);
+  assert.match(worktreeFindings('/repo', null).checked, /not checked/);
+  assert.deepEqual(worktreeFindings('/repo', fakeWorktreeGit(wt(20), false)).findings, []);
+  assert.match(worktreeFindings('/repo', fakeWorktreeGit(wt(20), false)).checked, /no git here/);
+});
+
+test('already-prunable worktrees are counted and named', () => {
+  const { findings } = worktreeFindings('/repo', fakeWorktreeGit(wt(WORKTREE_CEILING + 3, { prunable: true })));
+  assert.match(findings[0].message, /already prunable/);
 });


### PR DESCRIPTION
An audit of *"do we clean up agents that are no longer useful"* answered **no**. Three findings were checkable against real journals on this machine, so each was reproduced before being fixed.

- **`lease-expired` was dead code that looked alive.** It read `expires`/`expires_at`/`until`; agents wrote **`expiry` 33 times against `expires` 3**. So 33 of 36 recorded expiries were invisible.
- **The schema flagged the field that would have made it work.** No expiry spelling was in `DATA_KNOWN`, so recording one tripped `journal-key-unread` — the ledger reporting an agent's diligence back as an anomaly. Same for `purpose` (28), `story` (21), `text` (21).
- **Worktrees accumulate and nothing ever looked.** No removal path in any skill, agent or script; no journal event can represent one being destroyed. Measured: **26 worktrees in one repo, 33 GB under another's `.worktrees/`**. New `worktree-accumulating` warning above a ceiling of 8.

The worktree finding **reports and does not remove**, and that's the design, not rote: most of those hold work that never *concluded* rather than work that finished, so a "remove merged ones" sweep would clear almost nothing while being able to delete something wanted. Suggested command is `worktree list`; a test asserts it isn't `remove`. Verified live — 25 in one repo, silent at 0 here.

Plus two CLAUDE.md entries for traps that each cost a cycle today.

1515/1515 pass, 0 skipped · control-chars clean over 268 files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)