### PR TITLE
Exercise cloud access before promising a deploy, and never ask for a secret's value

### DIFF
--- a/skills/run/SKILL.md
+++ b/skills/run/SKILL.md
@@ -80,6 +80,16 @@ English regardless.
    - **dry-run every automaton** for one no-op iteration before you trust it
      with unattended work. Trust dialogs and missing dependencies surface
      then, not at 3am.
+   - **exercise cloud access, never infer it.** A profile in `~/.aws/config`, a
+     key in the environment and a role named in a template are three claims
+     that the call you actually need will succeed — none of them is the call.
+     Make one cheap read-only request per service the plan names, starting with
+     an identity check (`aws sts get-caller-identity` and its equivalents) and
+     then a `list`/`describe` on the one resource you will touch, and record
+     the account, region and profile as a `decision`. This is the teammate
+     probe two bullets up, one layer out: availability that was inferred rather
+     than exercised has already been wrong here, and the cloud version of that
+     mistake surfaces at deploy time — after the work, in front of the operator.
 5. **Project configuration — detect it yourself.**
    - If `.tyran/config.yaml` exists, read it and treat it as binding.
    - Otherwise send `tyran:scout` to establish: (a) the **stack** — languages,
@@ -295,6 +305,16 @@ open one.
    your scope without the domain owner's consent — proposals go to `NOTES.md`.
    Secrets never enter the repo. Production data only through the accounts the
    configuration names.
+   - **The gate below is a way in, so it has its own rule.** `journal.mjs ask`
+     writes the question into the journal, and `answer.mjs apply` folds the
+     operator's reply back as a `decision` — both in a file you commit. **Never
+     ask for a credential's VALUE. Ask where it lives**: the SSM parameter
+     NAME, the secrets-manager key, the vault path — something whose disclosure
+     costs nothing and which the machine doing the work can already resolve.
+     *"Which SSM parameter holds the staging database password?"* is a question
+     whose answer is safe in a committed file. *"What is the staging database
+     password?"* is a leak with a ticket number on it, and the operator who
+     pasted it now has a credential to rotate.
 6. **Gates are the only stops:** plan acceptance (L) or concept acceptance
    (XL); product, visual and irreversible decisions, put in plain language
    with your recommendation; anything hard to undo or visible outside the


### PR DESCRIPTION
Two items from `NOTES-REQUESTS` §12.4, both small, both skill text.

## Exercise cloud access, never infer it

STEP 0 already refuses to infer that Agent Teams are available — it spawns a throwaway teammate, because *"availability that was inferred rather than exercised has already been wrong"*. Cloud access had no such rule, and it is the same mistake one layer out: a profile in `~/.aws/config`, a key in the environment and a role named in a template are three claims that the call you need will succeed, and **none of them is the call**.

The difference is when it surfaces. A missing teammate shows up at spawn. A missing permission shows up at deploy — after the work, in front of the operator.

The rule: one cheap read-only request per service the plan names, starting with an identity check and then a `list`/`describe` on the one resource you will touch, with account, region and profile recorded as a `decision`.

## Never ask for a secret's value

A leak the gate mechanism makes easy. `journal.mjs ask` writes the question into the journal, and `answer.mjs apply` folds the operator's reply back as a `decision` — **both in a file the repo commits.** An agent that asks *"what is the staging database password?"* has put a secret in git and handed the operator a rotation.

Ask **where it lives** instead: the SSM parameter NAME, the secrets-manager key, the vault path — something the machine doing the work can already resolve and whose disclosure costs nothing.

Placed under **Boundaries**, next to "Secrets never enter the repo", because it is that rule applied to the one mechanism that routes around it.

No docs surface carries either claim, so there is no second copy to keep in step.

## A note from writing this

`gh pr create` with this description inline was **refused by Tyran's own policy gate** — the prose tripped the credential-file pattern. That is the third false-positive class recorded in §12.5, reproduced here by accident. Still deliberately unfixed: the safe direction is refusing, and the obvious fix kills the whole family.

## Verification

```
tests 9  pass 9  fail 0      (agents + skills)
```

> Stacked on #89, which is stacked on #88.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
