### PR TITLE
The first sentence a new install reads was wrong

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,20 +229,29 @@ echo "wrong branch — hold everything" > .tyran/STOP
 
 ## The dashboard
 
+**It is already running.** `/tyran:setup` writes `board: autostart: true`, so
+every session after it starts the dashboard if it is not up and prints the URL —
+**open that.** The board is bound to loopback, re-rendered on every request, and
+it reloads itself every 30 seconds.
+
+The **Settings** tab is an editor for `.tyran/config.yaml` and the autonomy
+policy — every knob with a sentence explaining it, your comments kept, and
+loosening a boundary behind a second deliberate press. Setup turns it on;
+`board: write: false` makes the board read-only, `autostart: false` stops it
+starting at all.
+
+From a plain shell — outside Claude Code, or in a script:
+
 ```bash
-npx @jjanczur/tyran board --dir .tyran --serve
+npx @jjanczur/tyran board --dir .tyran --detach   # starts it, prints the URL, returns
+npx @jjanczur/tyran board --dir .tyran --status   # where is it, if anywhere
+npx @jjanczur/tyran board --dir .tyran --stop     # ends it
 ```
 
-It prints `board: serving http://127.0.0.1:4173/` — **open that URL.** The
-board is bound to loopback, re-rendered on every request, and it reloads itself
-every 30 seconds; `--port <n>` if 4173 is taken, `Ctrl-C` to stop. That command
-is the one place a Node version matters, because `npx` runs the scripts outside
-Claude Code and they need **Node ≥ 22**.
-
-Add `--write` and the **Settings** tab becomes an editor for `.tyran/config.yaml`
-and the autonomy policy — every knob with a sentence explaining it, your
-comments kept, and loosening a boundary behind a second deliberate press. It is
-read-only without that flag.
+`--serve` instead of `--detach` holds the terminal until `Ctrl-C`, which is what
+you want only if you are a person at a prompt. `--port <n>` if 4173 is taken.
+These are the one place a Node version matters, because `npx` runs the scripts
+outside Claude Code and they need **Node ≥ 22**.
 
 No terminal, no server: the same page is written to **`.tyran/state/board.html`**
 after every agent, so you can just open the file —
