### PR TITLE
The board stops throwing you off the page you were reading (0.1.42)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
     {
       "name": "tyran",
       "description": "A task conductor for Claude Code: multi-agent orchestration with an enforced evidence contract, repo-specific learning, and update-safe local evolution.",
-      "version": "0.1.41",
+      "version": "0.1.42",
       "source": "./",
       "author": {
         "name": "Jacek Janczura",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "tyran",
-  "version": "0.1.41",
+  "version": "0.1.42",
   "description": "A task conductor for Claude Code: multi-agent orchestration with an enforced evidence contract, repo-specific learning, and update-safe local evolution.",
   "author": {
     "name": "Jacek Janczura",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,75 @@
 # Changelog
 
+## 0.1.42 — 2026-08-18
+
+### The board stopped throwing you off the page you were reading
+
+Six defects, all reported by an operator using the board rather than found by
+a test, and every one of them a place where the page knew something and did
+not act on it.
+
+**The tab lived in a local variable.** The page reloads itself every 30
+seconds; tab state did not survive that, so anyone reading Spend was returned
+to Overview twice a minute. The open tab now travels in the URL fragment, which
+also makes `#questions` a link you can send someone. `replaceState`, not an
+assignment to `location.hash` — the latter pushes a history entry per reload,
+and Back then walks backwards through half an hour of refreshes instead of
+leaving the page. A `hashchange` listener answers the other half: changing only
+the fragment is a same-document navigation that reloads nothing, so without it
+a deep link into an already-open page moved the URL and nothing else. That half
+is invisible to source reading and was found in a browser.
+
+**Spend now holds the refresh timer, as Settings already did.** Nothing on it
+is live: it is one scan of your transcripts, and reloading under a reader
+comparing two rows re-runs the scan to redraw numbers that did not move. The
+lane filter holds it too, and releases when cleared. Overview and Board are
+never held — a board that quietly stopped updating at midnight is the failure
+this page exists to prevent.
+
+**An initiative row is a button now.** It was the one thing on the page you
+could read and not open. Selecting one opens the ticket detail's own shape:
+directory, state, tickets merged, findings, when it last moved — and the
+documents beside its journal, which the board has listed as paths since it
+learned to list them and could not show.
+
+`GET /doc.json?init=…&name=…` serves those five files, and it takes **no path**.
+`name` must equal a member of `INITIATIVE_FILES`; `init` must equal a directory
+`state/` actually contains. Nothing from the request is joined into a path
+until it has matched one of those two lists, so traversal is refused by never
+being a candidate rather than by a filter someone has to keep ahead of. The
+text is invisible-escaped like every other journal-side value that reaches a
+human, capped at 200 000 codepoints, and rendered by nothing — these documents
+are agent-written, out of reports about other repositories. Reading is not
+behind `--write`: that flag draws its line at changing the repository.
+
+**Finished and abandoned stopped looking identical.** A percentage cannot tell
+them apart, and the board had nothing else — measured across 63 real journals,
+43 sat on an unanswered question and 6 were genuinely done. A `checkpoint`
+whose phase is the reserved word `closed` is the only event that ends an
+initiative, and it already closes that initiative's open spawns; the row now
+says `FINISHED`, carries the timestamp, sorts last and leaves the "waiting on
+you" count. It is deliberately **not** a deployment claim: no event in the
+closed set records a deploy, so the board does not imply one.
+
+**The answer box grew the keystroke everyone tried.** ⌘/Ctrl+Enter sends, and
+the placeholder says so — "Answer" was always the send button, but a labelled
+verb beside a text box reads as a mode switch. Bare Enter still inserts a
+newline, on purpose: answers are sentences, which is why the field is a
+textarea, and what it sends is appended to a journal that can never take it
+back.
+
+**And the three `npx answer` commands folded away.** They are the only route on
+a read-only board or one opened over `file://`, so they cannot be removed — but
+above the questions on a writable board they were three commands you never need
+in the place the eye lands first. They now sit behind "Answer from the terminal
+instead", and open themselves on the boards where they are the answer, decided
+by the `writable` flag the settings fetch already returned.
+
+Documented on both surfaces, including the difference the page never explained:
+a **default** is what happens if you say nothing (blank is recorded verbatim as
+your decision), a **recommendation** is what the asking agent thinks you should
+do (it fills the box and submits nothing).
+
 ## 0.1.41 — 2026-08-18
 
 ### The knowledge store can now shrink, and nothing is destroyed to do it

--- a/README.md
+++ b/README.md
@@ -322,7 +322,7 @@ enforces the cap (3868 of 5000 characters). What each one assumes, when it
 fires and who invokes it, is in
 [skills and agents](https://jjanczur.github.io/tyran/skills/); the prompts
 themselves are in [`skills/`](skills/) and [`agents/`](agents/). Behind all of
-it: 1612 unit tests, run with `node --test "tests/**/*.test.mjs"`.
+it: 1620 unit tests, run with `node --test "tests/**/*.test.mjs"`.
 
 ## Documentation
 

--- a/docs/board.md
+++ b/docs/board.md
@@ -101,10 +101,17 @@ closed, and `apply` refuses the whole file rather than appending a duplicate.
 ### Or answer it on the page
 
 With the board served `--write`, every question in the **Waiting on you** tab
-carries a box. Type an answer and press **Answer**; on a question that has a
-recorded default, press **Take the default** instead. The three commands above
-still work and stay printed on the tab — the box is a convenience, and a board
-opened over `file://` or without `--write` has to leave you somewhere to go.
+carries a box. Type an answer and press **Answer** — or **⌘/Ctrl+Enter**, which
+the placeholder names, because a labelled verb next to a text box does not read
+as send. Bare **Enter** deliberately does not send: answers are sentences, the
+box is a textarea for that reason, and what it sends is appended to a journal
+that can never take it back. On a question with a recorded default, press **Take
+the default** instead.
+
+The three commands above still work, and the tab still carries them — folded
+into *"Answer from the terminal instead"*, and opened automatically on a board
+that cannot answer in the page (read-only, or `file://`), where they are not a
+footnote but the only route there is.
 
 The request carries exactly two things: **which** ask, and your words.
 Everything else — the question, the recorded default, the ticket, the gate id —
@@ -120,11 +127,20 @@ type to know:
 
 | | |
 |---|---|
-| **decision · a default is recorded** | saying nothing has a safe outcome. You may take the recommendation and move on. |
+| **decision · a default is recorded** | saying nothing has a safe outcome. You may take the default and move on. |
 | **blocking · no safe default** | nobody recorded a fallback, so this one waits for you. |
 
 It is the same distinction that already makes the answer sheet sort
 no-default-first.
+
+**A default and a recommendation are not the same field**, and the buttons
+behave differently because of it. The **default** is what happens if you say
+nothing: *Take the default* submits blank, and the server writes the recorded
+value verbatim as your decision, marked `(default accepted)`. The
+**recommendation** is what the asking agent thinks you should do: *Use the
+recommendation* fills the box and submits nothing, so the wording stays yours to
+edit. When the two read alike on a card, that is the asking agent having written
+one sentence into both fields.
 
 ## Opening it
 
@@ -198,13 +214,28 @@ reloading itself every 30 seconds — on a timer the page can stop, not a
 parses the tag and removing the tag afterwards does not cancel it. A reload
 nothing can stop would destroy a half-typed answer or model name, so the
 timer is held while you are editing and re-armed when you leave.
+
+**What the reload must not cost you.** The open tab lives in the URL fragment
+(`#spend`, `#board`), so a refresh returns to the tab you were reading rather
+than to Overview — which is what it used to do, twice a minute, to anyone who
+left the page on Spend. It is `replaceState`, not an assignment to
+`location.hash`: the latter pushes a history entry per reload, and Back then
+walks through half an hour of refreshes instead of leaving the page. The
+fragment is also a link — `#questions` opens the queue directly, on a page
+already open as well as on a cold load. Three things hold the timer outright:
+typing in an answer box, the **Settings** tab, and the **Spend** tab, whose
+numbers are one scan of your transcripts and do not move on their own. The lane
+filter holds it while it has text and releases it when cleared. **Overview** and
+**Board** are never held — a board that silently stopped updating at midnight is
+the exact failure this page exists to prevent.
 The artefact itself never reads a clock —
 "as of" is the newest event timestamp, which keeps `--check` valid for the
 HTML too; the only clock is the viewer's own browser, which ages the agent
 strip.
 
-One scroll was answering four different questions at once, so each has a tab,
-and the page opens on Overview:
+One scroll was answering four different questions at once, so each has a tab.
+With no fragment in the URL — or one no tab answers to — the page opens on
+Overview:
 
 | tab | what it answers |
 |---|---|
@@ -224,6 +255,31 @@ the ticket, the board's own annotation, and — once the spend fetch has landed
 — that ticket's tokens and cost. The card stays a summary. What does not fit
 goes into the panel rather than into a wider card, which is what a grid of
 lanes cannot afford.
+
+**An initiative row is a button too**, and selecting one opens the same kind of
+panel under the list: its directory, its state, tickets merged, findings, when
+it last moved, and the documents it actually has. Selecting a document reads it
+from the server and shows it in the panel — as text, never parsed, because these
+files are written by agents out of reports about other repositories.
+
+The route behind that is `GET /doc.json?init=…&name=…`, and it takes **no path**.
+`name` must equal a member of a fixed five (`PLAN.md`, `NOTES.md`, `RETRO.md`,
+`STATE.md`, `PROGRESS.md`) and `init` must equal a directory `state/` actually
+contains — nothing from the request is joined into a path until it has matched
+one of those two lists, so traversal is refused by never being a candidate
+rather than by a filter. Content is invisible-escaped like every other
+journal-side value that reaches a human, and capped at 200 000 codepoints with
+the cut declared. Reading is not behind `--write`: that flag draws its line at
+changing the repository.
+
+**Finished is a fact, not a percentage.** A row says `FINISHED` when a
+`checkpoint` declared the initiative's phase `closed` — the same event that
+closes its still-open spawns, and the only one in the closed set that ends an
+initiative. Finished rows sort last and drop out of the "waiting on you" count.
+Note what it does not claim: **no journal event records a deployment**, so the
+board never says one happened. An initiative sitting at 100% with no closing
+checkpoint is work that stopped, not work that ended — and telling those two
+apart is the whole point of the flag.
 
 The panel also carries the two facts the **lane could only imply** and an
 **Execution** table:
@@ -276,8 +332,9 @@ node scripts/board.mjs --dir .tyran --serve --transcripts <dir>   # ... and Spen
 ```
 
 `--serve` binds `127.0.0.1` only, re-renders per request, and never derives a
-filesystem path from a URL; `--write` adds the [Settings](#settings) routes and
-nothing else, and refuses on its own (`--write` without `--serve` or `--detach`
+filesystem path from a URL — including `/doc.json`, which takes an initiative
+and a file NAME and matches both against fixed lists; `--write` adds the
+[Settings](#settings) routes and nothing else, and refuses on its own (`--write` without `--serve` or `--detach`
 is a usage error, not a silent no-op). `--transcripts <dir>` is the same
 refusal, for the same reason: it means something only to `/cost.json`, which
 only exists under a server. Repeatable, and it overrides `spend.transcript_dirs` in

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jjanczur/tyran",
-  "version": "0.1.41",
+  "version": "0.1.42",
   "description": "Command-line scripts for the Tyran task conductor (doctor, journal, schema, and repo tooling) for CI and terminals outside Claude Code. Installing this package does NOT install the Claude Code plugin — add that separately with `/plugin marketplace add jjanczur/tyran` inside Claude Code.",
   "type": "module",
   "engines": {

--- a/scripts/board-html.mjs
+++ b/scripts/board-html.mjs
@@ -134,6 +134,22 @@ h3{font-family:var(--font);color:var(--heading);font-size:.85rem;margin:1.1rem 0
 .file{display:flex;gap:.5rem;align-items:baseline;flex-wrap:wrap;font-size:.76rem}
 .file .fname{color:var(--steel-bright);font-family:var(--mono);font-weight:600;min-width:6rem}
 .file code{color:var(--muted);font-size:.72rem;word-break:break-all}
+/* On an initiative the name is a button that opens the file; on a ticket it is
+   still a plain span. Underlined rather than boxed: it sits in a list of paths
+   and a row of buttons there would read as a toolbar. */
+.file button.fname{background:transparent;border:0;padding:0;font-size:inherit;cursor:pointer;
+  text-align:left;text-decoration:underline;text-underline-offset:.18em}
+.file button.fname:hover{color:var(--brass-bright)}
+.file button.fname:focus-visible{outline:2px solid var(--steel);outline-offset:2px}
+.docview{margin-top:.5rem}
+.dochead{display:flex;gap:.6rem;align-items:baseline;flex-wrap:wrap;margin-bottom:.3rem}
+/* The document, as TEXT. It is agent-written markdown rendered by nothing —
+   pre-wrap so a long line folds instead of pushing the page sideways, and a
+   ceiling so a 2000-line NOTES.md scrolls inside the panel rather than
+   burying the board under it. */
+pre.doc{background:var(--bg-sunken);border:1px solid var(--hairline);border-radius:.45rem;
+  padding:.7rem .85rem;font-family:var(--mono);font-size:.74rem;line-height:1.5;color:var(--text);
+  white-space:pre-wrap;word-break:break-word;max-height:32rem;overflow:auto;margin:0}
 
 /* ---- what actually ran on a ticket ---- */
 .runs{width:100%;border-collapse:collapse;margin-top:.3rem;font-size:.74rem;display:block;overflow-x:auto}
@@ -184,6 +200,20 @@ h3{font-family:var(--font);color:var(--heading);font-size:.85rem;margin:1.1rem 0
 .reply textarea:disabled{opacity:.55;cursor:not-allowed}
 .reply .acts{display:flex;flex-wrap:wrap;gap:.4rem;align-items:center;margin-top:.4rem}
 .reply .hint{font-size:.75rem;color:var(--muted);margin-top:.3rem}
+/* Folded shut on a board that can answer in the page, opened by the settings
+   fetch on one that cannot. The summary is a sentence, not a chevron with a
+   noun: what is behind it is a route, not a section. */
+.howbox{margin:.3rem 0 .8rem}
+.howbox>summary{cursor:pointer;font-size:.76rem;color:var(--muted);list-style:none;padding:.2rem 0}
+.howbox>summary::-webkit-details-marker{display:none}
+/* The marker is written as a CHARACTER, not a CSS escape: this whole
+   stylesheet lives inside a template literal, where a backslash-2 escape is
+   read by JavaScript first and rejected as an octal one, taking the module
+   down before any CSS exists. */
+.howbox>summary::before{content:"▸ ";color:var(--steel)}
+.howbox[open]>summary::before{content:"▾ "}
+.howbox>summary:hover{color:var(--text)}
+.howbox>summary:focus-visible{outline:2px solid var(--steel);outline-offset:2px}
 pre.how{background:var(--bg-sunken);border:1px solid var(--hairline);border-radius:.45rem;padding:.7rem .85rem;font-family:var(--mono);font-size:.76rem;color:var(--text);overflow-x:auto;margin:.4rem 0 .7rem}
 pre.how .c{color:var(--muted)}
 
@@ -203,11 +233,23 @@ pre.how .c{color:var(--muted)}
 .comp .s-cache_write_1h{background:var(--ink)}
 /* ---- initiatives ---- */
 .inits{display:flex;flex-direction:column;gap:.3rem;margin:.5rem 0}
+/* A button, because selecting one opens its detail — the same interaction the
+   lane cards have. The reset is the whole point of the first three
+   declarations: a button inherits neither the page font nor its colour. */
 .initrow{display:grid;grid-template-columns:minmax(0,1.6fr) 5rem auto minmax(0,1fr);
-  gap:.6rem;align-items:center;padding:.35rem .5rem;border-radius:4px}
+  gap:.6rem;align-items:center;padding:.35rem .5rem;border-radius:4px;
+  font:inherit;color:inherit;background:transparent;border:1px solid transparent;
+  width:100%;text-align:left;cursor:pointer}
+.initrow:hover{border-color:var(--hairline);background:var(--bg-raised)}
+.initrow:focus-visible{outline:2px solid var(--steel);outline-offset:2px}
+.initrow[aria-pressed="true"]{border-color:var(--brass-edge);background:var(--brass-low)}
 /* An initiative nobody can move without the operator is the one thing on this
    section worth catching an eye. */
 .initrow.waiting{background:color-mix(in srgb,var(--brass) 12%,transparent)}
+/* Finished work is CONTEXT, not news: it keeps its row and its numbers and
+   stops competing for attention with the initiatives that are still running. */
+.initrow.finished .il,.initrow.finished .iv{color:var(--muted)}
+.initrow .iw.done{color:var(--sage);font-weight:600}
 .initrow .il{min-width:0;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
 .initrow .islug{color:var(--muted);margin-left:.4rem;font-size:.85em}
 .initrow .ib{height:6px;background:var(--line);border-radius:3px;overflow:hidden}
@@ -404,6 +446,14 @@ if (data.schema !== 1) {
     ['spend', 'Spend', null],
     ['settings', 'Settings', null],
   ];
+  // The open tab lives in the URL fragment, and that is not cosmetic. Tab
+  // state was a local variable while this page reloads itself every 30
+  // seconds, so an operator reading Spend was thrown back to Overview twice a
+  // minute — the page contradicting its own reason to be left open.
+  //
+  // replaceState, never an assignment to location.hash: assigning pushes a
+  // history entry, and one entry per reload means the Back button walks
+  // backwards through half an hour of refreshes instead of leaving the page.
   var select = function (key) {
     for (var i = 0; i < TABS.length; i += 1) {
       var k = TABS[i][0];
@@ -411,6 +461,9 @@ if (data.schema !== 1) {
       buttons[k].setAttribute('aria-selected', on ? 'true' : 'false');
       panels[k].hidden = !on;
     }
+    try {
+      history.replaceState(null, '', '#' + key);
+    } catch (e) { /* a restorable tab is a nicety; never let it take the page down */ }
   };
   TABS.forEach(function (spec) {
     var b = el('button', null, spec[1]);
@@ -614,21 +667,141 @@ if (data.schema !== 1) {
   // "Waiting" is the initiative's own count of open operator questions. The
   // idle time is computed HERE, from last_ts, because the payload is
   // byte-compared and reads no clock — the same split the agent strip uses.
+  // Reading an initiative's own documents, which were paths you copied into an
+  // editor and nothing else. SERVED, never embedded, for the same reason spend
+  // is: one NOTES.md runs to tens of kilobytes and board.json is a committed,
+  // byte-compared artefact.
+  //
+  // The request names an initiative and a FILE NAME, never a path - the server
+  // matches that name against its own fixed list (see board.mjs), so no URL
+  // this page can build reaches a file Tyran did not already agree to show.
+  // The markdown is rendered as TEXT in a pre, deliberately not parsed: these
+  // documents are written by agents, and the rule this whole page keeps is
+  // that nothing from that side ever becomes markup.
+  var loadDoc = function (init, file, view) {
+    clear(view);
+    view.appendChild(el('div', 'hint', 'reading ' + file.name + '…'));
+    fetch('doc.json?init=' + encodeURIComponent(init) + '&name=' + encodeURIComponent(file.name),
+      { headers: { accept: 'application/json' } })
+      .then(function (r) { return r.json().then(function (p) { return { ok: r.ok, payload: p }; }); })
+      .then(function (res) {
+        clear(view);
+        var payload = res.payload || {};
+        if (!res.ok) {
+          view.appendChild(el('div', 'setnote bad', String(payload.error || 'this file could not be read')));
+          return;
+        }
+        var head = el('div', 'dochead');
+        head.appendChild(el('span', 'fname', file.name));
+        head.appendChild(el('code', null, payload.path));
+        var close = el('button', 'sbtn', 'Close');
+        close.setAttribute('type', 'button');
+        close.addEventListener('click', function () { clear(view); });
+        head.appendChild(close);
+        view.appendChild(head);
+        var pre = el('pre', 'doc');
+        pre.textContent = payload.text;
+        view.appendChild(pre);
+        if (payload.truncated === true) {
+          view.appendChild(el('div', 'hint',
+            'Shown to ' + payload.bytes + ' bytes and cut there — open ' + payload.path + ' for the rest.'));
+        }
+      })
+      .catch(function () {
+        clear(view);
+        view.appendChild(el('div', 'setnote bad',
+          'This board is not being served, so it cannot read files. Start one with: npx @jjanczur/tyran board --dir .tyran --serve'));
+      });
+  };
+
   var inits = Array.isArray(data.initiatives) ? data.initiatives : [];
   if (inits.length > 0) {
-    var stalled = inits.filter(function (i) { return i.waiting > 0; }).sort(function (a, b) {
+    // Finished is a fact the journal STATES, never one inferred from a
+    // percentage: a checkpoint whose phase is the reserved word closed. See
+    // board.mjs for why that event and no other.
+    var isClosed = function (i) { return typeof i.closed === 'string' && i.closed !== ''; };
+    // A finished initiative blocks nobody, so its leftover questions are moot
+    // and it stays out of the nag. Its own row still reports them.
+    var stalled = inits.filter(function (i) { return i.waiting > 0 && !isClosed(i); }).sort(function (a, b) {
       return (ageMsOf(b.last_ts) || 0) - (ageMsOf(a.last_ts) || 0);
     });
+    var finished = inits.filter(isClosed);
     ov.appendChild(el('h2', null, 'Initiatives'));
     if (stalled.length > 0) {
       ov.appendChild(el('div', 'hint',
         stalled.length + ' of ' + inits.length + ' are waiting on an answer from you. ' +
         'Longest-waiting first — an initiative with an open question does not move until it is answered.'));
     }
+    if (finished.length > 0) {
+      ov.appendChild(el('div', 'hint',
+        finished.length + ' finished, sorted last. Finished means a checkpoint declared the initiative closed; it ' +
+        'is not a claim that anything was deployed, which no journal event records. An initiative sitting at 100% ' +
+        'without that checkpoint is work that stopped, not work that ended.'));
+    }
+    // Selecting an initiative, which was the one thing on this page you could
+    // read and not open. Deliberately the ticket detail's shape and place:
+    // same interaction, same corner of the screen, nothing new to learn.
+    var initDetail = el('div');
+    var initSelected = null;
+    var showInit = function (i, button) {
+      if (initSelected) initSelected.setAttribute('aria-pressed', 'false');
+      initSelected = button;
+      button.setAttribute('aria-pressed', 'true');
+      clear(initDetail);
+      var box = el('div', 'detail');
+      box.appendChild(el('div', 'dt', i.title || i.name));
+      var dl = el('dl');
+      var irow = function (k, v) {
+        if (v === null || v === undefined || v === '') return;
+        dl.appendChild(el('dt', null, k));
+        dl.appendChild(el('dd', null, v));
+      };
+      irow('directory', i.name);
+      irow('state', isClosed(i)
+        ? 'finished — a checkpoint closed it ' + ago(i.closed) + ' (' + i.closed + ')'
+        : 'open' + (i.phase ? ' · phase ' + i.phase : ' · no phase recorded'));
+      irow('tickets', i.merged + ' of ' + i.tickets + ' merged ('
+        + (typeof i.percent === 'number' ? i.percent : 0) + '%)');
+      irow('waiting on you', i.waiting > 0
+        ? i.waiting + ' question(s) — the "Waiting on you" tab answers them' : null);
+      irow('findings', i.findings > 0 ? i.findings + ' — STATE.md carries the table' : null);
+      irow('last event', i.last_ts ? ago(i.last_ts) + ' (' + i.last_ts + ')' : null);
+      box.appendChild(dl);
+      // The documents this initiative ACTUALLY has, listed by the server after
+      // an existsSync - never a fixed list of what a well-run initiative ought
+      // to contain. A named file that is not there is the same lie as a
+      // missing one, in the other direction.
+      var docs = (data.files || {})[i.name] || [];
+      if (docs.length === 0) {
+        box.appendChild(el('div', 'hint',
+          'No PLAN.md, NOTES.md, RETRO.md, STATE.md or PROGRESS.md beside this journal — those five are what the board can open.'));
+      } else {
+        box.appendChild(el('div', 'dt', 'Files'));
+        var view = el('div', 'docview');
+        var list = el('div', 'files');
+        docs.forEach(function (f) {
+          var line = el('div', 'file');
+          var open = el('button', 'fname', f.name);
+          open.setAttribute('type', 'button');
+          open.addEventListener('click', function () { loadDoc(i.name, f, view); });
+          line.appendChild(open);
+          line.appendChild(el('code', null, f.path));
+          list.appendChild(line);
+        });
+        box.appendChild(list);
+        box.appendChild(view);
+      }
+      initDetail.appendChild(box);
+    };
     var table = el('div', 'inits');
-    var ordered = stalled.concat(inits.filter(function (i) { return !(i.waiting > 0); }));
+    var ordered = stalled
+      .concat(inits.filter(function (i) { return !(i.waiting > 0) && !isClosed(i); }))
+      .concat(finished);
     ordered.forEach(function (i) {
-      var row = el('div', i.waiting > 0 ? 'initrow waiting' : 'initrow');
+      var row = el('button', 'initrow'
+        + (isClosed(i) ? ' finished' : i.waiting > 0 ? ' waiting' : ''));
+      row.setAttribute('type', 'button');
+      row.setAttribute('aria-pressed', 'false');
       // The TITLE, which the journal has carried all along while this page
       // showed a directory slug.
       var label = el('div', 'il');
@@ -643,16 +816,20 @@ if (data.schema !== 1) {
       var counts = i.merged + '/' + i.tickets + ' merged';
       // Named only when there is something to name. A findings count of zero
       // on every row is noise that teaches the eye to skip the column.
-      if (i.findings > 0) counts += ' \u00b7 ' + i.findings + ' finding' + (i.findings === 1 ? '' : 's');
+      if (i.findings > 0) counts += ' · ' + i.findings + ' finding' + (i.findings === 1 ? '' : 's');
       row.appendChild(el('div', 'iv', counts));
       var age = ageMsOf(i.last_ts);
-      row.appendChild(el('div', i.waiting > 0 ? 'iw warn' : 'iw',
-        i.waiting > 0
-          ? i.waiting + ' waiting on you \u00b7 quiet ' + ago(i.last_ts)
-          : (age === null ? '' : 'last moved ' + ago(i.last_ts))));
+      row.appendChild(el('div', isClosed(i) ? 'iw done' : i.waiting > 0 ? 'iw warn' : 'iw',
+        isClosed(i)
+          ? 'FINISHED · closed ' + ago(i.closed)
+          : i.waiting > 0
+            ? i.waiting + ' waiting on you · quiet ' + ago(i.last_ts)
+            : (age === null ? '' : 'last moved ' + ago(i.last_ts))));
+      row.addEventListener('click', function () { showInit(i, row); });
       table.appendChild(row);
     });
     ov.appendChild(table);
+    ov.appendChild(initDetail);
   }
 
   ov.appendChild(el('h2', null, 'Agents'));
@@ -902,19 +1079,37 @@ if (data.schema !== 1) {
     [].forEach.call(lanesWrap.children, function (box) { shown += box.tyranApply(q); });
     filterCount.textContent = q === '' ? '' : shown + ' of ' + allCards.length + ' ticket(s)';
   };
-  filterInput.addEventListener('input', applyFilter);
+  filterInput.addEventListener('input', function () {
+    applyFilter();
+    // The same rule every other input on this page follows: a reload must not
+    // eat what you are in the middle of typing. Re-armed the moment the box is
+    // empty again, because the Board is one of the two views that has to stay
+    // live — a filter left holding the timer would freeze it for the night.
+    // Wrapped, not passed: both helpers are defined further down, and
+    // addEventListener with undefined is a silent no-op rather than an error.
+    if (filterInput.value.trim() === '') armRefresh(); else holdRefresh();
+  });
   bd.appendChild(lanesWrap);
   bd.appendChild(detail);
 
   // ---- questions --------------------------------------------------------
   var qs = panels.questions;
   qs.appendChild(el('div', 'hint', 'Every question here is a gate in the journal, and it stays open until you close it. Blank takes the recorded default and is still written down as your decision; a single dash leaves it for next time.'));
+  // The terminal route, folded shut. It is the ONLY way to answer on a board
+  // opened over file:// or served without --write, so it can never be removed
+  // — but on a writable board it is three commands the operator does not need,
+  // printed above the questions, which is where the eye lands first. So it
+  // opens itself exactly when it is the answer: the settings fetch below finds
+  // out whether this board can write, and a board that cannot gets it open.
+  var howBox = el('details', 'howbox');
+  howBox.appendChild(el('summary', null, 'Answer from the terminal instead'));
   var how = el('pre', 'how');
   how.textContent =
     'npx @jjanczur/tyran answer render --dir .tyran   # writes .tyran/state/ANSWERS.md\\n' +
     '$EDITOR .tyran/state/ANSWERS.md                  # fill the answer: lines\\n' +
     'npx @jjanczur/tyran answer apply --dir .tyran    # closes what you answered';
-  qs.appendChild(how);
+  howBox.appendChild(how);
+  qs.appendChild(howBox);
   if (asks.length === 0) qs.appendChild(el('div', 'empty', 'nothing — the agents have what they need'));
 
   // Answering from the page. The three commands above still work and stay
@@ -928,9 +1123,14 @@ if (data.schema !== 1) {
   var replyBox = function (a, hasDefault) {
     var box = el('div', 'reply');
     var input = el('textarea');
-    input.placeholder = hasDefault
+    // The shortcut is named where the cursor already is. "Answer" IS the send
+    // button and always was, but a labelled verb beside a text box reads as a
+    // mode switch rather than as send, and an operator who types an answer and
+    // presses Enter gets a newline with nothing to say why.
+    input.placeholder = (hasDefault
       ? 'Your answer, in your own words \\u2014 or use the default button.'
-      : 'Your answer, in your own words. There is no recorded default for this one.';
+      : 'Your answer, in your own words. There is no recorded default for this one.')
+      + ' \\u2318/Ctrl+Enter sends.';
     var acts = el('div', 'acts');
     var send = el('button', 'sbtn', 'Answer');
     send.setAttribute('type', 'button');
@@ -969,7 +1169,8 @@ if (data.schema !== 1) {
           + ': ' + p.recorded + ' \\u00b7 decision ' + p.decision + ' \\u2014 reload to refresh the board';
       });
     };
-    send.addEventListener('click', function () {
+    var attempt = function () {
+      if (input.disabled) return;
       if (input.value.trim() === '') {
         status.className = 'sstat bad';
         status.textContent = hasDefault
@@ -978,6 +1179,20 @@ if (data.schema !== 1) {
         return;
       }
       submit(input.value);
+    };
+    send.addEventListener('click', attempt);
+    // Enter ALONE must not send, and the modifier is not decoration. This is a
+    // textarea because an operator explaining a decision writes sentences, and
+    // what it sends is appended to a journal that can never take it back — a
+    // question closed by a stray keystroke is a decision nobody made. The
+    // keyCode fallback is for a browser that reports no key on a dead-key
+    // layout; a duplicate hit is harmless because the handler is idempotent
+    // once the field disables itself.
+    input.addEventListener('keydown', function (e) {
+      if ((e.metaKey || e.ctrlKey) && (e.key === 'Enter' || e.keyCode === 13)) {
+        e.preventDefault();
+        attempt();
+      }
     });
     if (useDefault) useDefault.addEventListener('click', function () { submit(''); });
 
@@ -1629,13 +1844,20 @@ if (data.schema !== 1) {
     stBody.appendChild(pol);
   };
 
-  // Leaving this tab re-arms the refresh, entering it stops it. A page that
+  // Leaving these tabs re-arms the refresh, entering one stops it. A page that
   // reloads under an open select is a page that loses the change you were
-  // halfway through making, and the board has three other tabs that want to
-  // stay live.
+  // halfway through making.
+  //
+  // Spend joined Settings for a different reason: nothing on it is live. It is
+  // one fetch of a report over transcripts, and reloading the page under a
+  // reader who is comparing two rows of a cost table re-runs that scan to
+  // redraw numbers that did not move. Overview and Board are the two views
+  // that must NOT be held — a stale board overnight is the failure this page
+  // exists to prevent.
+  var HELD_TABS = { settings: true, spend: true };
   Object.keys(buttons).forEach(function (key) {
     buttons[key].addEventListener('click', function () {
-      if (key === 'settings') holdRefresh(); else armRefresh();
+      if (HELD_TABS[key] === true) holdRefresh(); else armRefresh();
     });
   });
 
@@ -1672,6 +1894,11 @@ if (data.schema !== 1) {
   fetch('settings.json', { headers: { accept: 'application/json' } })
     .then(function (r) { return r.ok ? r.json() : Promise.reject(new Error(String(r.status))); })
     .then(function (payload) {
+      // A read-only board cannot post an answer, so the terminal commands stop
+      // being a footnote and become the instruction — opened here rather than
+      // guessed at render time, because whether this board may write is a fact
+      // only the server has.
+      if (payload.writable !== true) howBox.open = true;
       if (payload.schema !== 1) {
         clear(stBody);
         stBody.appendChild(el('div', 'setnote bad', 'Settings were served in a format this page does not know (schema ' +
@@ -1692,13 +1919,31 @@ if (data.schema !== 1) {
       }
     })
     .catch(function () {
+      // No server at all — file://, or a copy on a docs site. Nothing on this
+      // page can write, so the terminal route is the only one there is. Set
+      // BEFORE the file:// return, which is silent on purpose.
+      howBox.open = true;
       if (String(location.protocol) === 'file:') return;
       clear(stBody);
       stBody.appendChild(el('div', 'setnote bad',
         'Settings could not be read: the board server did not answer. They are served, never embedded \\u2014 start it with: npx @jjanczur/tyran board --dir .tyran --serve --write'));
     });
 
-  select('overview');
+  // An unknown fragment is not worth a message: someone hand-edited the URL,
+  // or a later Tyran renamed a tab. hasOwnProperty rather than a truth test on
+  // the lookup, so a fragment spelling "constructor" cannot select a prototype.
+  var tabFromHash = function () {
+    var wanted = String(location.hash || '').replace(/^#/, '');
+    return Object.prototype.hasOwnProperty.call(panels, wanted) ? wanted : 'overview';
+  };
+  select(tabFromHash());
+  // Changing only the fragment of a URL is a SAME-DOCUMENT navigation: the
+  // browser fires this and reloads nothing, so without it a link to #board —
+  // or an operator editing the address bar on the page they already have open
+  // — moved the URL and left the page on whatever tab it was showing.
+  // Measured in a real browser; it is the half of fragment routing that is
+  // invisible until someone tries it.
+  window.addEventListener('hashchange', function () { select(tabFromHash()); });
 
   var foot = el('footer');
   foot.appendChild(el('div', null, 'GENERATED by tyran scripts/board.mjs — do not edit. Reloads itself every 30 s unless you are editing; ages are computed in this browser.'));

--- a/scripts/board.mjs
+++ b/scripts/board.mjs
@@ -35,7 +35,7 @@ import { spawn as spawnProcess } from 'node:child_process';
 import { basename, join, resolve } from 'node:path';
 import { realpathSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
-import { readJournal } from './journal.mjs';
+import { isClosingPhase, readJournal } from './journal.mjs';
 import {
   BOARD_FILE,
   BOARD_JSON_FILE,
@@ -48,7 +48,7 @@ import {
   writeAllAtomic,
   writeAtomic,
 } from './project.mjs';
-import { jsonEscapeInvisible } from './invisible.mjs';
+import { escapeInvisible, jsonEscapeInvisible } from './invisible.mjs';
 import { renderBoardError, renderBoardHtml } from './board-html.mjs';
 import { COST_SCHEMA, WINDOWS, costJson, costReport } from './cost.mjs';
 import { SettingsError, applyPolicyClass, applySetting, readSettings } from './settings.mjs';
@@ -225,10 +225,12 @@ export function readInitiativeBoards(tyranDir) {
  * rather than embedded. Relative is also the more useful form — it is what
  * the reader pastes, from the repo root, into an editor.
  *
- * Nothing is served from here: `--serve` derives a filesystem path from no
- * URL at all, which is worth more than a clickable link. The one route that
- * writes — Settings, behind `--write` — reaches two fixed files named in
- * `settings.mjs` and takes a KEY from the request, never a path.
+ * These five ARE served, since 0.1.42, by `readInitiativeDoc` below — and the
+ * promise this comment has always made survives it intact: `--serve` still
+ * derives a filesystem path from no URL at all. The route takes a NAME and
+ * matches it against the list above, exactly as the one route that writes —
+ * Settings, behind `--write` — reaches two fixed files named in `settings.mjs`
+ * by taking a KEY from the request and never a path.
  */
 export const INITIATIVE_FILES = Object.freeze(['PLAN.md', 'NOTES.md', 'RETRO.md', 'STATE.md', 'PROGRESS.md']);
 
@@ -239,6 +241,89 @@ export function initiativeFiles(tyranDir, name) {
     name: file,
     path: join(shown, file),
   }));
+}
+
+/**
+ * How much of one document travels to the page, in CODEPOINTS.
+ *
+ * Codepoints and not bytes because the cut is applied to a decoded string:
+ * slicing a UTF-8 buffer at a fixed offset lands inside a character often
+ * enough, and hands the reader a replacement mark that was never in the file.
+ *
+ * A cap at all because this route reads whatever grew beside a journal, and a
+ * NOTES.md three weeks into an initiative is not a thing to push through one
+ * response. The panel says it was cut and names the path holding the rest.
+ */
+export const MAX_DOC_CHARS = 200_000;
+
+/**
+ * One initiative document, for the page's file viewer.
+ *
+ * TWO CLOSED SETS AND NO PATH ARITHMETIC — that is the whole security story,
+ * and it is why the comment on `initiativeFiles` above ("nothing is served
+ * from here") could be revisited rather than merely broken. `name` must equal
+ * a member of `INITIATIVE_FILES`, and `init` must equal a directory that
+ * `state/` actually contains, compared against the very listing the board
+ * folds. Nothing from the request is joined into a path until it has matched
+ * one of those two lists, so `..`, an absolute path, a NUL and a name that
+ * differs only by case are all rejected by never becoming candidates — not by
+ * a filter someone has to keep ahead of the next trick.
+ *
+ * The text is invisible-ESCAPED, like every other journal-side value that
+ * reaches a human (invisible.mjs): these documents are written by agents out
+ * of reports about foreign repositories, and the reader is looking at them on
+ * a page instead of in the editor that would have shown the same bytes.
+ *
+ * Nothing is echoed back on a refusal. A message naming what was asked for is
+ * a message carrying attacker-chosen text into the operator's browser, and
+ * naming the five files it DOES serve is more useful anyway.
+ */
+export function readInitiativeDoc(tyranDir, init, name) {
+  if (!INITIATIVE_FILES.includes(name)) {
+    return { ok: false, status: 400, error: `this board serves only: ${INITIATIVE_FILES.join(', ')}` };
+  }
+  const stateDir = join(tyranDir, 'state');
+  let names;
+  try {
+    names = readdirSync(stateDir);
+  } catch (err) {
+    return { ok: false, status: 503, error: `${err?.code ?? 'unreadable'} reading the state directory` };
+  }
+  if (!names.includes(init)) {
+    return { ok: false, status: 404, error: 'no initiative by that name in this board' };
+  }
+  const file = join(stateDir, init, name);
+  let raw;
+  try {
+    raw = readFileSync(file, 'utf8');
+  } catch (err) {
+    // ENOENT here is ordinary: `initiativeFiles` listed what existed when the
+    // page was rendered, and an initiative that has since been archived is a
+    // fact to report rather than a failure.
+    return {
+      ok: false,
+      status: err?.code === 'ENOENT' ? 404 : 503,
+      error: err?.code === 'ENOENT'
+        ? `${name} is not beside that journal — the board lists what exists when it renders, so reload it`
+        : `${err?.code ?? 'unreadable'} reading ${name}`,
+    };
+  }
+  const chars = [...raw];
+  const truncated = chars.length > MAX_DOC_CHARS;
+  return {
+    ok: true,
+    status: 200,
+    schema: 1,
+    init,
+    name,
+    // Repo-relative, the same form `initiativeFiles` records and for the same
+    // reason: it is what the reader pastes into an editor, and it names no
+    // home directory.
+    path: join(basename(resolve(tyranDir)), 'state', init, name),
+    truncated,
+    chars: truncated ? MAX_DOC_CHARS : chars.length,
+    text: escapeInvisible(truncated ? chars.slice(0, MAX_DOC_CHARS).join('') : raw),
+  };
 }
 
 /** Pure merge of per-initiative boards into the one payload. */
@@ -297,6 +382,28 @@ export function crossBoard({ initiatives, errors, warned = [], stop = null }) {
       // caller assembling one by hand need not have every collection. A
       // missing array must read as "none", never take the board down.
       findings: (state.findings ?? []).length,
+      // FINISHED and ABANDONED read identically on a percentage bar, and they
+      // are the opposite situation: one is work that ended, the other is work
+      // that stopped. The board had no way to tell them apart — measured, it
+      // is the same 63 journals where 43 sat on an unanswered question and 6
+      // were genuinely done.
+      //
+      // A checkpoint whose phase is the reserved word `closed` is the ONLY
+      // event that declares an initiative over (journal.mjs), which is already
+      // what closes its still-open spawns — so this hangs on that same fact
+      // rather than inventing a second rule for "finished" (ADR-21). The
+      // TIMESTAMP, not a boolean: "closed 9 days ago" is the reading, and the
+      // page ages it in the reader's browser like every other time here.
+      //
+      // `phase` travels beside it because an initiative that is NOT closed
+      // still has its own word for where it is, and the per-initiative
+      // board.json has carried that word all along while the cross board
+      // showed a percentage and nothing else.
+      //
+      // NOT deployment: nothing in the closed event set records a deploy, so
+      // the board must not imply one. This says the initiative was wound up.
+      phase: state.checkpoint?.phase ?? null,
+      closed: isClosingPhase(state.checkpoint?.phase) ? state.checkpoint.ts : null,
       last_ts: state.lastTs,
     });
     if (state.lastTs !== null && (asOf === null || state.lastTs > asOf)) asOf = state.lastTs;
@@ -895,6 +1002,27 @@ function main() {
         }
         if (req.url === '/settings.json') {
           sendJson(res, 200, { ...readSettings(dir), writable: flags.write });
+          return;
+        }
+        // An initiative's own documents, which the board could name and not
+        // open. A GET behind the same Host pin as everything else, and NOT
+        // behind `--write`: reading a PLAN.md is what this whole page does,
+        // and the flag draws its line at changing the repository.
+        //
+        // The route takes an initiative and a FILE NAME. It takes no path,
+        // because a route that takes a path is a route whose safety is a
+        // filter — see readInitiativeDoc for the two closed sets that replace
+        // one. The old comment on `initiativeFiles` said this board derives a
+        // filesystem path from no URL at all; it still does not.
+        if (req.url.startsWith('/doc.json?') || req.url === '/doc.json') {
+          const q = new URLSearchParams(req.url.slice(req.url.indexOf('?') + 1));
+          const doc = readInitiativeDoc(dir, String(q.get('init') ?? ''), String(q.get('name') ?? ''));
+          if (doc.ok !== true) {
+            sendJson(res, doc.status, { ok: false, error: doc.error });
+            return;
+          }
+          const { ok, status, ...payload } = doc;
+          sendJson(res, 200, payload);
           return;
         }
         if (req.url === '/settings/config' || req.url === '/settings/policy' || req.url === '/answer') {

--- a/site/src/content/docs/board.mdx
+++ b/site/src/content/docs/board.mdx
@@ -104,10 +104,17 @@ closed, and `apply` refuses the whole file rather than appending a duplicate.
 ### Or answer it on the page
 
 With the board served `--write`, every question in the **Waiting on you** tab
-carries a box. Type an answer and press **Answer**; on a question that has a
-recorded default, press **Take the default** instead. The three commands above
-still work and stay printed on the tab — the box is a convenience, and a board
-opened over `file://` or without `--write` has to leave you somewhere to go.
+carries a box. Type an answer and press **Answer** — or **⌘/Ctrl+Enter**, which
+the placeholder names, because a labelled verb next to a text box does not read
+as send. Bare **Enter** deliberately does not send: answers are sentences, the
+box is a textarea for that reason, and what it sends is appended to a journal
+that can never take it back. On a question with a recorded default, press **Take
+the default** instead.
+
+The three commands above still work, and the tab still carries them — folded
+into *"Answer from the terminal instead"*, and opened automatically on a board
+that cannot answer in the page (read-only, or `file://`), where they are not a
+footnote but the only route there is.
 
 The request carries exactly two things: **which** ask, and your words.
 Everything else — the question, the recorded default, the ticket, the gate id —
@@ -123,11 +130,20 @@ type to know:
 
 | | |
 |---|---|
-| **decision · a default is recorded** | saying nothing has a safe outcome. You may take the recommendation and move on. |
+| **decision · a default is recorded** | saying nothing has a safe outcome. You may take the default and move on. |
 | **blocking · no safe default** | nobody recorded a fallback, so this one waits for you. |
 
 It is the same distinction that already makes the answer sheet sort
 no-default-first.
+
+**A default and a recommendation are not the same field**, and the buttons
+behave differently because of it. The **default** is what happens if you say
+nothing: *Take the default* submits blank, and the server writes the recorded
+value verbatim as your decision, marked `(default accepted)`. The
+**recommendation** is what the asking agent thinks you should do: *Use the
+recommendation* fills the box and submits nothing, so the wording stays yours to
+edit. When the two read alike on a card, that is the asking agent having written
+one sentence into both fields.
 
 ## Opening it
 
@@ -201,13 +217,29 @@ reloading itself every 30 seconds — on a timer the page can stop, not a
 parses the tag and removing the tag afterwards does not cancel it. A reload
 nothing can stop would destroy a half-typed answer or model name, so the
 timer is held while you are editing and re-armed when you leave.
+
+**What the reload must not cost you.** The open tab lives in the URL fragment
+(`#spend`, `#board`), so a refresh returns to the tab you were reading rather
+than to Overview — which is what it used to do, twice a minute, to anyone who
+left the page on Spend. It is `replaceState`, not an assignment to
+`location.hash`: the latter pushes a history entry per reload, and Back then
+walks through half an hour of refreshes instead of leaving the page. The
+fragment is also a link — `#questions` opens the queue directly, on a page
+already open as well as on a cold load. Three things hold the timer outright:
+typing in an answer box, the **Settings** tab, and the **Spend** tab, whose
+numbers are one scan of your transcripts and do not move on their own. The lane
+filter holds it while it has text and releases it when cleared. **Overview** and
+**Board** are never held — a board that silently stopped updating at midnight is
+the exact failure this page exists to prevent.
+
 The artefact itself never reads a clock —
 "as of" is the newest event timestamp, which keeps `--check` valid for the
 HTML too; the only clock is the viewer's own browser, which ages the agent
 strip.
 
-One scroll was answering four different questions at once, so each has a tab,
-and the page opens on Overview:
+One scroll was answering four different questions at once, so each has a tab.
+With no fragment in the URL — or one no tab answers to — the page opens on
+Overview:
 
 | tab | what it answers |
 |---|---|
@@ -227,6 +259,31 @@ the ticket, the board's own annotation, and — once the spend fetch has landed
 — that ticket's tokens and cost. The card stays a summary. What does not fit
 goes into the panel rather than into a wider card, which is what a grid of
 lanes cannot afford.
+
+**An initiative row is a button too**, and selecting one opens the same kind of
+panel under the list: its directory, its state, tickets merged, findings, when
+it last moved, and the documents it actually has. Selecting a document reads it
+from the server and shows it in the panel — as text, never parsed, because these
+files are written by agents out of reports about other repositories.
+
+The route behind that is `GET /doc.json?init=…&name=…`, and it takes **no path**.
+`name` must equal a member of a fixed five (`PLAN.md`, `NOTES.md`, `RETRO.md`,
+`STATE.md`, `PROGRESS.md`) and `init` must equal a directory `state/` actually
+contains — nothing from the request is joined into a path until it has matched
+one of those two lists, so traversal is refused by never being a candidate
+rather than by a filter. Content is invisible-escaped like every other
+journal-side value that reaches a human, and capped at 200 000 codepoints with
+the cut declared. Reading is not behind `--write`: that flag draws its line at
+changing the repository.
+
+**Finished is a fact, not a percentage.** A row says `FINISHED` when a
+`checkpoint` declared the initiative's phase `closed` — the same event that
+closes its still-open spawns, and the only one in the closed set that ends an
+initiative. Finished rows sort last and drop out of the "waiting on you" count.
+Note what it does not claim: **no journal event records a deployment**, so the
+board never says one happened. An initiative sitting at 100% with no closing
+checkpoint is work that stopped, not work that ended — and telling those two
+apart is the whole point of the flag.
 
 The panel also carries the two facts the **lane could only imply** and an
 **Execution** table:
@@ -279,8 +336,9 @@ node scripts/board.mjs --dir .tyran --serve --transcripts <dir>   # ... and Spen
 ```
 
 `--serve` binds `127.0.0.1` only, re-renders per request, and never derives a
-filesystem path from a URL; `--write` adds the [Settings](#settings) routes and
-nothing else, and refuses on its own (`--write` without `--serve` or `--detach`
+filesystem path from a URL — including `/doc.json`, which takes an initiative
+and a file NAME and matches both against fixed lists; `--write` adds the
+[Settings](#settings) routes and nothing else, and refuses on its own (`--write` without `--serve` or `--detach`
 is a usage error, not a silent no-op). `--transcripts <dir>` is the same
 refusal, for the same reason: it means something only to `/cost.json`, which
 only exists under a server. Repeatable, and it overrides `spend.transcript_dirs` in

--- a/tests/unit/board.test.mjs
+++ b/tests/unit/board.test.mjs
@@ -24,10 +24,12 @@ import { fileURLToPath } from 'node:url';
 import {
   BOARD_HTML_FILE,
   MAX_INITIATIVES,
+  MAX_DOC_CHARS,
   MAX_LOGGED_ERRORS,
   crossBoard,
   crossJson,
   readInitiativeBoards,
+  readInitiativeDoc,
   renderAll,
   renderCrossMd,
   openInBrowser,
@@ -251,7 +253,55 @@ test('the page is four tabs, opens on Overview, and carries the queue count in i
   assert.match(html, /\['spend', 'Spend', null\]/);
   assert.match(html, /el\('span', 'count', '\(' \+ spec\[2\] \+ '\)'\)/, 'the count must reach the tab label');
   assert.match(html, /panels\[k\]\.hidden = !on;/, 'an unselected tab must be hidden, not merely unstyled');
-  assert.match(html, /^\s*select\('overview'\);$/m, 'the page must open on Overview');
+  // Overview is now the FALLBACK rather than an unconditional opening move —
+  // the tab travels in the fragment (see the test below) — and a page reached
+  // with no fragment, or with one no tab answers to, must still open here.
+  assert.match(
+    html,
+    /hasOwnProperty\.call\(panels, wanted\) \? wanted : 'overview';/,
+    'an absent or unknown fragment must fall back to Overview',
+  );
+});
+
+test('the open tab travels in the URL, because the page reloads itself under the reader', () => {
+  // MUTANT 1: drop the replaceState and let `select` keep tab state in memory
+  // only. Every 30-second reload then throws the reader from Spend or
+  // Settings back to Overview — measured on a real board, and the reason this
+  // exists: the page whose whole pitch is that you can leave it open was
+  // resetting twice a minute.
+  // MUTANT 2: swap replaceState for `location.hash = key`. The tab is
+  // restored, and the Back button now walks backwards through one history
+  // entry per refresh instead of leaving the page.
+  // MUTANT 3: read the fragment with `panels[wanted]` instead of
+  // hasOwnProperty. A URL ending in a fragment spelling "constructor" then
+  // selects an inherited property and the page throws while rendering.
+  const html = demoHtml();
+  assert.match(html, /history\.replaceState\(null, '', '#' \+ key\);/, 'the tab must be written to the fragment');
+  assert.ok(!/location\.hash = /.test(html), 'assigning location.hash pushes a history entry per reload');
+  assert.match(html, /var wanted = String\(location\.hash \|\| ''\)\.replace\(\/\^#\/, ''\);/);
+  assert.match(html, /Object\.prototype\.hasOwnProperty\.call\(panels, wanted\)/);
+  // MUTANT 4: drop the hashchange listener. Changing only the fragment is a
+  // SAME-DOCUMENT navigation — nothing reloads — so a link to #board, or an
+  // operator editing the address bar on the page they already have open,
+  // moves the URL and leaves the page where it was. Found in a browser,
+  // because no source reading shows it.
+  assert.match(html, /window\.addEventListener\('hashchange', function \(\) \{ select\(tabFromHash\(\)\); \}\);/);
+});
+
+test('Spend and Settings hold the refresh; Overview and Board must not', () => {
+  // MUTANT 1: drop `spend` from HELD_TABS. The cost tab then re-runs its
+  // transcript scan under a reader comparing two rows, to redraw numbers that
+  // did not move.
+  // MUTANT 2: add `board` or `overview`. That is the failure this page exists
+  // to prevent — an operator asleep in front of a board that stopped updating
+  // at midnight cannot tell it from a fleet that stopped working.
+  const html = demoHtml();
+  assert.match(html, /var HELD_TABS = \{ settings: true, spend: true \};/);
+  assert.match(html, /if \(HELD_TABS\[key\] === true\) holdRefresh\(\); else armRefresh\(\);/);
+  // The lane filter is typing too, and it died on every reload like the
+  // answer boxes used to. Re-armed when empty, or a filter left in the box
+  // freezes the one view that has to stay live.
+  assert.match(html, /if \(filterInput\.value\.trim\(\) === ''\) armRefresh\(\); else holdRefresh\(\);/);
 });
 
 test('a lane card is a button that presses, so the detail panel has something to hang off', () => {
@@ -286,6 +336,44 @@ test('the questions tab prints the three commands that close a question', () => 
   // and the answer words, because a blank line is a recorded decision and
   // reads as one only if the page says so before it is typed
   assert.match(html, /Blank takes the recorded default and is still written down as your decision; a single dash leaves it for next time\./);
+});
+
+test('the terminal commands fold away on a board that can answer, and open on one that cannot', () => {
+  // MUTANT 1: render the pre unwrapped again. Three commands an operator with
+  // a writable board never needs then sit above the questions, which is where
+  // the eye lands first — reported as "npx commands without any context".
+  // MUTANT 2: keep the details but drop the two lines that open it. A
+  // read-only board, or one opened over file://, then HIDES the only route
+  // that can close a question there, which is strictly worse than printing it
+  // unconditionally ever was.
+  const html = demoHtml();
+  assert.match(html, /var howBox = el\('details', 'howbox'\);/);
+  assert.match(html, /el\('summary', null, 'Answer from the terminal instead'\)/);
+  assert.ok(!/howBox\.open = true;\s*\n\s*qs\.appendChild/.test(html), 'it must not start open');
+  // opened by the fact only the server has, on both branches: served
+  // read-only, and not served at all
+  assert.match(html, /if \(payload\.writable !== true\) howBox\.open = true;/);
+  assert.match(html, /howBox\.open = true;\n\s*if \(String\(location\.protocol\) === 'file:'\) return;/);
+});
+
+test('a modifier plus Enter sends an answer, and Enter alone does not', () => {
+  // MUTANT 1: delete the keydown listener. "Answer" is then the only way to
+  // send, and an operator who types a sentence and presses Enter gets a
+  // newline with nothing on the page to say why — reported as "there is no
+  // send button".
+  // MUTANT 2: drop the metaKey/ctrlKey test and send on bare Enter. This is a
+  // textarea because answers are sentences, and what it sends is appended to
+  // a journal that can never take it back: a gate closed by a stray keystroke
+  // is a decision nobody made.
+  const html = demoHtml();
+  assert.match(html, /input\.addEventListener\('keydown', function \(e\) \{/);
+  assert.match(html, /if \(\(e\.metaKey \|\| e\.ctrlKey\) && \(e\.key === 'Enter' \|\| e\.keyCode === 13\)\) \{/);
+  assert.match(html, /e\.preventDefault\(\);\n\s*attempt\(\);/);
+  // one code path, not two: the button and the shortcut must refuse an empty
+  // box in the same words
+  assert.match(html, /send\.addEventListener\('click', attempt\);/);
+  // and the shortcut is named where the cursor already is
+  assert.match(html, /Ctrl\+Enter sends\./);
 });
 
 test('the palette is the muted one, saturation on edges rather than on whole fills', () => {
@@ -438,6 +526,65 @@ test('the drill-down lists the initiative files that exist, and invents none', (
 
   const bare = crossBoard(readInitiativeBoards(tree({ demo: demo() })));
   assert.deepEqual(bare.files, {}, 'no files on disk, no files claimed');
+});
+
+test('a document is reached by TWO CLOSED SETS, never by a path from the URL', () => {
+  // The reason this route could be added at all. `initiativeFiles` has said
+  // since it was written that the board derives a filesystem path from no URL,
+  // and that promise is kept by never joining request text into a path until
+  // it has matched a fixed list — the traversal cases below are refused
+  // because they are never candidates, not because a filter caught them.
+  //
+  // MUTANT: accept any `name` and join it. Every one of these then reads a
+  // file outside the initiative, from a server the operator left running.
+  const dir = tree({ demo: demo() });
+  writeFileSync(join(dir, 'state', 'demo', 'PLAN.md'), '# plan\n');
+  writeFileSync(join(dir, 'secret.txt'), 'not yours\n');
+
+  for (const name of ['../../secret.txt', '../secret.txt', '/etc/passwd', 'plan.md', 'PLAN.md ', '', 'journal.jsonl']) {
+    const out = readInitiativeDoc(dir, 'demo', name);
+    assert.equal(out.ok, false, `${JSON.stringify(name)} must be refused`);
+    assert.equal(out.status, 400);
+    assert.match(out.error, /this board serves only: PLAN\.md, NOTES\.md/);
+  }
+  for (const init of ['..', '../..', 'demo/../demo', 'nope', '']) {
+    const out = readInitiativeDoc(dir, init, 'PLAN.md');
+    assert.equal(out.ok, false, `initiative ${JSON.stringify(init)} must be refused`);
+    assert.equal(out.status, 404);
+  }
+  // Nothing the caller sent is echoed back: a refusal naming what was asked
+  // for carries attacker-chosen text into the operator's browser.
+  assert.ok(!readInitiativeDoc(dir, '<script>', 'PLAN.md').error.includes('<script>'));
+
+  const ok = readInitiativeDoc(dir, 'demo', 'PLAN.md');
+  assert.equal(ok.ok, true);
+  assert.equal(ok.text, '# plan\n');
+  // Repo-relative, the form `initiativeFiles` already records: an absolute
+  // path names a home directory and a username.
+  assert.match(ok.path, /^[^/]+\/state\/demo\/PLAN\.md$/);
+});
+
+test('a document is invisible-escaped and capped, like every value that reaches a human', () => {
+  // MUTANT 1: return the file raw. These documents are written by agents out
+  // of reports about FOREIGN repositories, and the reader is looking at them
+  // on a page rather than in the editor that would show the same bytes — the
+  // exact asymmetry invisible.mjs was written to end.
+  // MUTANT 2: slice a Buffer instead of codepoints. The cut then lands inside
+  // a character and the panel shows a replacement mark that was never there.
+  const dir = tree({ demo: demo() });
+  writeFileSync(join(dir, 'state', 'demo', 'NOTES.md'), `bidi ${String.fromCodePoint(0x202e)} here\n`);
+  const escaped = readInitiativeDoc(dir, 'demo', 'NOTES.md');
+  assert.ok(!escaped.text.includes(String.fromCodePoint(0x202e)), 'a bidi override must not reach the page');
+  assert.match(escaped.text, /<U\+202E>/);
+  assert.equal(escaped.truncated, false);
+
+  // One astral character per position, so a byte-wise cut would be visible.
+  writeFileSync(join(dir, 'state', 'demo', 'PROGRESS.md'), '🙂'.repeat(MAX_DOC_CHARS + 10));
+  const cut = readInitiativeDoc(dir, 'demo', 'PROGRESS.md');
+  assert.equal(cut.truncated, true);
+  assert.equal(cut.chars, MAX_DOC_CHARS);
+  assert.equal([...cut.text].length, MAX_DOC_CHARS, 'the cut is counted in codepoints, not UTF-16 units');
+  assert.ok(!cut.text.includes('�'), 'no character may be cut in half');
 });
 
 test('over the ceiling the SERVED page is readable prose, not a 500 it re-fetches every 30 s', () => {
@@ -1008,6 +1155,48 @@ test('the page renders the initiative rows and names what is waiting', () => {
   assert.match(html, /data\.initiatives/, 'the client must read the initiatives rows');
   assert.match(html, /waiting on you/, 'the stalled count must be spelled out, not implied by a colour');
   assert.match(html, /initrow/);
+});
+
+test('a closing checkpoint marks an initiative finished; a percentage never does', () => {
+  // MUTANT 1: derive `closed` from percent === 100. Work that stopped and
+  // work that ended then read identically, which is the state the operator
+  // reported: 100% on a row nobody could tell apart from an abandoned one.
+  // MUTANT 2: set the flag on any checkpoint. Every initiative that ever
+  // recorded a phase is then "finished" the moment it starts.
+  const closing = demo() + JSON.stringify({
+    ts: '2026-07-27T10:00:00.000Z',
+    ev: 'checkpoint',
+    init: 'demo',
+    actor: 'conductor',
+    data: { phase: 'Closed', next_steps: ['none'] },
+  }) + '\n';
+  const open = crossBoard(readInitiativeBoards(tree({ demo: demo() }))).initiatives[0];
+  assert.equal(open.closed, null, 'an initiative with no closing checkpoint is not finished');
+  assert.equal(typeof open.phase, 'string', 'its phase still travels — an open initiative has a word for where it is');
+
+  const done = crossBoard(readInitiativeBoards(tree({ demo: closing }))).initiatives[0];
+  // The TIMESTAMP, not a boolean: "closed 9 days ago" is the reading, and the
+  // page ages it in the reader's browser like every other time on the page.
+  assert.equal(done.closed, '2026-07-27T10:00:00.000Z');
+  // Case-insensitive and trimmed, because a human writes this phase by hand —
+  // the rule is journal.mjs's, imported rather than restated here.
+  assert.equal(done.phase, 'Closed');
+});
+
+test('an initiative row is a button, and finished ones say so and sort last', () => {
+  // MUTANT 1: render the rows as divs again. The one thing on this page an
+  // operator could read and not open stays unopenable — reported verbatim:
+  // "I can't open tickets and initiatives to read details".
+  // MUTANT 2: drop the finished branch from the ordering. Completed work then
+  // competes for the top of the section with the initiatives still running.
+  const html = demoHtml();
+  assert.match(html, /var row = el\('button', 'initrow'/, 'a row must be a real button, not a clickable div');
+  assert.match(html, /row\.addEventListener\('click', function \(\) \{ showInit\(i, row\); \}\);/);
+  assert.match(html, /\.concat\(finished\);/, 'finished initiatives sort last');
+  assert.match(html, /'FINISHED · closed ' \+ ago\(i\.closed\)/);
+  // and the board must not overclaim: nothing in the closed event set records
+  // a deployment, so the page may not imply one
+  assert.match(html, /is not a claim that anything was deployed/);
 });
 
 test('an ask offers its recommendation as one click, not as text to retype', () => {


### PR DESCRIPTION
Six defects, every one reported by an operator using the board rather than found by a test, and every one a place where the page knew something and did not act on it.

## What changed

**The open tab lives in the URL fragment.** Tab state was a local variable while the page reloads itself every 30 seconds, so anyone reading Spend was returned to Overview twice a minute. `replaceState`, not an assignment to `location.hash` — the latter pushes a history entry per reload, and Back then walks backwards through half an hour of refreshes instead of leaving the page. `#questions` is now a link you can send someone.

**A `hashchange` listener**, because changing only the fragment is a same-document navigation that reloads nothing: without it, a deep link into an already-open page moved the URL and left the page where it was. Found in a real browser — no amount of source reading shows it.

**Spend holds the refresh timer, as Settings already did.** Nothing on it is live; it is one scan of your transcripts, and reloading under a reader comparing two rows re-runs the scan to redraw numbers that did not move. The lane filter holds it while it has text. Overview and Board are never held — a board that quietly stopped updating at midnight is the failure this page exists to prevent.

**An initiative row is a button.** It was the one thing on the page you could read and not open. Selecting one opens the ticket detail's own shape — directory, state, tickets merged, findings, last event — plus the documents beside its journal, which the board has listed as paths since it learned to list them and could not show.

`GET /doc.json?init=…&name=…` serves those five files and **takes no path**: `name` must equal a member of `INITIATIVE_FILES`, `init` must equal a directory `state/` actually contains, and nothing from the request is joined into a path until it has matched one of those two lists — so traversal is refused by never being a candidate rather than by a filter someone has to keep ahead of. Text is invisible-escaped like every other journal-side value that reaches a human, capped at 200 000 codepoints, and rendered by nothing. Reading is not behind `--write`; that flag draws its line at changing the repository.

**`FINISHED` is a fact, not a percentage.** It comes from the `checkpoint` whose phase is the reserved word `closed` — the same event that closes an initiative's open spawns, and the only one that ends an initiative. Finished rows sort last and leave the "waiting on you" count. Deliberately **not** a deployment claim: no event in the closed set records a deploy.

**⌘/Ctrl+Enter sends an answer**, and the placeholder says so — "Answer" was always the send button, but a labelled verb beside a text box reads as a mode switch. Bare Enter still writes a newline on purpose: answers are sentences, and what it sends is appended to a journal that can never take it back. The three `npx answer` commands fold into "Answer from the terminal instead" and open themselves on a board that cannot answer in the page.

## Verification

- **1620 unit tests, 0 skipped**, 0 failures. README count updated; `--check` byte-exact; `doctor --state` healthy.
- **Real Chromium against a live board**: reload keeps the tab with no history growth, an unknown fragment falls back to Overview, PLAN.md loads through the new route, bare Enter kept the newline and sent nothing while ⌘Enter recorded a decision — zero console errors, zero ≥400 responses.
- **curl against the route**: traversal and unknown names return 400/404, the `Host` pin still 403s.

Both doc surfaces updated, including the distinction the page never explained: a **default** is what happens if you say nothing, a **recommendation** is what the asking agent thinks you should do.

🤖 Generated with [Claude Code](https://claude.com/claude-code)