### PR TITLE
Three surfaces promised a consolidation step that nobody implements

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -115,6 +115,12 @@ and you publish a site whose sandbox link 404s.
   file is invisible to it: the suite passes locally and CI — which only ever
   sees committed files — is the first thing to look at the real set. Two
   separate cycles have been lost to this.
+- **When a change adds or removes TESTS, update the README's count.** It is
+  verified by a CI step, not by the suite, so `node --test` stays green and
+  the push is the first thing that disagrees. `grep -n 'unit tests' README.md`
+  against the run's own `tests N`. Two cycles lost to this in one session,
+  which is the same shape as the entry above: a check the local loop cannot
+  see.
 - **A field added to `cost.mjs`'s scan needs two more edits or it is silently
   null forever.** `report.sources` is a WHITELIST projection, and `COST_SCHEMA`
   is what discards caches written before the field existed. Missing either, an

--- a/README.md
+++ b/README.md
@@ -309,7 +309,7 @@ enforces the cap (4352 of 5000 characters). What each one assumes, when it
 fires and who invokes it, is in
 [skills and agents](https://jjanczur.github.io/tyran/skills/); the prompts
 themselves are in [`skills/`](skills/) and [`agents/`](agents/). Behind all of
-it: 1569 unit tests, run with `node --test "tests/**/*.test.mjs"`.
+it: 1571 unit tests, run with `node --test "tests/**/*.test.mjs"`.
 
 ## Documentation
 

--- a/docs/self-improvement.md
+++ b/docs/self-improvement.md
@@ -131,8 +131,16 @@ same number as `knowledge-store-unreachable`.
 
 It is a MEASUREMENT and never an edit. Which of two overlapping entries is the
 true one is a judgement, and a script that guessed would delete exactly the
-detail the store exists to hold — so consolidation is a retrospective step
-that writes a **new** file for you to review, leaving the original untouched.
+detail the store exists to hold.
+
+**Nothing merges overlapping entries yet**, and this page said otherwise until
+0.1.35 — it promised a retrospective step writing a new file for you to
+review, and `knowledge.mjs audit` printed the same promise in its own output.
+No such step exists in `skills/retro/SKILL.md` or `agents/retro.md`. What the
+retrospective really does to this store is **counter upkeep**: it folds each
+report's knowledge-brief verdicts into the entries' counters, retires an entry
+the counters have written off, and splits one `doctor --state` flags as
+`knowledge-entry-oversized`. Merging two overlapping entries is still yours.
 
 ## Where a lesson lands: four stores, four questions
 

--- a/scripts/knowledge.mjs
+++ b/scripts/knowledge.mjs
@@ -313,7 +313,17 @@ function main() {
     // A measurement, never an edit: which of two overlapping entries is the
     // true one is a judgement, and a script that guessed would delete the
     // hard-won detail this exists to protect.
-    out.push('  This reports; it never edits. /tyran:retro consolidates, writing a NEW file for review.');
+    //
+    // This line used to promise that `/tyran:retro` consolidates, writing a
+    // new file for review. It does not, and never has: grep the skill and the
+    // agent and there is no consolidation step in either. What the retro
+    // really does to this store is COUNTER upkeep — folding each report's
+    // brief verdicts in, retiring an entry the counters have written off, and
+    // splitting one `doctor` calls oversized. Merging two overlapping entries
+    // is nobody's job yet. Saying so is the point: a tool that names a
+    // downstream step by name is the last place a reader will doubt it.
+    out.push('  This reports; it never edits. Nothing merges overlapping entries yet — /tyran:retro');
+    out.push('  keeps the counters, retires what stopped earning its keep, and splits what is oversized.');
     process.stdout.write(out.join('\n') + '\n');
     process.exitCode = 0;
     return;

--- a/site/src/content/docs/self-improvement.mdx
+++ b/site/src/content/docs/self-improvement.mdx
@@ -133,8 +133,16 @@ same number as `knowledge-store-unreachable`.
 
 It is a MEASUREMENT and never an edit. Which of two overlapping entries is the
 true one is a judgement, and a script that guessed would delete exactly the
-detail the store exists to hold — so consolidation is a retrospective step
-that writes a **new** file for you to review, leaving the original untouched.
+detail the store exists to hold.
+
+**Nothing merges overlapping entries yet**, and this page said otherwise until
+0.1.35 — it promised a retrospective step writing a new file for you to
+review, and `knowledge.mjs audit` printed the same promise in its own output.
+No such step exists in `skills/retro/SKILL.md` or `agents/retro.md`. What the
+retrospective really does to this store is **counter upkeep**: it folds each
+report's knowledge-brief verdicts into the entries' counters, retires an entry
+the counters have written off, and splits one `doctor --state` flags as
+`knowledge-entry-oversized`. Merging two overlapping entries is still yours.
 
 ## Where a lesson lands: four stores, four questions
 

--- a/tests/unit/knowledge.test.mjs
+++ b/tests/unit/knowledge.test.mjs
@@ -1,6 +1,6 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { mkdtempSync, mkdirSync, writeFileSync } from 'node:fs';
+import { mkdtempSync, mkdirSync, readdirSync, readFileSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { execFileSync } from 'node:child_process';
@@ -297,4 +297,42 @@ test('the audit never edits — it returns a measurement', () => {
   const before = JSON.stringify(entries);
   auditEntries(entries, { budget: 4000 });
   assert.equal(JSON.stringify(entries), before, 'inputs are untouched');
+});
+
+test('the audit does not promise a consolidation step that nobody implements', () => {
+  // It did, for as long as the feature has existed: the audit printed
+  // "/tyran:retro consolidates, writing a NEW file for review", and both doc
+  // surfaces said the same. Grep the skill and the agent — there is no
+  // consolidation step in either, and no such file is ever written.
+  //
+  // A tool that names a downstream step BY NAME is the last place a reader
+  // will doubt it, which is what made this survive three surfaces.
+  const d = store({ 'a.yaml': [entry()] });
+  const r = cli(['audit', '--dir', d]);
+  assert.equal(r.code, 0);
+  assert.doesNotMatch(
+    r.stdout,
+    /consolidat/i,
+    'the audit must not claim a consolidation step until one exists',
+  );
+  // What it SHOULD say is what the retro really does to this store.
+  assert.match(r.stdout, /never edits/);
+});
+
+test('no shipped surface claims consolidation while no code implements it', () => {
+  // The claim lived in three places at once, which is why correcting one was
+  // never going to be enough. This test fails if any of them grows it back
+  // while `scripts/` still has no consolidation.
+  const root = fileURLToPath(new URL('../..', import.meta.url));
+  const implemented = readdirSync(join(root, 'scripts'))
+    .filter((f) => f.endsWith('.mjs'))
+    .some((f) => /export function consolidate|'consolidate'/.test(readFileSync(join(root, 'scripts', f), 'utf8')));
+  if (implemented) return; // someone built it — the claim is then allowed
+  for (const surface of ['docs/self-improvement.md', 'site/src/content/docs/self-improvement.mdx']) {
+    const text = readFileSync(join(root, surface), 'utf8');
+    const promises = text
+      .split('\n')
+      .filter((l) => /consolidat/i.test(l) && !/nothing merges|said otherwise|still yours/i.test(l));
+    assert.deepEqual(promises, [], `${surface} promises consolidation, which nothing implements`);
+  }
 });


### PR DESCRIPTION
## The claim

`knowledge.mjs audit` printed, in its own output:

> `This reports; it never edits. /tyran:retro consolidates, writing a NEW file for review.`

Both doc surfaces said the same thing. Grep `skills/retro/SKILL.md` and `agents/retro.md`: **there is no consolidation step in either**, and no such file is ever written. The promise has been there for as long as the feature has.

A tool that names a downstream step *by name* is the last place a reader will doubt it — which is how this survived on three surfaces at once. It is worse than ADR-21's three spellings of one answer: it is three spellings of a **non-answer**.

## What the retro really does

Counter upkeep, not consolidation. It folds each report's knowledge-brief verdicts into the entries' counters, retires an entry the counters have written off, and splits one `doctor --state` flags as `knowledge-entry-oversized`.

Merging two overlapping entries is still the operator's job, and all three surfaces now say so.

## Two tests, because correcting one surface was never going to be enough

1. the audit's own output makes no such claim;
2. **either** doc growing it back fails, while `scripts/` still has no consolidation — and the test steps aside automatically if someone actually builds it, so it blocks the false promise without blocking the feature.

The feature itself stays specced in `NOTES-REQUESTS.md` §12.2.

```
node --test tests/unit/knowledge.test.mjs  -> 27 pass / 0 fail, exit 0
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)