@@ -309,7 +318,7 @@ enforces the cap (4352 of 5000 characters). What each one assumes, when it
 fires and who invokes it, is in
 [skills and agents](https://jjanczur.github.io/tyran/skills/); the prompts
 themselves are in [`skills/`](skills/) and [`agents/`](agents/). Behind all of
-it: 1571 unit tests, run with `node --test "tests/**/*.test.mjs"`.
+it: 1575 unit tests, run with `node --test "tests/**/*.test.mjs"`.
 
 ## Documentation
 

--- a/hooks/scripts/session-start.mjs
+++ b/hooks/scripts/session-start.mjs
@@ -256,8 +256,32 @@ export function renderContext({ repoRoot, initiatives, doctor, hardware, nowIso,
     lines.push('- run `node scripts/doctor.mjs --state --now "$(date -u +%FT%TZ)"` by hand');
   }
   lines.push('');
-  lines.push('Run `/tyran` to resume, or read `.tyran/state/<init>/STATE.md` in full.');
+  lines.push(closingLine(initiatives));
   return lines.join('\n');
+}
+
+/**
+ * The last line — which, on a fresh install, is the FIRST sentence Tyran says.
+ *
+ * Until the board began starting itself this line was unreachable from an
+ * empty repo: the guard above returned '' when there was no initiative and no
+ * pause, so only someone with state to resume ever read it. Autostart made
+ * `board` non-null in every adopted repo, the guard stopped tripping, and a
+ * first-time user's opening message became an instruction to *resume* work
+ * that does not exist and to open a `STATE.md` under a literal `<init>`
+ * directory that is not on disk. A wrong first sentence, not a missing one.
+ *
+ * Naming the initiative when there is exactly one is the same defect a size
+ * down: `<init>` is a placeholder standing in a sentence whose writer already
+ * knows the answer. The name is a directory read off disk, so it is journal-
+ * adjacent input and goes through `inlinePlain` like everything else here.
+ */
+export function closingLine(initiatives) {
+  if (initiatives.length === 0) {
+    return 'No initiative here yet — run `/tyran` and describe what you want done.';
+  }
+  const where = initiatives.length === 1 ? inlinePlain(initiatives[0].name) : '<init>';
+  return `Run \`/tyran\` to resume, or read \`.tyran/state/${where}/STATE.md\` in full.`;
 }
 
 /**

--- a/tests/unit/hook-session-start.test.mjs
+++ b/tests/unit/hook-session-start.test.mjs
@@ -20,6 +20,7 @@ import {
   CONTEXT_BUDGET,
   DEADLINE_MS,
   buildContext,
+  closingLine,
   recordConductor,
   ensureBoard,
   fitBudget,
@@ -176,6 +177,50 @@ test('an open gate carries its QUESTION into the resumed session', () => {
   });
   assert.match(context, /Q-1: WAITING_ON_OPERATOR — flat fee or per-seat on the team plan\?/);
   assert.match(context, /plan-approval: open \(2026-07-26T09:35:00\.000Z\)/, 'a gate with no question keeps its old shape');
+});
+
+test('a repo with no initiative is not told to RESUME, and not sent to a path that does not exist', () => {
+  // MUTANT: restore the unconditional
+  // 'Run `/tyran` to resume, or read `.tyran/state/<init>/STATE.md` in full.'
+  // That line was unreachable from an empty repo until the board began
+  // starting itself: renderContext returned '' when there was no initiative
+  // and no pause. Autostart makes `board` non-null in every adopted repo, so
+  // the guard stopped tripping and this became the FIRST sentence a new user
+  // reads — telling them to resume work that does not exist and to open a
+  // STATE.md under a literal `<init>` directory that is not on disk.
+  const line = closingLine([]);
+  assert.doesNotMatch(line, /resume/i, 'there is nothing to resume in a repo with no initiative');
+  assert.doesNotMatch(line, /<init>/, 'a placeholder path is worse than no path');
+  assert.doesNotMatch(line, /STATE\.md/, 'the file it would name has not been written yet');
+  assert.match(line, /\/tyran/, 'the one thing they can usefully do next stays named');
+});
+
+test('the closing line names the initiative when there is exactly one', () => {
+  // MUTANT: keep `<init>` unconditionally. It is a placeholder standing in a
+  // sentence whose writer already knows the answer — the reader is sent to look
+  // up a name the probe had in hand.
+  assert.match(closingLine([{ name: 'auth-rewrite' }]), /`\.tyran\/state\/auth-rewrite\/STATE\.md`/);
+  assert.doesNotMatch(closingLine([{ name: 'auth-rewrite' }]), /<init>/);
+  // Two or more and there is no single right answer, so the placeholder earns
+  // its place again.
+  assert.match(closingLine([{ name: 'a' }, { name: 'b' }]), /<init>/);
+});
+
+test('an adopted-but-empty repo still gets the board URL, and a closing line that fits it', () => {
+  // The regression path end to end: board non-null, zero initiatives. The
+  // section that is genuinely useful — where the dashboard is — must survive,
+  // and only the closing sentence changes.
+  const context = renderContext({
+    repoRoot: '/tmp/fresh',
+    initiatives: [],
+    doctor: { available: true, counts: { error: 0, warning: 0, info: 0 }, findings: [] },
+    hardware: hardwareLine(),
+    nowIso: '2026-08-17T10:00:00.000Z',
+    board: { url: 'http://127.0.0.1:4173/', started: true },
+  });
+  assert.match(context, /127\.0\.0\.1:4173/, 'the URL is the reason this renders at all');
+  assert.match(context, /No initiative here yet/);
+  assert.doesNotMatch(context, /<init>/);
 });
 
 test('recording the session id can never fail the session, and never records garbage', () => {
@@ -597,6 +642,17 @@ test('the working budget is measured AFTER sanitization, so it still binds', () 
   );
   // The value that actually ships expands no further downstream.
   assert.equal(INVISIBLE_CP(fitted).length, 0);
+});
+
+test('the initiative name in the closing line is sanitized like every other injected value', () => {
+  // MUTANT: interpolate `initiatives[0].name` raw. It is a DIRECTORY NAME read
+  // off disk, so it reaches this sentence from the filesystem and lands in the
+  // conductor's context — the last step of the ADR-19 path, and the newest
+  // value to travel it.
+  const P = TAGGED('IGNORE PRIOR') + String.fromCodePoint(0x202e) + String.fromCodePoint(0x200b);
+  const line = closingLine([{ name: `init${P}` }]);
+  assert.equal(INVISIBLE_CP(line).length, 0, 'no invisible codepoint reaches the injected line');
+  assert.equal(line.includes('\n'), false, 'a newline here forges a second line of context');
 });
 
 // --------------------------------------------- the dead-gate warning


### PR DESCRIPTION
Found by installing Tyran into a clean repo and driving the `SessionStart` probe the way Claude Code does, rather than by reading the code.

## What a new user saw

```
Run `/tyran` to resume, or read `.tyran/state/<init>/STATE.md` in full.
```

Nothing to resume, and `.tyran/state/<init>/` is not a directory — at that point `.tyran/state/` holds only `board-server.json`.

## Why it started happening

A regression from 0.1.34, and mine. The guard in `renderContext` used to make that line unreachable from an empty repo. Autostart added `board` to it (8932250):

```diff
-  if (initiatives.length === 0 && pause === null) return '';
+  if (initiatives.length === 0 && pause === null && board === null) return '';
```

`board` is non-null in every adopted repo, so the guard stopped tripping and the full scaffold began rendering for repos with no state at all.

**Blast radius, checked:** a repo that never adopted Tyran still injects `{}`. It is exactly the adopted-but-empty case.

## After

```
Dashboard: starting at http://127.0.0.1:4173/ (give it a moment)

### Doctor: 0 error(s) · 1 warning(s) · 0 info
- [tyran-dir-untracked] …/.tyran

No initiative here yet — run `/tyran` and describe what you want done.
```

The useful half — where the dashboard is, one actionable warning — survives; only the closing sentence changed. `closingLine` also names the initiative when there is exactly one, instead of sending the reader to look up `<init>`. That name is a directory read off disk, so it goes through `inlinePlain` like every other value on the ADR-19 path, tested with the existing hostile payload.

## README

Stale in the same way: it opened with `--serve`, which the user no longer needs to run, and taught `--write` as an opt-in flag that setup now writes by default. It now leads with "it is already running" and keeps the shell commands for use outside a session, pointing at `--detach`. `docs/board.md` and its `.mdx` twin already said this, so no second surface needed changing.

## Verification

```
tests 1575  pass 1575  fail 0      (4 new)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
