### PR TITLE
The commit, the reviewer and the model reach the card

### DIFF
--- a/README.md
+++ b/README.md
@@ -309,7 +309,7 @@ enforces the cap (4352 of 5000 characters). What each one assumes, when it
 fires and who invokes it, is in
 [skills and agents](https://jjanczur.github.io/tyran/skills/); the prompts
 themselves are in [`skills/`](skills/) and [`agents/`](agents/). Behind all of
-it: 1562 unit tests, run with `node --test "tests/**/*.test.mjs"`.
+it: 1569 unit tests, run with `node --test "tests/**/*.test.mjs"`.
 
 ## Documentation
 

--- a/docs/board.md
+++ b/docs/board.md
@@ -225,6 +225,25 @@ the ticket, the board's own annotation, and — once the spend fetch has landed
 goes into the panel rather than into a wider card, which is what a grid of
 lanes cannot afford.
 
+The panel also carries the two facts the **lane could only imply** and an
+**Execution** table:
+
+| row | what it answers |
+|---|---|
+| `review` | the verdict, **who** wrote it, and when. `changes-requested` used to name a lane and never a reviewer |
+| `merged` | the **commit**, the merge mode, and when. `done` said a ticket shipped without saying what shipped |
+| Execution | one row per run: agent, **model**, when it started, how it ended |
+
+All three come from journal events that already existed — `review` carries
+ticket/verdict/by, `merge` carries ticket/sha — and reached no surface at all.
+Measured across 387 real journals and 1799 cards: **1243 carried a merge sha
+and 1074 a review verdict** that nothing displayed.
+
+Execution is the half of "what did this cost me" that Spend cannot answer:
+Spend gives dollars per ticket, this gives what was actually spawned to earn
+them — three implementers on one ticket, or the same story reopened on a
+bigger model, read down a column.
+
 The **Waiting on you** tab prints the three commands of
 [Answering](#answering) above the queue, and states the three answer words
 with them. It is the one thing on this page an operator cannot derive from

--- a/docs/projections.md
+++ b/docs/projections.md
@@ -1,6 +1,6 @@
 # Projections reference
 
-`scripts/project.mjs` · 79 unit tests, including byte-exact
+`scripts/project.mjs` · 85 unit tests, including byte-exact
 golden files
 
 The journal stays the only source of truth; everything on this page is a

--- a/scripts/board-html.mjs
+++ b/scripts/board-html.mjs
@@ -135,6 +135,12 @@ h3{font-family:var(--font);color:var(--heading);font-size:.85rem;margin:1.1rem 0
 .file .fname{color:var(--steel-bright);font-family:var(--mono);font-weight:600;min-width:6rem}
 .file code{color:var(--muted);font-size:.72rem;word-break:break-all}
 
+/* ---- what actually ran on a ticket ---- */
+.runs{width:100%;border-collapse:collapse;margin-top:.3rem;font-size:.74rem;display:block;overflow-x:auto}
+.runs th{text-align:left;color:var(--muted);font-weight:600;padding:.2rem .5rem .2rem 0;border-bottom:1px solid var(--hairline);white-space:nowrap}
+.runs td{padding:.22rem .5rem .22rem 0;border-bottom:1px solid var(--hairline);vertical-align:top}
+.runs td:first-child{font-family:var(--mono);color:var(--steel-bright)}
+
 /* ---- lanes ---- */
 .lanes{display:grid;grid-template-columns:repeat(auto-fill,minmax(15rem,1fr));gap:.6rem;align-items:start}
 .lane{background:var(--bg-sunken);border:1px solid var(--hairline-soft);border-radius:var(--radius);padding:.55rem}
@@ -731,6 +737,16 @@ if (data.schema !== 1) {
     // a ticket had come back and never why, which is the one thing the card is
     // opened for.
     row('reported', card.report_text);
+    // The two lifecycle facts the lane could only imply: which commit a
+    // merged ticket became, and who wrote the review that sent it back.
+    if (card.review) {
+      row('review', card.review.verdict + (card.review.by ? ' by ' + card.review.by : '')
+        + (card.review.ts ? ' · ' + ago(card.review.ts) : ''));
+    }
+    if (card.merge) {
+      row('merged', (card.merge.sha || 'no sha') + (card.merge.mode ? ' (' + card.merge.mode + ')' : '')
+        + (card.merge.ts ? ' · ' + ago(card.merge.ts) : ''));
+    }
     row('last event', card.since ? ago(card.since) + ' (' + card.since + ')' : null);
     if (cost) {
       var hit = (cost.by_ticket || []).filter(function (r) { return r.ticket === card.id; })[0];
@@ -739,6 +755,30 @@ if (data.schema !== 1) {
       row('spend', costError);
     }
     box.appendChild(dl);
+    // What actually ran on this ticket: agent, model, when, verdict. A table
+    // rather than more dl rows, because the interesting reading is DOWN a
+    // column — three implementers on one ticket, or the same story reopened
+    // on a bigger model — and that comparison is what a list of prose rows
+    // makes impossible.
+    var runs = card.execution || [];
+    if (runs.length > 0) {
+      box.appendChild(el('div', 'dt', 'Execution'));
+      var tbl = el('table', 'runs');
+      var head = el('tr');
+      ['agent', 'model', 'started', 'verdict'].forEach(function (h) { head.appendChild(el('th', null, h)); });
+      tbl.appendChild(head);
+      runs.forEach(function (r) {
+        var tr = el('tr');
+        tr.appendChild(el('td', null, r.agent + (r.role ? ' (' + r.role + ')' : '')));
+        // A spawn that named no model is a real state, not a gap to hide: it
+        // means the conductor let the platform default decide.
+        tr.appendChild(el('td', null, r.model || '—'));
+        tr.appendChild(el('td', null, r.started ? ago(r.started) : '—'));
+        tr.appendChild(el('td', null, r.verdict || (r.ended ? 'no verdict' : 'running')));
+        tbl.appendChild(tr);
+      });
+      box.appendChild(tbl);
+    }
     // The files this initiative ACTUALLY has, listed by the server after an
     // existsSync — never a fixed list of what a well-run initiative ought to
     // contain. Paths, not links: the board serves three URLs and derives a

--- a/scripts/project.mjs
+++ b/scripts/project.mjs
@@ -400,6 +400,17 @@ export function fold({ events = [], truncatedTail = false, badLines = [] } = {})
         title: null,
         deps: null,
         agents: [],
+        // The same spawns as `agents`, by REFERENCE rather than by name, so a
+        // ticket can answer "what actually ran here" — which model, from when
+        // to when, ending in what verdict. `agents` stays a list of names
+        // because BOARD.md and the lane cards both read it as one.
+        //
+        // References, not copies, on purpose: the `report` fold mutates a
+        // spawn's status, verdict and reportTs after this push, and a copy
+        // taken at spawn time would freeze every run as `running` with no
+        // verdict — which is exactly the row an operator opens a finished
+        // ticket to read.
+        runs: [],
         report: null,
         review: null,
         merge: null,
@@ -482,7 +493,11 @@ export function fold({ events = [], truncatedTail = false, badLines = [] } = {})
           }
         }
         state.agents.push(agent);
-        if (data.ticket != null) ticketOf(data.ticket, ts).agents.push(agent.agent);
+        if (data.ticket != null) {
+          const onTicket = ticketOf(data.ticket, ts);
+          onTicket.agents.push(agent.agent);
+          onTicket.runs.push(agent);
+        }
         break;
       }
       case 'report': {
@@ -909,6 +924,25 @@ export function boardOf(state, { staleHours = DEFAULT_STALE_HOURS } = {}) {
       // discarded at fold time, so the board could say a ticket had come back
       // and never why — the one thing the reader opens the card for.
       report_text: t.report?.text ?? null,
+      // The two lifecycle facts the LANE could only imply. `done` said a
+      // ticket was merged and never which commit; `changes-requested` said a
+      // review had come back and never who wrote it. Both are in the journal
+      // — `review` carries ticket/verdict/by and `merge` carries ticket/sha —
+      // and neither reached the one surface people open to ask.
+      review: t.review === null ? null : { verdict: t.review.verdict, by: t.review.by, ts: t.review.ts },
+      merge: t.merge === null ? null : { sha: t.merge.sha, mode: t.merge.mode, ts: t.merge.ts },
+      // What actually ran, in spawn order: which agent, on which model, from
+      // when to when, ending in what verdict. `worked_by` answers "who
+      // touched this"; this answers "what did it cost me and how did it go",
+      // which is the question a finished ticket is opened for.
+      execution: t.runs.map((a) => ({
+        agent: a.agent,
+        role: a.role,
+        model: a.model,
+        started: a.spawnTs,
+        ended: a.reportTs,
+        verdict: a.verdict,
+      })),
       annotation: annotations.length > 0 ? annotations.join(' · ') : null,
     });
   }

--- a/site/src/content/docs/board.mdx
+++ b/site/src/content/docs/board.mdx
@@ -228,6 +228,25 @@ the ticket, the board's own annotation, and — once the spend fetch has landed
 goes into the panel rather than into a wider card, which is what a grid of
 lanes cannot afford.
 
+The panel also carries the two facts the **lane could only imply** and an
+**Execution** table:
+
+| row | what it answers |
+|---|---|
+| `review` | the verdict, **who** wrote it, and when. `changes-requested` used to name a lane and never a reviewer |
+| `merged` | the **commit**, the merge mode, and when. `done` said a ticket shipped without saying what shipped |
+| Execution | one row per run: agent, **model**, when it started, how it ended |
+
+All three come from journal events that already existed — `review` carries
+ticket/verdict/by, `merge` carries ticket/sha — and reached no surface at all.
+Measured across 387 real journals and 1799 cards: **1243 carried a merge sha
+and 1074 a review verdict** that nothing displayed.
+
+Execution is the half of "what did this cost me" that Spend cannot answer:
+Spend gives dollars per ticket, this gives what was actually spawned to earn
+them — three implementers on one ticket, or the same story reopened on a
+bigger model, read down a column.
+
 The **Waiting on you** tab prints the three commands of
 [Answering](#answering) above the queue, and states the three answer words
 with them. It is the one thing on this page an operator cannot derive from

--- a/site/src/content/docs/projections.mdx
+++ b/site/src/content/docs/projections.mdx
@@ -5,7 +5,7 @@ description: 'How STATE.md and PROGRESS.md are generated from the journal, the d
 import Provenance from '../../components/Provenance.astro';
 
 <Provenance>
-`scripts/project.mjs` · 79 unit tests, including byte-exact golden files
+`scripts/project.mjs` · 85 unit tests, including byte-exact golden files
 </Provenance>
 
 The journal stays the only source of truth; everything on this page is a

--- a/tests/fixtures/golden/board.json
+++ b/tests/fixtures/golden/board.json
@@ -56,6 +56,9 @@
         "worked_by": [],
         "since": "2026-07-26T09:02:02.000Z",
         "report_text": null,
+        "review": null,
+        "merge": null,
+        "execution": [],
         "annotation": null
       }
     ],
