### PR TITLE
The chip printed spawn time under the words "last signal"

### DIFF
--- a/NOTES-REQUESTS.md
+++ b/NOTES-REQUESTS.md
@@ -425,7 +425,36 @@ This specific instruction does not take.
 open spawns silent it would fire on every one — the always-on warning this
 repo already refuses by name (see `SEVERITY_BY_CODE`'s comment on `spawn-open`).
 
-Three honest options, in order of preference:
+**DECIDED 2026-08-17 (0.1.36): options 1 and 2, together.** The measurement
+below was made and it settles the mechanism half without waiting for the
+compliance experiment. Folding 420 real journals through `boardOf`: **72
+running agents on boards, `last_signal === since` for 72 of 72** — never once
+an actual signal — with `detail`, `next` and `state: 'blocked'` at zero across
+the same set.
+
+So `last_signal` was not merely empty, it was *spawn time under a label saying
+"when it last spoke"*, published in three places: the agent chip
+(*"N min since last signal"*), the `BOARD.md` column, and the cross-repo line.
+A wrong number reads as a measurement; a blank does not. The fallback is gone,
+the age the chip shows is now measured from `since` and says *"since it
+started"*, and the golden fixture's blind spot is named: its one agent DOES
+signal, so the case that is universal in the wild was the case no fixture
+covered.
+
+Option 2 shipped with it — `agents/implementer.md` now asks for ONE emission,
+at the first blockage. Three of the four were reconstructable from events
+another party writes (the lease IS `started`, the report IS the end of
+`working`), and a self-report that only its author can contradict is worth less
+than one somebody else produces. A blockage is the exception: nothing else in
+the journal says an agent is stuck, or why.
+
+Option 3 was rejected: it would delete the one emission carrying information
+nothing else can reconstruct. `spawn-blocked` and the `blocked` lane stay, now
+fed by an instruction with a plausible chance of being followed. Whether it IS
+followed is still unmeasured — revisit with a count of `progress` events after
+a few real initiatives under the new wording.
+
+The original three options, for the record:
 
 1. **Derive freshness from what agents actually write.** `lease.acquired`
    (434) is already the `started` signal, and it is emitted at the same moment
@@ -459,8 +488,13 @@ Recorded because the list has only ever lived in a conversation.
    388 journals, median proof length short. The ask is for the raw command
    output, which is a payload-size question the byte-compared projection makes
    non-trivial. **S–M.**
-4. **STEP-0 live cloud probe** and **the credential-gate template asking for
-   the SSM parameter NAME**. Both are skill-text edits, both small. **S.**
+4. ~~**STEP-0 live cloud probe** and **the credential-gate template asking for
+   the SSM parameter NAME**.~~ SHIPPED 0.1.36. Both landed in
+   `skills/run/SKILL.md`: cloud access is exercised rather than inferred, on
+   the same argument STEP 0 already makes about Agent Teams; and a gate must
+   never ask for a secret's VALUE, because `journal.mjs ask` writes the
+   question and `answer.mjs apply` folds the reply back as a `decision`, both
+   into a committed file.
 5. **The third policy-gate false positive** — a word ending `.key`/`.pem`
    refused as a file. Deliberately unfixed: the safe direction is refusing,
    and the obvious fix kills the whole credential family.

--- a/README.md
+++ b/README.md
@@ -318,7 +318,7 @@ enforces the cap (4352 of 5000 characters). What each one assumes, when it
 fires and who invokes it, is in
 [skills and agents](https://jjanczur.github.io/tyran/skills/); the prompts
 themselves are in [`skills/`](skills/) and [`agents/`](agents/). Behind all of
-it: 1575 unit tests, run with `node --test "tests/**/*.test.mjs"`.
+it: 1576 unit tests, run with `node --test "tests/**/*.test.mjs"`.
 
 ## Documentation
 

--- a/agents/implementer.md
+++ b/agents/implementer.md
@@ -15,16 +15,25 @@ commits and anything written to disk are in English.**
      lease file as the handoff describes. Another agent's unexpired lease
      means you do NOT start — you report back. Release it when you finish,
      including when you finish by failing.
-   - **Signal at four points, no more** — `progress` events appended to the
-     MAIN checkout's journal (the handoff carries its absolute path):
-     `started` right after the lease (it is also the proof the lease protocol
-     was honoured) · `blocked` at the FIRST blockage, BEFORE attempting any
-     workaround · `unblocked` when it clears · `working` before the final
-     full validation run, the longest silent stretch you have. Shape:
+   - **Signal ONCE: at the first blockage, before any workaround.** A
+     `progress` event appended to the MAIN checkout's journal (the handoff
+     carries its absolute path):
      `node ${CLAUDE_PLUGIN_ROOT}/scripts/journal.mjs append <abs-journal>
      progress <init> --actor <you> --data
-     '{"agent":"<you>","state":"blocked","ticket":"T-n","detail":"..."}'`.
-     Four emissions per story; this is a closed list, not a diary.
+     '{"agent":"<you>","state":"blocked","ticket":"T-n","detail":"..."}'`,
+     and `state: "unblocked"` when it clears.
+
+     This asked for four emissions until 2026-08-17 — `started`, `blocked`,
+     `unblocked`, `working` — and measurement ended the argument: **one**
+     `progress` event across 388 real journals, against roughly six thousand
+     the instruction predicted. The lease bullet immediately above produced
+     434 in the same set, so this is not an agent that ignores the journal or
+     ignores this file. Three of the four asks were also reconstructable from
+     events someone else writes — your lease IS `started`, your report IS the
+     end of `working` — and a signal only you can contradict is worth less
+     than one another party produces. A blockage is the exception: nothing
+     else in the journal says you are stuck, or why. So the list is one item
+     long, and it is the item that carries information nothing else can.
    - **Grep before you build.** Search for an existing implementation of the
      thing you are about to write; if it exists, report it as a corrected
      premise instead of duplicating it. Durable discoveries worth another

--- a/docs/board.md
+++ b/docs/board.md
@@ -531,13 +531,27 @@ stale agents are still counted, still in the strip, and now said out loud. The
 same correction reaches `BOARD.md`, whose headline says *open* rather than
 *running*, with the stale count beside it.
 
-Every agent now carries two times. **`last_signal`** is what it SAID, from its
-own `progress` events. **`last_evidence`** is what it SHOWED: a `report` with
-its `evidence[]`, a `finding` with its proof, a `review` verdict. The strip
-sorts on evidence, and an agent that has shown nothing ages from its SPAWN
-rather than from the last thing it said — otherwise the chatty agent outranks
-one that produced something twenty minutes ago, which is the exact inversion
-this split exists to correct.
+Every agent carries three times. **`since`** is when it was spawned.
+**`last_signal`** is what it SAID, from its own `progress` events — and it is
+`null` until it says something. **`last_evidence`** is what it SHOWED: a
+`report` with its `evidence[]`, a `finding` with its proof, a `review` verdict.
+The strip sorts on evidence, and an agent that has shown nothing ages from its
+SPAWN rather than from the last thing it said — otherwise the chatty agent
+outranks one that produced something twenty minutes ago, which is the exact
+inversion this split exists to correct.
+
+**`last_signal` fell back to the spawn time until 0.1.36, and that was a wrong
+number rather than a missing one.** Measured over 420 real journals: 72 running
+agents on boards, `last_signal === since` for **72 of 72** — never once an
+actual signal — with `detail`, `next` and `state: "blocked"` at zero across the
+same set. The chip therefore printed *"N min since last signal"* about agents
+that had never signalled, and the golden fixture missed it because its one
+agent does signal: the case that is universal in the wild was the case no
+fixture covered. The age is still shown, because an agent open for six hours is
+worth flagging — it now says *"since it started"*, which is what it measures.
+`agents/implementer.md` asked for four `progress` emissions per story and got
+**one across 388 journals**; it now asks for one, at a blockage, which is the
+only one of the four that carries something no other event can reconstruct.
 
 There is deliberately no doctor finding for it. The threshold that separates
 "quiet because the work is hard" from "quiet because nothing is happening" is

--- a/scripts/board-html.mjs
+++ b/scripts/board-html.mjs
@@ -501,11 +501,21 @@ if (data.schema !== 1) {
       // Four buckets, not three. The old top bucket was "30 minutes or six
       // hours", which are not the same event: one is a long test run, the
       // other is an agent that is not coming back.
-      var ageMs = ageMsOf(a.last_signal);
-      var ageText = ageMs === null ? 'no signal recorded'
-        : ageMs >= 10800000 ? Math.round(ageMs / 3600000) + ' HOURS since last signal — likely dead'
-        : Math.round(ageMs / 60000) + ' min since last signal';
+      // Measured from SPAWN, and it says so. This line read "N min since last
+      // signal" off a field that held spawn time for 72 of 72 agents across
+      // 420 journals — a real number under a label describing a different
+      // event. The number was worth keeping; the label was not.
+      var ageMs = ageMsOf(a.since);
+      var ageText = ageMs === null ? 'start time unknown'
+        : ageMs >= 10800000 ? Math.round(ageMs / 3600000) + ' HOURS since it started — likely dead'
+        : Math.round(ageMs / 60000) + ' min since it started';
       chip.appendChild(el('div', ageClass(ageMs), ageText));
+      // Shown only when there IS one. An agent that has signalled is rare
+      // enough that it deserves its own line rather than a slot that reads the
+      // same whether it spoke or not.
+      if (a.last_signal) {
+        chip.appendChild(el('div', ageClass(ageMsOf(a.last_signal)), 'said so ' + ago(a.last_signal)));
+      }
       // Signal is what the agent SAID; evidence is what it SHOWED. An agent
       // emitting progress every few minutes while achieving nothing is the
       // healthiest-looking chip on the board, and the strip is sorted by the

--- a/scripts/board.mjs
+++ b/scripts/board.mjs
@@ -453,7 +453,8 @@ export function renderCrossMd(payload) {
     parts.push(
       `- \`${inline(a.agent)}\` (${inline(a.role)}) — ${inline(a.init)}` +
         `${a.ticket != null ? ` · \`${inline(a.ticket)}\`` : ''} · ${inline(a.state)}` +
-        `${a.detail != null ? ` — ${inline(a.detail)}` : ''} · last signal ${inline(a.last_signal)}` +
+        `${a.detail != null ? ` — ${inline(a.detail)}` : ''} · started ${inline(a.since)}` +
+        `${a.last_signal != null ? ` · last signal ${inline(a.last_signal)}` : ''}` +
         `${a.next != null ? ` · next: ${inline(a.next)}` : ''}\n`,
     );
   }

--- a/scripts/project.mjs
+++ b/scripts/project.mjs
@@ -978,7 +978,22 @@ export function boardOf(state, { staleHours = DEFAULT_STALE_HOURS } = {}) {
         open_hours: ageHours === null ? null : Math.round(ageHours * 10) / 10,
         detail: signal?.detail ?? null,
         next: signal?.next ?? null,
-        last_signal: signal?.ts ?? a.spawnTs,
+        // NULL when the agent has never signalled, and it almost never has.
+        //
+        // This used to fall back to `a.spawnTs`, which made every consumer
+        // print spawn time under a label that says "when it last spoke".
+        // Measured over 420 real journals: 72 running agents on boards, and
+        // `last_signal === since` for 72 of 72. Not once a signal. `detail`,
+        // `next` and `state: 'blocked'` were zero across the same set, because
+        // all four come from a `progress` event that fires once in 388
+        // journals against an instruction asking for four per story.
+        //
+        // The fallback made that invisible: the board looked like it was
+        // reporting agent chatter and was reporting process ages. A wrong
+        // number reads as a measurement, which is worse than a blank — so the
+        // blank is the honest value, and `since` (right below) is where spawn
+        // time has always actually lived.
+        last_signal: signal?.ts ?? null,
         // What it has SHOWN. Null until it shows something, which is the
         // ordinary state of an agent that has just started — the strip says
         // "nothing yet" rather than implying silence.
@@ -1029,13 +1044,17 @@ export function renderBoard(state, board = boardOf(state)) {
   parts.push('\n## Agents\n\n');
   parts.push(
     table(
-      ['Agent', 'Role', 'Ticket', 'State', 'Detail', 'Last signal'],
+      // "Started" is the column that always has a value; "Last signal" is the
+      // one that almost never does, and printing spawn time in it made the
+      // table look fuller than the journal was.
+      ['Agent', 'Role', 'Ticket', 'State', 'Detail', 'Started', 'Last signal'],
       sortByKey(board.agents, (a) => a.agent).map((a) => [
         inline(a.agent),
         inline(a.role),
         inline(a.ticket),
         inline(a.state),
         inline(a.detail),
+        inline(a.since),
         inline(a.last_signal),
       ]),
     ),

--- a/site/src/content/docs/board.mdx
+++ b/site/src/content/docs/board.mdx
@@ -535,13 +535,27 @@ stale agents are still counted, still in the strip, and now said out loud. The
 same correction reaches `BOARD.md`, whose headline says *open* rather than
 *running*, with the stale count beside it.
 
-Every agent now carries two times. **`last_signal`** is what it SAID, from its
-own `progress` events. **`last_evidence`** is what it SHOWED: a `report` with
-its `evidence[]`, a `finding` with its proof, a `review` verdict. The strip
-sorts on evidence, and an agent that has shown nothing ages from its SPAWN
-rather than from the last thing it said — otherwise the chatty agent outranks
-one that produced something twenty minutes ago, which is the exact inversion
-this split exists to correct.
+Every agent carries three times. **`since`** is when it was spawned.
+**`last_signal`** is what it SAID, from its own `progress` events — and it is
+`null` until it says something. **`last_evidence`** is what it SHOWED: a
+`report` with its `evidence[]`, a `finding` with its proof, a `review` verdict.
+The strip sorts on evidence, and an agent that has shown nothing ages from its
+SPAWN rather than from the last thing it said — otherwise the chatty agent
+outranks one that produced something twenty minutes ago, which is the exact
+inversion this split exists to correct.
+
+**`last_signal` fell back to the spawn time until 0.1.36, and that was a wrong
+number rather than a missing one.** Measured over 420 real journals: 72 running
+agents on boards, `last_signal === since` for **72 of 72** — never once an
+actual signal — with `detail`, `next` and `state: "blocked"` at zero across the
+same set. The chip therefore printed *"N min since last signal"* about agents
+that had never signalled, and the golden fixture missed it because its one
+agent does signal: the case that is universal in the wild was the case no
+fixture covered. The age is still shown, because an agent open for six hours is
+worth flagging — it now says *"since it started"*, which is what it measures.
+`agents/implementer.md` asked for four `progress` emissions per story and got
+**one across 388 journals**; it now asks for one, at a blockage, which is the
+only one of the four that carries something no other event can reconstruct.
 
 There is deliberately no doctor finding for it. The threshold that separates
 "quiet because the work is hard" from "quiet because nothing is happening" is

--- a/tests/fixtures/golden/BOARD.md
+++ b/tests/fixtures/golden/BOARD.md
@@ -13,9 +13,9 @@
 
 ## Agents
 
-| Agent | Role | Ticket | State | Detail | Last signal |
-|---|---|---|---|---|---|
-| impl-2 | implementer | T-2 | blocked | waiting on the worktree lease | 2026-07-26T09:41:40.000Z |
+| Agent | Role | Ticket | State | Detail | Started | Last signal |
+|---|---|---|---|---|---|---|
+| impl-2 | implementer | T-2 | blocked | waiting on the worktree lease | 2026-07-26T09:36:01.000Z | 2026-07-26T09:41:40.000Z |
 
 ## waiting-operator (1)
 

--- a/tests/unit/board.test.mjs
+++ b/tests/unit/board.test.mjs
@@ -784,12 +784,40 @@ test('the strip sorts on what agents SHOWED, not on what they said', () => {
   const quiet = payload.agents.find((a) => a.agent === 'quiet');
   assert.equal(quiet.last_evidence, '2026-01-01T00:05:00Z');
   assert.equal(quiet.evidence_kind, 'finding');
+  // MUTANT: restore `last_signal: signal?.ts ?? a.spawnTs`.
+  //
+  // `quiet` has never emitted a progress event, so its signal time is NOT a
+  // time — it is an absence. The fallback published its spawn instead, and
+  // every consumer printed that under a label reading "last signal": the chip
+  // ("N min since last signal"), the BOARD.md column, and the cross-repo line.
+  // Measured over 420 real journals: 72 running agents, `last_signal ===
+  // since` for 72 of 72, never once an actual signal. The golden fixture hid
+  // it because its one agent DOES signal — the case that is universal in the
+  // wild was the case no fixture covered.
+  assert.equal(quiet.last_signal, null, 'an agent that has never signalled has no signal time');
+  assert.equal(quiet.since, '2026-01-01T00:04:00Z', 'its spawn is carried by `since`, where it belongs');
 });
 
 test('the page shows signal and evidence as two different facts', () => {
   const html = demoHtml();
   assert.match(html, /nothing shown yet/, 'an agent that has shown nothing says so');
   assert.match(html, /a\.evidence_kind/, 'and what it showed is named');
+});
+
+test('the chip measures the age it can actually prove, and labels it that way', () => {
+  // MUTANT: point the age line back at `a.last_signal`.
+  //
+  // The number was always the spawn age; only the words said otherwise. It is
+  // worth keeping — an agent open for six hours IS the thing an operator wants
+  // flagged — so this is a relabelling, not a deletion. The `said so` line
+  // renders only when there is a signal to render, which is what makes the
+  // instruction's effect visible on the board instead of hidden behind a
+  // fallback.
+  const html = demoHtml();
+  assert.match(html, /ageMsOf\(a\.since\)/, 'the age is measured from spawn, which is the fact on hand');
+  assert.match(html, /since it started/, 'and it is labelled as spawn age');
+  assert.doesNotMatch(html, /since last signal/, 'nothing may print spawn time under the word signal');
+  assert.match(html, /if \(a\.last_signal\)/, 'a real signal still gets its own line');
 });
 
 test('the header counts LIVE agents, and says how many are stale', () => {


### PR DESCRIPTION
Closes the decision `NOTES-REQUESTS` §11 left open — with the measurement that section said nobody had made.

## The measurement

Folding **420 real journals** through `boardOf`:

| | |
|---|---:|
| running agents on boards | 72 |
| `last_signal === since` | **72 of 72** |
| `last_signal` an actual signal | **0** |
| chips with `detail` | 0 |
| chips with `next` | 0 |
| chips with `state: "blocked"` | 0 |

All of them come from a `progress` event that fires **once in 388 journals**, against an instruction asking for four per story.

## Why that was a wrong number, not a missing one

```js
last_signal: signal?.ts ?? a.spawnTs,
```

The fallback meant this was never empty — it was **spawn time published under a label that says "when it last spoke"**, in three places: the agent chip (*"N min since last signal"*), the `BOARD.md` column, and the cross-repo agent line.

A blank reads as an absence. A number reads as a measurement. This repo's own rule, from `CLAUDE.md`: *"A wrong number, not a missing one."*

## What changed

The age was worth keeping — an agent open for six hours **is** what an operator wants flagged — so this is a relabelling, not a deletion:

- the chip measures from `since` and says *"since it started"*;
- `BOARD.md` gains a **Started** column beside the one that is almost always empty;
- a real signal gets its own line, rendered only when there is one.

## Why the tests did not catch it

The golden fixture's one agent **does** signal, so the case that is universal in the wild was the case no fixture covered. The test added here uses the `quiet` agent that was already in the suite for a different reason and had simply never been asserted on.

## The instruction (option 2 of §11)

`agents/implementer.md` asked for four emissions and got one across 388 journals. It now asks for **one**, at the first blockage.

Three of the four were reconstructable from events another party writes — the lease **is** `started`, the report **is** the end of `working` — and a self-report only its author can contradict is worth less than one somebody else produces. A blockage is the exception: nothing else in the journal says an agent is stuck, or why.

**Option 3 (delete `progress` entirely) was rejected** for that reason. `spawn-blocked` and the `blocked` lane stay, now fed by an instruction with a plausible chance of being followed. Whether it *is* followed is still unmeasured, and §11 records that as the next count to take.

## Verification

```
tests 1576  pass 1576  fail 0      (1 new test, 2 new assertions)
```

Both doc surfaces updated; goldens regenerated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
