### PR TITLE
0.1.35 — the audit stops naming a step nobody wrote

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
     {
       "name": "tyran",
       "description": "A task conductor for Claude Code: multi-agent orchestration with an enforced evidence contract, repo-specific learning, and update-safe local evolution.",
-      "version": "0.1.34",
+      "version": "0.1.35",
       "source": "./",
       "author": {
         "name": "Jacek Janczura",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "tyran",
-  "version": "0.1.34",
+  "version": "0.1.35",
   "description": "A task conductor for Claude Code: multi-agent orchestration with an enforced evidence contract, repo-specific learning, and update-safe local evolution.",
   "author": {
     "name": "Jacek Janczura",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,31 @@
 # Changelog
 
+## 0.1.35 — 2026-08-17
+
+### Three surfaces promised a consolidation step that nobody implements
+
+`knowledge.mjs audit` printed, in its own output, *"/tyran:retro
+consolidates, writing a NEW file for review"*. Both doc surfaces said the same.
+Grep `skills/retro/SKILL.md` and `agents/retro.md`: there is no consolidation
+step in either, and no such file has ever been written.
+
+A tool that names a downstream step BY NAME is the last place a reader will
+doubt it, which is how this survived on three surfaces at once — worse than
+ADR-21's three spellings of one answer, because it is three spellings of a
+NON-answer.
+
+What the retrospective really does to `.tyran/knowledge/` is counter upkeep:
+it folds each report's knowledge-brief verdicts into the entries' counters,
+retires an entry the counters have written off, and splits one `doctor --state`
+flags as `knowledge-entry-oversized`. **Merging two overlapping entries is
+still yours**, and all three surfaces now say so.
+
+Two tests, because correcting one surface was never going to be enough: the
+audit's own output makes no such claim, and either doc growing it back fails
+while `scripts/` has no consolidation — stepping aside automatically if
+someone builds it, so the test blocks the false promise without blocking the
+feature. It stays specced in `NOTES-REQUESTS.md` §12.2.
+
 ## 0.1.34 — 2026-08-17
 
 ### The dashboard starts itself

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jjanczur/tyran",
-  "version": "0.1.34",
+  "version": "0.1.35",
   "description": "Command-line scripts for the Tyran task conductor (doctor, journal, schema, and repo tooling) for CI and terminals outside Claude Code. Installing this package does NOT install the Claude Code plugin — add that separately with `/plugin marketplace add jjanczur/tyran` inside Claude Code.",
   "type": "module",
   "engines": {


### PR DESCRIPTION
Ships #86.

`knowledge.mjs audit` **printed** "/tyran:retro consolidates, writing a NEW file for review", and both doc surfaces agreed. There is no consolidation step in `skills/retro/SKILL.md` or `agents/retro.md`, and no such file has ever been written.

Released rather than left on main because the false claim was printed by a command people actually run — and because the corrected docs say "until 0.1.35", which is only true once this ships.

What the retro really does to `.tyran/knowledge/`: counter upkeep — fold the brief verdicts, retire what the counters wrote off, split what `doctor --state` calls oversized. Merging overlapping entries is still the operator's job.

Also carries a CLAUDE.md note: the README's test count is checked by CI, not by the suite, so `node --test` stays green and the push is the first thing that disagrees. Two cycles lost to it this session.

```
node --test "tests/**/*.test.mjs"  -> 1571 pass / 0 fail, exit 0
versions  plugin.json / marketplace.json / package.json all 0.1.35
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)