@@ -78,6 +81,18 @@
         ],
         "since": "2026-07-26T09:41:50.000Z",
         "report_text": null,
+        "review": null,
+        "merge": null,
+        "execution": [
+          {
+            "agent": "impl-2",
+            "role": "implementer",
+            "model": "work",
+            "started": "2026-07-26T09:36:01.000Z",
+            "ended": null,
+            "verdict": null
+          }
+        ],
         "annotation": "worktree lease held by another window"
       }
     ],
@@ -91,6 +106,26 @@
         ],
         "since": "2026-07-26T09:32:00.000Z",
         "report_text": null,
+        "review": {
+          "verdict": "APPROVE",
+          "by": "rev-1",
+          "ts": "2026-07-26T09:31:00.000Z"
+        },
+        "merge": {
+          "sha": "88ea8cb",
+          "mode": "rebase",
+          "ts": "2026-07-26T09:32:00.000Z"
+        },
+        "execution": [
+          {
+            "agent": "impl-1",
+            "role": "implementer",
+            "model": "work",
+            "started": "2026-07-26T09:04:01.000Z",
+            "ended": "2026-07-26T09:30:00.000Z",
+            "verdict": "done"
+          }
+        ],
         "annotation": null
       }
     ]

--- a/tests/unit/board.test.mjs
+++ b/tests/unit/board.test.mjs
@@ -992,3 +992,43 @@ test('findings are POINTED AT, never copied into the payload', () => {
   assert.ok(!json.includes('"proof"'), 'no proof text may reach the board payload');
   assert.ok(!json.includes('"claim"'), 'no claim text may reach the board payload');
 });
