### PR TITLE
chore(release): 0.1.33 — the board shows what its journal already knew

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
     {
       "name": "tyran",
       "description": "A task conductor for Claude Code: multi-agent orchestration with an enforced evidence contract, repo-specific learning, and update-safe local evolution.",
-      "version": "0.1.32",
+      "version": "0.1.33",
       "source": "./",
       "author": {
         "name": "Jacek Janczura",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "tyran",
-  "version": "0.1.32",
+  "version": "0.1.33",
   "description": "A task conductor for Claude Code: multi-agent orchestration with an enforced evidence contract, repo-specific learning, and update-safe local evolution.",
   "author": {
     "name": "Jacek Janczura",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,20 @@ work; it was full of ABANDONED work. Archiving would have touched under 10% of
 initiatives, left the 64-initiative ceiling exactly where it is, and — since
 archivable means 100% merged — pulled the headline percentage DOWN.
 
+**Upgrading: one expected `--check` drift.** The payload gains a top-level
+`initiatives` key, so a `board.json` committed by an earlier version no longer
+matches what this one generates. Measured: `board.mjs --check` exits 1 once on
+an upgraded install and 0 after a single regenerate —
+
+```bash
+node scripts/board.mjs --dir .tyran   # then commit the three artefacts
+```
+
+`doctor --state` is silent about it either way; the only surface is an
+explicit `--check`, which matters if you run one in CI. The board `schema`
+stays 1 because nothing about the existing keys changed, the same call made
+when `errors_logged` was added.
+
 ### Two more things that had never worked and said nothing
 
 - **`/run.json` never carried a reset time.** `pickWindow` tested

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,58 @@
 # Changelog
 
+## 0.1.33 — 2026-08-17
+
+### The board was hiding what its own journal already knew
+
+Three directory slugs and one blended percentage. The journal has carried a
+written title since it existed — "The kanban board: one screen that answers
+what is going on" — and `crossBoard` summed every initiative's progress before
+throwing the parts away, so an operator reading "47%" across three slugs could
+not tell which was nearly done from which had not started.
+
+Each initiative now has its own row: title, progress, and how many questions
+it is waiting on. The payload reads no clock — it ships `last_ts` and the page
+ages it — so `board.mjs --check` stays byte-exact.
+
+**This replaced an archive feature, on measurement.** Across 63 distinct real
+journals only 6 were finished-and-archivable while **43 were waiting on a
+question nobody had answered**. The board was never cluttered with completed
+work; it was full of ABANDONED work. Archiving would have touched under 10% of
+initiatives, left the 64-initiative ceiling exactly where it is, and — since
+archivable means 100% merged — pulled the headline percentage DOWN.
+
+### Two more things that had never worked and said nothing
+
+- **`/run.json` never carried a reset time.** `pickWindow` tested
+  `typeof resets_at === 'string'` while every writer produces epoch SECONDS,
+  so it returned null for every real payload it was ever given: the run panel
+  could say a pause was in force but never when it would end. Live since the
+  feature shipped.
+- **The closing checkpoint had no producer.** The projection has closed every
+  still-open spawn on `checkpoint phase=closed` since 0.1.31, and nothing ever
+  emitted one — 9 of 63 real journals had one. So an agent that finished weeks
+  ago still read as live work. The conductor is now told to write it, including
+  when an initiative ends because it was ABANDONED, and the test executes the
+  command rather than grepping for it.
+
+`runState` also reports `limits_mode`: "the gate cannot see" and "the feature
+was never switched on" are different facts with the same symptom.
+
+### An ask offers its recommendation as one click
+
+It was shown as text, and the only way to accept it was to retype it into the
+box beneath it. For an operator who is not an engineer, that gap was most of
+the difficulty of the page. The button fills the box rather than submitting,
+so the wording stays editable and the answer stays deliberate.
+
+### Findings are pointed at, not copied
+
+Measured across 63 distinct journals: 3 carry any finding, 49 in total, and
+none names a ticket — so they cannot enrich a card. Median claim is 429
+characters and `STATE.md` already renders the full table. The initiative row
+carries a count when it is non-zero and nothing else; a test forbids `claim`
+or `proof` reaching the byte-compared payload.
+
 ## 0.1.32 — 2026-08-17
 
 ### Overnight mode could never fire, on any install

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jjanczur/tyran",
-  "version": "0.1.32",
+  "version": "0.1.33",
   "description": "Command-line scripts for the Tyran task conductor (doctor, journal, schema, and repo tooling) for CI and terminals outside Claude Code. Installing this package does NOT install the Claude Code plugin — add that separately with `/plugin marketplace add jjanczur/tyran` inside Claude Code.",
   "type": "module",
   "engines": {


### PR DESCRIPTION
Four changes on top of 0.1.32, three of them things that had **never worked while reporting nothing**:

- the board showed directory slugs and one blended percentage while the journal held a written title and per-initiative progress all along;
- `/run.json` never carried a reset time — a type guard tested for a string against writers that emit epoch seconds;
- the closing checkpoint had a consumer and no producer, so an agent that finished weeks ago still read as live work.

Plus an ask offers its recommendation as one click instead of text to retype, and findings are pointed at rather than copied into a byte-compared payload.

The archive feature this replaced was dropped **on measurement**: 6 of 63 real journals archivable, 43 waiting on an unanswered question.

1535/1535 pass, 0 skipped · control-chars clean · `--check` byte-identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)