### PR TITLE
A board that failed to start deleted the record of the one that was running

### DIFF
--- a/README.md
+++ b/README.md
@@ -318,7 +318,7 @@ enforces the cap (4352 of 5000 characters). What each one assumes, when it
 fires and who invokes it, is in
 [skills and agents](https://jjanczur.github.io/tyran/skills/); the prompts
 themselves are in [`skills/`](skills/) and [`agents/`](agents/). Behind all of
-it: 1575 unit tests, run with `node --test "tests/**/*.test.mjs"`.
+it: 1578 unit tests, run with `node --test "tests/**/*.test.mjs"`.
 
 ## Documentation
 

--- a/scripts/board-daemon.mjs
+++ b/scripts/board-daemon.mjs
@@ -112,8 +112,34 @@ export function writeServerRecord(dir, record) {
   }
 }
 
-export function removeServerRecord(dir) {
+/**
+ * Remove the record — but only if it is THIS process's to remove.
+ *
+ * `owner` is the pid the caller claims. It defaults to this process because
+ * the ordinary caller is a server tidying up after itself, and the defect this
+ * guards is precisely a caller tidying up after somebody else: `board.mjs`
+ * registers its `clear` handler on `process.exit` unconditionally, so a
+ * `--serve` that lost the port to EADDRINUSE still ran it on the way out and
+ * deleted the record belonging to the healthy board that HELD the port. That
+ * board went on serving with no record naming it — invisible to `--status`,
+ * unreachable by `--stop`, and stoppable only with `lsof` and a kill. A leaked
+ * server is the exact failure this module was written to end, so it may not be
+ * reintroduced by the cleanup path.
+ *
+ * The guard lives here rather than at the call site on purpose. Ownership
+ * enforced by whoever remembers to check is caller discipline, which this
+ * repository rejects by name in `journal.mjs` and `doctor.mjs`.
+ *
+ * `owner: null` means "any", and `stopServer` is the one caller that has
+ * earned it: it health-probes the port and confirms the board answering there
+ * belongs to this directory before it signals or unlinks anything.
+ */
+export function removeServerRecord(dir, { owner = process.pid } = {}) {
   try {
+    if (owner !== null) {
+      const record = readServerRecord(dir);
+      if (record !== null && record.pid !== owner) return false;
+    }
     rmSync(serverRecordPath(dir), { force: true });
     return true;
   } catch {
@@ -290,7 +316,20 @@ export async function startDetached(
 ) {
   const existing = await findLiveServer(dir, port, { probe });
   if (existing !== null) {
-    return { started: false, reused: true, port: existing.port, url: urlFor(existing.port), pid: existing.health.pid ?? null };
+    // `write` comes back with the reuse so the caller can tell the operator
+    // when the flags on THIS command line did not apply. Start-time flags are
+    // silently inert against a server that is already up, and autostart has
+    // made "already up" the ordinary case rather than the unlucky one — so the
+    // remedy printed on the Spend tab (`--transcripts <dir>`) reported success
+    // and changed nothing for anyone whose board was already running.
+    return {
+      started: false,
+      reused: true,
+      port: existing.port,
+      url: urlFor(existing.port),
+      pid: existing.health.pid ?? null,
+      write: existing.health.write === true,
+    };
   }
   const chosen = await pickPort(dir, port, { probe });
   if (chosen === null) {
@@ -381,7 +420,10 @@ export async function stopServer(dir, { probe = probeHealth, kill = process.kill
   if (record === null) return { stopped: false, reason: 'no board server is recorded for this directory' };
   const health = await probe(record.port);
   if (health === null || !sameDir(health.dir, dir)) {
-    removeServerRecord(dir);
+    // `owner: null` — see removeServerRecord. Clearing a record that names
+    // another pid is this function's JOB, and it has proved the right to it:
+    // either nothing answers, or what answers is not this directory's board.
+    removeServerRecord(dir, { owner: null });
     return { stopped: false, reason: `nothing is answering on port ${record.port} — cleared the stale record` };
   }
   const pid = health.pid ?? record.pid;
@@ -391,7 +433,7 @@ export async function stopServer(dir, { probe = probeHealth, kill = process.kill
   } catch (err) {
     return { stopped: false, reason: `could not signal pid ${pid}: ${String(err?.message ?? err)}` };
   }
-  removeServerRecord(dir);
+  removeServerRecord(dir, { owner: null });
   return { stopped: true, pid, port: record.port };
 }
 

--- a/scripts/board-html.mjs
+++ b/scripts/board-html.mjs
@@ -1004,7 +1004,7 @@ if (data.schema !== 1) {
   var sp = panels.spend;
   var spBody = el('div');
   sp.appendChild(spBody);
-  spBody.appendChild(el('div', 'hint', 'Spend is read from the transcripts Claude Code already writes, and it is served rather than embedded — open this board with "board.mjs --serve" to see it. Over file:// there is no server, so this tab stays empty.'));
+  spBody.appendChild(el('div', 'hint', 'Spend is read from the transcripts Claude Code already writes, and it is served rather than embedded. You are reading the file on disk, so this tab stays empty. Setup starts a dashboard with every session — open the URL it printed, or run "board.mjs --dir .tyran --detach" to start one and print it.'));
 
   // Mirrors compositionLabel in cost.mjs. Restated rather than imported
   // because this file is a browser bundle with no module graph — the two are
@@ -1073,8 +1073,9 @@ if (data.schema !== 1) {
     if (payload && payload.transcripts_found === false) {
       hints.push(
         'No transcripts found for this repo. If the conductor ran from another working directory, ' +
-        'point the board at that session: board.mjs --serve --transcripts <dir> or set ' +
-        'spend.transcript_dirs in .tyran/config.yaml.'
+        'set spend.transcript_dirs in .tyran/config.yaml \\u2014 that survives a restart and is read ' +
+        'on the next request. The --transcripts <dir> flag does the same, but only as a server STARTS: ' +
+        'against a board that is already up it has no effect, so stop that one first.'
       );
     }
     return hints;
@@ -1242,8 +1243,9 @@ if (data.schema !== 1) {
     if ((cov.agent_transcripts || 0) === 0 && agents.length > 0) {
       into.appendChild(el('div', 'hint',
         'No agent transcripts found where this repo\\u2019s transcripts are expected. If the conductor ' +
-        'ran from another working directory, point the board at that session: board.mjs --serve ' +
-        '--transcripts <dir> or set spend.transcript_dirs in .tyran/config.yaml.'));
+        'ran from another working directory, set spend.transcript_dirs in .tyran/config.yaml. The ' +
+        '--transcripts <dir> flag does the same, but only as a server STARTS: against a board that is ' +
+        'already up it has no effect, so stop that one first.'));
     }
     // cost.transcripts_found is true whenever this function runs at all, so
     // spendResolutionHints only ever contributes the missing-dirs line here
@@ -1351,7 +1353,7 @@ if (data.schema !== 1) {
   var st = panels.settings;
   var stBody = el('div');
   st.appendChild(stBody);
-  stBody.appendChild(el('div', 'setnote', 'Settings are read from .tyran/config.yaml and .tyran/policies/autonomy.yaml, and they are served rather than embedded — open this board with "board.mjs --serve" to see them.'));
+  stBody.appendChild(el('div', 'setnote', 'Settings are read from .tyran/config.yaml and .tyran/policies/autonomy.yaml, and they are served rather than embedded. You are reading the file on disk. Setup starts a dashboard with every session — open the URL it printed, or run "board.mjs --dir .tyran --detach" to start one and print it.'));
 
   // Auto-refresh, and the reason it is a timer rather than a meta tag.
   //

--- a/scripts/board.mjs
+++ b/scripts/board.mjs
@@ -805,12 +805,27 @@ function main() {
         // "Already running" is a SUCCESS, and saying which one it is matters:
         // this command is meant to be safe to run on every session start, so
         // its ordinary outcome is that there was nothing to do.
+        if (result.reused) {
+          console.log(`board: already serving ${result.url} (pid ${result.pid ?? '?'})`);
+          // Start-time flags do not reach a server that is already up. Saying
+          // so is the whole fix: the command reported success, the operator
+          // reloaded the tab, and nothing had changed — with `--transcripts`
+          // that is the remedy the Spend tab itself recommends.
+          const inert = [];
+          if (flags.transcripts.length > 0) inert.push('--transcripts');
+          if (flags.write && !result.write) inert.push('--write');
+          if (inert.length > 0) {
+            console.log(
+              `board: ${inert.join(' and ')} had NO effect — that server was started separately. ` +
+                `To change how it runs: node scripts/board.mjs --dir ${dir} --stop, then start it again.`,
+            );
+          }
+          return;
+        }
         console.log(
-          result.reused
-            ? `board: already serving ${result.url} (pid ${result.pid ?? '?'})`
-            : `board: serving ${result.url} (pid ${result.pid ?? '?'}; ` +
-              `${flags.write ? 'Settings can edit config.yaml and autonomy.yaml' : 'read-only'}; ` +
-              `stop it with: node scripts/board.mjs --dir ${dir} --stop)`,
+          `board: serving ${result.url} (pid ${result.pid ?? '?'}; ` +
+            `${flags.write ? 'Settings can edit config.yaml and autonomy.yaml' : 'read-only'}; ` +
+            `stop it with: node scripts/board.mjs --dir ${dir} --stop)`,
         );
       });
     return;

--- a/tests/unit/board-daemon.test.mjs
+++ b/tests/unit/board-daemon.test.mjs
@@ -193,12 +193,50 @@ test('a half-written record reads as no record at all', async () => {
 
 test('the record round-trips and carries the schema', async () => {
   const dir = tyranDir();
-  writeServerRecord(dir, { pid: 42, port: 4173, url: 'http://127.0.0.1:4173/', write: true });
+  // The pid is this process's because removal is now ownership-checked, and a
+  // real server is always removing its OWN record here.
+  writeServerRecord(dir, { pid: process.pid, port: 4173, url: 'http://127.0.0.1:4173/', write: true });
   const back = readServerRecord(dir);
   assert.equal(back.schema, SERVER_RECORD_SCHEMA);
-  assert.equal(back.pid, 42);
+  assert.equal(back.pid, process.pid);
   removeServerRecord(dir);
   assert.equal(readServerRecord(dir), null);
+  rmSync(dir, { recursive: true, force: true });
+});
+
+test('a board that FAILED to start does not delete the record of the one that is running', async () => {
+  // MUTANT: drop the ownership check in removeServerRecord.
+  //
+  // Reproduced live before the fix. With a board already up on 4173, a second
+  // `--serve` loses the bind, prints "port 4173 is already in use", and exits —
+  // running the `clear` handler board.mjs registers on `process.exit`
+  // unconditionally. That deleted the RUNNING board's record. Measured after:
+  //
+  //   $ curl 127.0.0.1:4173/health.json   -> {"tyran_board":true,...,"pid":61160}
+  //   $ ls .tyran/state/                  -> (empty)
+  //   $ board.mjs --stop                  -> "no board server is recorded"
+  //
+  // A server serving with nothing naming it: invisible to --status, unreachable
+  // by --stop, killable only with lsof. That is the leak this module exists to
+  // end, arriving through the cleanup path instead of the start path.
+  const dir = tyranDir();
+  writeServerRecord(dir, { pid: process.pid + 1, port: 4173, url: 'http://127.0.0.1:4173/', write: true });
+  assert.equal(removeServerRecord(dir), false, 'a record naming another pid is not ours to remove');
+  assert.equal(readServerRecord(dir).pid, process.pid + 1, 'the running board keeps its record');
+  rmSync(dir, { recursive: true, force: true });
+});
+
+test('stopServer still clears a stale record it did not write', async () => {
+  // The other side of the guard: `owner: null`. stopServer health-probes FIRST,
+  // so by the time it unlinks it has established that nothing is answering (or
+  // that what answers is not this directory's board). Without the exemption the
+  // ownership check would strand exactly the stale records it exists to clear.
+  const dir = tyranDir();
+  writeServerRecord(dir, { pid: process.pid + 1, port: 4173, url: 'http://127.0.0.1:4173/', write: true });
+  const result = await stopServer(dir, { probe: async () => null, kill: () => {} });
+  assert.equal(result.stopped, false);
+  assert.match(result.reason, /cleared the stale record/);
+  assert.equal(readServerRecord(dir), null, 'the stale record is gone');
   rmSync(dir, { recursive: true, force: true });
 });
 
@@ -215,6 +253,31 @@ test('a live board is reused and NOTHING is spawned', async () => {
   assert.equal(spawned, 0, 'a second server must never be started next to a live one');
   assert.equal(result.reused, true);
   assert.equal(result.port, 4173);
+  rmSync(dir, { recursive: true, force: true });
+});
+
+test('reuse reports whether the running board can WRITE, so inert flags can be named', async () => {
+  // MUTANT: drop `write` from the reuse result. Start-time flags never reach a
+  // server that is already up, and autostart made "already up" the ordinary
+  // case — so `--detach --write` against a read-only board printed
+  // "already serving", exit 0, and left Settings read-only with nothing on
+  // screen explaining why. The Spend tab's own remedy (`--transcripts <dir>`)
+  // failed the same way, which is worse: the product recommended it.
+  const dir = tyranDir();
+  const ro = await startDetached(dir, {
+    port: 4173,
+    probe: probeOver({ 4173: { tyran_board: true, dir, pid: 7, write: false } }),
+    spawn: () => ({ unref() {}, on() {} }),
+  });
+  assert.equal(ro.reused, true);
+  assert.equal(ro.write, false, 'a read-only board must be reported as read-only');
+
+  const rw = await startDetached(dir, {
+    port: 4173,
+    probe: probeOver({ 4173: { tyran_board: true, dir, pid: 7, write: true } }),
+    spawn: () => ({ unref() {}, on() {} }),
+  });
+  assert.equal(rw.write, true);
   rmSync(dir, { recursive: true, force: true });
 });
 

--- a/tests/unit/board.test.mjs
+++ b/tests/unit/board.test.mjs
@@ -319,14 +319,18 @@ test('spend reaches three places from the one fetch, and explains itself when th
   assert.match(html, /ovSpend\.appendChild/, 'the overview must carry a spend headline once the fetch lands');
   assert.match(html, /if \(cost\) \{/, 'a selected card must be able to show its own spend');
   assert.match(html, /row\('spend', fmtTokens\(hit\.tokens\) \+ ' tokens [^']*' \+ fmtUsd\(hit\.usd\)\);/);
-  assert.match(html, /Over file:\/\/ there is no server, so this tab stays empty\./);
+  assert.match(html, /You are reading the file on disk, so this tab stays empty\./);
+  // And it points at the form that returns the shell. `--serve` holds the
+  // terminal, which is what a person at a prompt may want and what an operator
+  // following a hint off a web page does not.
+  assert.match(html, /--detach" to start one and print it\./);
 });
 
 test('the missing-transcript-dir hint renders even when nothing was found at all', () => {
   // MUTANT: revert the fetch handler's `if (!payload.transcripts_found)` back
   // to a bare `return;`. The pure function's own tests (board-client-literal
   // .test.mjs) would stay green — they never touch this call site — while the
-  // Spend tab silently keeps its pre-fetch "open with --serve" hint on the
+  // Spend tab silently keeps its pre-fetch "you are reading the file" hint on the
   // exact payload review reproduced live: every `spend.transcript_dirs` entry
   // present but every one of them a typo. This test pins the WIRING, not just
   // the function it wires in.


### PR DESCRIPTION
Found while checking what the Spend tab's own remedy actually does, now that autostart makes "a board is already running" the ordinary case rather than the unlucky one.

## A leaked server that cannot be stopped

Reproduced live, before the fix:

```console
$ board.mjs --dir .tyran --detach
board: serving http://127.0.0.1:4173/ (pid 61160; read-only; ...)

$ board.mjs --dir .tyran --serve --transcripts /tmp
board: port 4173 is already in use — pass --port <n> for another

$ board.mjs --dir .tyran --stop
board: no board server is recorded for this directory

$ curl -s 127.0.0.1:4173/health.json
{"tyran_board":true,...,"pid":61160}          <-- still serving

$ ls .tyran/state/
(empty)                                        <-- its record is gone
```

`board.mjs` registers its `clear` handler on `process.exit` **unconditionally**, so the process that *lost* the bind still ran it on the way out and unlinked the record written by the process that *held* the port.

The board went on serving with nothing naming it — invisible to `--status`, unreachable by `--stop`, killable only with `lsof`. That is the leaked-server class this module was written to end, arriving through the cleanup path instead of the start path.

**Fix.** `removeServerRecord` refuses to unlink a record naming another pid. The guard is in the module, not at the call site, because ownership enforced by whoever remembers to check is caller discipline — which `journal.mjs` and `doctor.mjs` both reject by name. `stopServer` passes `owner: null` and has earned the exemption: it health-probes first and unlinks only once it has established that nothing answers, or that what answers is not this directory's board.

After:

```console
$ board.mjs --dir .tyran --stop
board: stopped the server on port 4173 (pid 61739)
```

## Start-time flags that silently did nothing

Same session, same root cause:

```console
$ board.mjs --dir .tyran --detach --write --transcripts /tmp
board: already serving http://127.0.0.1:4173/ (pid 61754)
```

Exit 0, nothing changed, nothing said. `--transcripts` is the remedy **the Spend tab itself prints**, so the product recommended a command that reported success and fixed nothing.

After:

```console
board: already serving http://127.0.0.1:4173/ (pid 61754)
board: --transcripts and --write had NO effect — that server was started separately.
       To change how it runs: node scripts/board.mjs --dir .tyran --stop, then start it again.
```

A plain re-run stays silent — that matters, because autostart runs this on every session start and a nag on every session is worse than the bug.

## Hints

The four in-product hints that recommended `--serve` now lead with `spend.transcript_dirs` (it survives a restart and is read on the next request) and say plainly that the flag applies only as a server starts.

## Verification

```
tests 1578  pass 1578  fail 0      (3 new)
```

Each new test names the mutant it kills, including the live console transcript above.

> Stacked on #88 — review that one first; this branch is based on it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