+
+test('the detail panel renders the commit, the reviewer and the model that ran', () => {
+  // All three live in the client script, so no other test in this repository
+  // would notice them being reverted: board.json is unchanged by removing
+  // the code that DISPLAYS these fields, and the lane the card sits in is
+  // unchanged too. This asserts against the rendered page for that reason.
+  //
+  // MUTANT 1: drop the `card.review` / `card.merge` rows — the board goes
+  // back to saying a ticket shipped without saying what shipped.
+  // MUTANT 2: drop the Execution table — the model each run used, which is
+  // the half of "what did this cost me" that the Spend tab cannot answer,
+  // stops being reachable from the ticket entirely.
+  const html = renderBoardHtml(
+    JSON.stringify({
+      schema: 1,
+      as_of: '2026-07-26T09:00:00.000Z',
+      totals: { agents: 0, initiatives: 1, tickets: 1, merged: 1, percent: 100 },
+      asks: [], agents: [], paused: [], errors: [], initiatives: [], files: {},
+      lanes: { done: [{
+        id: 'T-1', title: 'a ticket', init: 'demo', agents: [], worked_by: ['impl-1'],
+        since: '2026-07-26T09:00:00.000Z', report_text: null, annotation: null,
+        review: { verdict: 'APPROVE', by: 'rev-1', ts: '2026-07-26T08:55:00.000Z' },
+        merge: { sha: '88ea8cb', mode: 'rebase', ts: '2026-07-26T09:00:00.000Z' },
+        execution: [{ agent: 'impl-1', role: 'implementer', model: 'deep', started: '2026-07-26T08:00:00.000Z', ended: '2026-07-26T08:50:00.000Z', verdict: 'done' }],
+      }] },
+    }),
+  );
+  assert.match(html, /card\.merge/, 'the merge row must exist in the client');
+  assert.match(html, /card\.review/, 'the review row must exist in the client');
+  assert.match(html, /card\.execution/, 'the execution table must exist in the client');
+  assert.match(html, /'agent', 'model', 'started', 'verdict'/, 'the run columns are named');
+  // The payload the client reads from must actually carry them. Whitespace
+  // tolerant: the embedded copy is written as given, so this asserts the
+  // DATA is there and not how the caller happened to format it.
+  assert.match(html, /"sha":\s*"88ea8cb"/);
+  assert.match(html, /"model":\s*"deep"/);
+  assert.match(html, /"verdict":\s*"APPROVE"/);
+  // And the table has to be styled, or it renders as run-together text.
+  assert.match(html, /\.runs\{/, 'the execution table needs its CSS');
+});

--- a/tests/unit/project.test.mjs
+++ b/tests/unit/project.test.mjs
@@ -1475,3 +1475,92 @@ test('a report carries WHAT the agent said, not only its verdict', () => {
   assert.equal(card({ text: '   ', note: 'used' }).report_text, 'used', 'blank is not text');
   assert.equal(card({}).report_text, null, 'and a report with no prose says nothing rather than empty');
 });
+
+// ------------------------------------- what the lane could only ever imply
+
+/** The card for one ticket, whatever lane it landed in. */
+const cardFor = (events, id) => {
+  const board = boardOf(fold({ events }));
+  for (const [, cards] of board.lanes) for (const c of cards) if (c.id === id) return c;
+  return null;
+};
+
+test('a merged card carries the COMMIT, not just the fact of merging', () => {
+  // MUTANT: drop `merge` from the card. The lane still says `done`, so
+  // nothing goes red — and the board can tell you a ticket shipped without
+  // being able to tell you what shipped. Measured across 387 real journals:
+  // 1243 of 1799 cards have a sha that reached no surface at all.
+  const card = cardFor(
+    [T('T-1'), ev({ ev: 'merge', ts: '2026-07-26T09:05:00.000Z', data: { ticket: 'T-1', sha: '88ea8cb', mode: 'rebase' } })],
+    'T-1',
+  );
+  assert.deepEqual(card.merge, { sha: '88ea8cb', mode: 'rebase', ts: '2026-07-26T09:05:00.000Z' });
+});
+
+test('a reviewed card carries the verdict AND who wrote it', () => {
+  // MUTANT: drop `review`. `changes-requested` still lands in its lane with
+  // the reviewer's name discarded — and "who said this" is the first question
+  // asked of a rejection.
+  const card = cardFor(
+    [T('T-2'), ev({ ev: 'review', ts: '2026-07-26T09:06:00.000Z', data: { ticket: 'T-2', verdict: 'CHANGES-REQUESTED', by: 'rev-1' } })],
+    'T-2',
+  );
+  assert.equal(card.review.verdict, 'CHANGES-REQUESTED');
+  assert.equal(card.review.by, 'rev-1');
+  assert.equal(card.review.ts, '2026-07-26T09:06:00.000Z');
+});
+
+test('the execution report names the MODEL each run used', () => {
+  // The half of "what did this cost me" that spend cannot answer: spend gives
+  // dollars per ticket, this gives what was actually spawned to earn them.
+  const card = cardFor(
+    [
+      T('T-3'),
+      ev({ ev: 'spawn', ts: '2026-07-26T09:07:00.000Z', data: { agent: 'impl-1', role: 'implementer', model: 'deep', ticket: 'T-3' } }),
+    ],
+    'T-3',
+  );
+  assert.equal(card.execution.length, 1);
+  assert.deepEqual(card.execution[0], {
+    agent: 'impl-1', role: 'implementer', model: 'deep', started: '2026-07-26T09:07:00.000Z', ended: null, verdict: null,
+  });
+});
+
+test('a run that has REPORTED carries its verdict and end, not a frozen spawn', () => {
+  // MUTANT: copy the spawn into `runs` instead of referencing it. The report
+  // fold mutates the spawn AFTER the push, so a copy freezes every run as
+  // running with no verdict — which is exactly the row an operator opens a
+  // FINISHED ticket to read.
+  const card = cardFor(
+    [
+      T('T-4'),
+      ev({ ev: 'spawn', ts: '2026-07-26T09:08:00.000Z', data: { agent: 'impl-9', role: 'implementer', model: 'work', ticket: 'T-4' } }),
+      ev({ ev: 'report', ts: '2026-07-26T09:09:00.000Z', data: { agent: 'impl-9', verdict: 'done', ticket: 'T-4' } }),
+    ],
+    'T-4',
+  );
+  assert.equal(card.execution[0].verdict, 'done');
+  assert.equal(card.execution[0].ended, '2026-07-26T09:09:00.000Z');
+});
+
+test('a ticket nothing ran on has an empty execution, never a missing key', () => {
+  // The shape is stable on purpose: board.json is byte-compared, and a key
+  // that appears only sometimes makes every consumer branch on its absence.
+  const card = cardFor([T('T-5')], 'T-5');
+  assert.deepEqual(card.execution, []);
+  assert.equal(card.review, null);
+  assert.equal(card.merge, null);
+});
+
+test('two runs on one ticket both survive, in spawn order', () => {
+  const card = cardFor(
+    [
+      T('T-6'),
+      ev({ ev: 'spawn', ts: '2026-07-26T09:10:00.000Z', data: { agent: 'a1', role: 'implementer', model: 'work', ticket: 'T-6' } }),
+      ev({ ev: 'spawn', ts: '2026-07-26T09:11:00.000Z', data: { agent: 'a2', role: 'implementer', model: 'deep', ticket: 'T-6' } }),
+    ],
+    'T-6',
+  );
+  assert.deepEqual(card.execution.map((r) => r.agent), ['a1', 'a2']);
+  assert.deepEqual(card.execution.map((r) => r.model), ['work', 'deep']);
+});


### PR DESCRIPTION
## Three facts the journal already had, that no surface displayed

Measured across **387 real journals and 1799 lane cards**:

| | count | what the board showed instead |
|---|---|---|
| cards carrying a merge sha | **1243** | lane `done` — a ticket shipped, and nothing said *what* shipped |
| cards carrying a review verdict | **1074** | lane `changes-requested` — a verdict, never a reviewer |
| runs naming their model | **213** | nothing; unreachable from the ticket entirely |

`review` (ticket/verdict/by) and `merge` (ticket/sha/mode) are journal event types with schemas. `boardOf` folded both onto the ticket, then dropped them when building the card.

**Nothing looked broken because the lane ENCODED them** — `done` means merged, `changes-requested` means a non-approving review. The board was right, and could not show its work.

## Execution

The other half of "what did this cost me". Spend gives dollars per ticket; this gives what was actually spawned to earn them — agent, model, start, verdict.

A table rather than more `dl` rows, because the interesting reading is *down a column*: three implementers on one ticket, or the same story reopened on a bigger model. A list of prose rows makes that comparison impossible.

## One subtlety worth reviewing

`t.runs` holds spawn **references, not copies**. The `report` fold mutates a spawn's `status`, `verdict` and `reportTs` *after* the push, so a copy taken at spawn time freezes every run as `running` with no verdict — precisely the row an operator opens a **finished** ticket to read. A test names that mutant.

## Payload cost — measured, not estimated

The worst real `board.json` goes **57 KiB → 84 KiB**. Acceptable for a page served over loopback.

The shape stays stable: an empty `execution: []` rather than an absent key, because `board.json` is byte-compared and a sometimes-present key makes every consumer branch on its absence. `BOARD.md` is byte-unchanged (1192 → 1192).

## Verification

```
node --test "tests/**/*.test.mjs"  -> 1569 pass / 0 fail, exit 0
  6 new in project.test.mjs, 1 in board.test.mjs asserting the RENDERED page
desc-budget          4352/5000, exit 0
scan-control-chars   clean, 272 files, exit 0
golden board.json    2183 -> 3104 bytes (regenerated)
```

Verified against a served board: the merge sha, the reviewer and the model all reach the page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)