### PR TITLE
The review reads data access and structure, and the self-review has criteria (0.1.45)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
     {
       "name": "tyran",
       "description": "A task conductor for Claude Code: multi-agent orchestration with an enforced evidence contract, repo-specific learning, and update-safe local evolution.",
-      "version": "0.1.44",
+      "version": "0.1.45",
       "source": "./",
       "author": {
         "name": "Jacek Janczura",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "tyran",
-  "version": "0.1.44",
+  "version": "0.1.45",
   "description": "A task conductor for Claude Code: multi-agent orchestration with an enforced evidence contract, repo-specific learning, and update-safe local evolution.",
   "author": {
     "name": "Jacek Janczura",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,50 @@
 # Changelog
 
+## 0.1.45 — 2026-08-22
+
+### The review reads data access and structure, and the self-review has criteria
+
+`code-review` gained two dimensions. **Data access and wasted work**: the
+round trips one request makes and how the count moves with the rows — a query
+inside a loop or an awaited per-item `map` is 1 + N, awaits with no dependency
+between them run together with the fan-out bounded, the same pure computation
+runs once per request, and a cache comes AFTER those, never instead of them,
+with the diff saying what invalidates it and why the TTL is that number. None
+of it shows in the diff alone, so the rule is to follow the new call up to the
+request that triggers it, and the finding is a count — "N+1 queries for N rows,
+expected 1" — which is what lets it pin as a test. **Structure**: a
+thousand-line file is built one reasonable addition at a time, so the question
+is whether THIS addition gives a module a second reason to change; the
+counterweight is `deslop`'s own — a layer or helper introduced for one caller
+is the opposite failure, not the cure — and a giant the story merely touched is
+a `NOTES.md` debt, not an in-story refactor.
+
+Reported from the operator's own repos: the implementer and reviewer shipped
+N+1 queries, serial awaits over independent calls, repeated queries that could
+have been one, and caches with no stated reason for their TTL, often enough
+that the same eight-point checklist was being pasted into every handoff by
+hand. The checklist now lives in one place — the skill the reviewer already
+loads — and nowhere else.
+
+The implementer's "self-review of your own diff" had no criteria: it named no
+skill and listed no dimension. It is now the `code-review` skill run on
+yourself, loaded rather than recalled, with data access called out as the
+dimension an author misses most, because each call site looked fine where it
+was written. For work that reads or writes data the short plan states the
+round trips one request will cost. `deslop` says in one sentence that a slow
+data path is not its business — it deletes, and the fix for a query in a loop
+adds lines — so "the optimization pass" can no longer be read as the
+performance pass. A test pins the pointer and the N+1 clause, because 0.1.40
+is exactly the kind of edit that drops a cross-reference.
+
+Not added: a performance-audit skill. The operator's four-phase audit — recon,
+a false-positive pass, a report split by what is safe to fix without asking,
+iterative implementation — is the shape of an initiative under `/tyran:run`:
+scout, plan, implementer, reviewer, with the policy classes deciding what needs
+a human. A skill nothing asks for by name is a library entry, and every
+description is paid for by every session. Skill descriptions: 3868 → 3947 of
+5000.
+
 ## 0.1.44 — 2026-08-19
 
 ### The board follows your OS, and finally has a light mode

--- a/README.md
+++ b/README.md
@@ -325,11 +325,11 @@ branch), `tyran:reviewer` (may fix what it finds, but editing forfeits
 suite on the cheapest tier, reports raw counts, never fixes), `tyran:retro`. A skill is admitted only when something already asks
 for the protocol by name, and every description is loaded into every session
 whether the skill fires or not — so the combined length is capped and CI
-enforces the cap (3868 of 5000 characters). What each one assumes, when it
+enforces the cap (3947 of 5000 characters). What each one assumes, when it
 fires and who invokes it, is in
 [skills and agents](https://jjanczur.github.io/tyran/skills/); the prompts
 themselves are in [`skills/`](skills/) and [`agents/`](agents/). Behind all of
-it: 1659 unit tests, run with `node --test "tests/**/*.test.mjs"`.
+it: 1660 unit tests, run with `node --test "tests/**/*.test.mjs"`.
 
 ## Documentation
 

--- a/agents/implementer.md
+++ b/agents/implementer.md
@@ -54,6 +54,14 @@ commits and anything written to disk are in English.**
    optimization pass recorded in the story file (`deslop` — it deletes rather
    than adds, and it needs a test that ran BEFORE your edit), repo validation,
    then commits, push and PR on the story branch.
+   - **The self-review is the `code-review` skill run on yourself** — load it
+     with the `Skill` tool; a checklist recalled from memory is the one you
+     already failed to apply while writing. The dimension an author misses
+     most is data access: each call site looked fine where you wrote it, and
+     the loop that multiplies it is in a file you did not open, so follow your
+     new call up to the request. For work that reads or writes data, the
+     short plan states the round trips one request will cost — a number
+     written down before the code is the cheapest one you will ever fix.
    - When a test fails for a reason you cannot explain, **stop patching and
      follow `root-cause`**. Reproduce it, change one variable at a time with
      the prediction written down first, and name the mechanism. A fix for a

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jjanczur/tyran",
-  "version": "0.1.44",
+  "version": "0.1.45",
   "description": "Command-line scripts for the Tyran task conductor (doctor, journal, schema, and repo tooling) for CI and terminals outside Claude Code. Installing this package does NOT install the Claude Code plugin — add that separately with `/plugin marketplace add jjanczur/tyran` inside Claude Code.",
   "type": "module",
   "engines": {

--- a/skills/code-review/SKILL.md
+++ b/skills/code-review/SKILL.md
@@ -1,5 +1,5 @@
 ---
-description: The depth half of a review - the dimensions a diff is read against (correctness, boundaries, concurrency, failure paths, secrets, test quality) and the rule that a finding is refuted before it is reported. The verdict stays with the reviewer agent. Use when reviewing a diff or a pull request.
+description: The depth half of a review - the dimensions a diff is read against (correctness, boundaries, concurrency, failure paths, secrets, data access, structure, test quality) and the rule that a finding is refuted before it is reported. The verdict stays with the reviewer agent. Use when reviewing a diff or a pull request, or when asked about N+1 queries or wasted round trips.
 ---
 
 # Code review — reading depth
@@ -57,6 +57,34 @@ gap nobody notices.
   through the real producer, not a stand-in for its output.
 - **Resource lifecycle.** What is opened, started, spawned or leased, and where
   it is closed — including on the path where an exception is thrown.
+- **Data access and wasted work.** Count the round trips one request makes
+  and how the count moves with the rows. A query, fetch or RPC inside a loop
+  or an awaited per-item `map` is 1 + N; one query over the set (a join, an
+  `IN`, a loader) is the shape. Awaits with no data dependency between them
+  run together, fan-out bounded — unbounded over a pool or a rate limit, a
+  slow request becomes a failed one. The same pure computation over the same
+  inputs runs once per request. A cache comes AFTER those, never instead: a
+  cache over a query that should not have run is a defect with a warm cache,
+  and one the diff adds or touches must say what invalidates it and why the
+  TTL is that number — a TTL is the staleness the product agreed to, and a
+  number with no reason is the first stale read filed in advance. None of this
+  shows in the diff alone: a helper that runs one query is correct where it is
+  written and N+1 where a loop calls it, so follow the new call up to the
+  request that triggers it. Rank by the path — a query on every page load is
+  a finding, a nightly job over twelve rows is a `NOTES.md` line. The finding
+  is a count, "N+1 queries for N rows, expected 1": an input and an expected
+  result, so it pins as a test against the query log.
+- **Structure.** A thousand-line file is built one reasonable addition at a
+  time, so the question is about THIS addition: does it give a module a second
+  reason to change, or grow the largest file in its area? A new concern is a
+  new module, and the simplest change that meets the criteria is the bar — a
+  layer, an option or a generic helper introduced for the one caller the story
+  has is the opposite failure, not the cure; `deslop` already names it as
+  slop. This finding is a location, not a counterexample: the file, the two
+  responsibilities it now carries, the seam between them. It is the story's
+  finding only when the story made the tangle; a giant the story merely
+  touched is a `NOTES.md` debt, and splitting it here is the work nobody asked
+  for.
 - **The gate itself.** If the change touches a check, ask what that check can
   no longer see. A loosened tolerance, a narrowed selector, a broadened
   try/catch and a skipped test all keep the run green while removing its

--- a/skills/deslop/SKILL.md
+++ b/skills/deslop/SKILL.md
@@ -64,7 +64,10 @@ fixed, the deleted test is the reason.
 
 **Keep behaviour unchanged unless you are fixing a defect you can name.** If the
 pass uncovers a real bug, that is a finding for the report and usually a
-separate change, not something to quietly correct inside a cleanup.
+separate change, not something to quietly correct inside a cleanup. The same
+goes for a slow data path — a query in a loop, awaits that could run together:
+that is `code-review`'s data-access dimension, its fix usually adds lines, and
+it belongs in the self-review before this pass, not inside it.
 
 ## Skill-file mode
 

--- a/tests/unit/agents.test.mjs
+++ b/tests/unit/agents.test.mjs
@@ -201,3 +201,23 @@ test('every agent tells its reader which language to answer in', () => {
     assert.match(text, /language the conductor writes to you in/, `${file}: no language rule`);
   }
 });
+
+test('the implementer self-reviews against code-review, and code-review carries the N+1 check', () => {
+  // The self-review had no criteria: it named no skill and listed no
+  // dimension, so an author's diff reached the reviewer with N+1 queries,
+  // serial awaits and unexplained cache TTLs in it, and the operator pasted
+  // the same checklist into every handoff by hand. The fix is one answer in
+  // one place (ADR-21): the dimensions live in `code-review`, and the
+  // implementer POINTS at them. A prompt-shortening pass like 0.1.40 is
+  // exactly the edit that drops a pointer without anyone noticing, so the
+  // pointer is pinned the way the reviewer's forfeit sentence is.
+  const implementer = readFileSync(join(AGENTS_DIR, 'implementer.md'), 'utf8');
+  assert.match(
+    // Whitespace-flexible: wrapped at 79 columns like every line here.
+    implementer.replace(/\s+/g, ' '),
+    /self-review is the `code-review` skill/i,
+    'implementer.md must send the self-review to the code-review skill, not to a checklist of its own',
+  );
+  const review = readFileSync(join(SKILLS_DIR, 'code-review', 'SKILL.md'), 'utf8');
+  assert.match(review, /N\+1/, 'code-review must carry the N+1 check — it is the dimension the implementer is pointed at');
+});


### PR DESCRIPTION
## Summary

The implementer and reviewer kept shipping N+1 queries, serial awaits over independent calls, repeated queries that could have been one, caches with no stated reason for their TTL, and files growing toward a thousand lines — often enough that the same eight-point checklist was being pasted into every handoff by hand. The checklist now lives in one place, the skill both agents already load, and nowhere else.

- **`skills/code-review/SKILL.md`** — two new dimensions. *Data access and wasted work*: round trips per request and how the count moves with the rows; awaits with no data dependency run together, fan-out bounded; the same pure computation once per request; a cache AFTER those, never instead, naming what invalidates it and why the TTL is that number; follow the new call up to the request because none of it shows in the diff alone; the finding is a count ("N+1 queries for N rows, expected 1"). *Structure*: does THIS addition give a module a second reason to change; a helper for one caller is the opposite failure (by reference to `deslop`); a giant the story merely touched is a `NOTES.md` debt. Description gains the dimension names and the trigger "when asked about N+1 queries or wasted round trips" (293 → 372 chars; budget 3868 → 3947 of 5000).
- **`agents/implementer.md`** — "self-review of your own diff" had no criteria; it is now the `code-review` skill run on yourself, loaded with `Skill`, with data access named as the dimension an author misses most. No checklist and no "N+1" in the agent file on purpose (ADR-21).
- **`skills/deslop/SKILL.md`** — one sentence: a slow data path is not its business; its fix adds lines and belongs in the self-review before this pass.
- **`tests/unit/agents.test.mjs`** — pins the pointer and the N+1 clause (1659 → 1660). ADR-20: `code-review` misspelled in the sub-bullet → 10/1; every `N+1` removed → 10/1; restored, 11/11.
- **Release 0.1.45** — changelog entry (including what was NOT added: a perf-audit skill, and why) and the three version files.

Not changed: `agents/reviewer.md` (everything arrives through the skill it already loads), the conductor, docs surfaces (none enumerates dimensions).

## Test plan

- [x] `node --test "tests/**/*.test.mjs"` — 1660 / 1660, 0 fail, 0 skipped
- [x] `node scripts/desc-budget.mjs .` — 3947 of 5000; README figure matches
- [x] `node scripts/scan-control-chars.mjs .` — clean; `claude plugin validate .` — passed
- [x] Two cold reviewers on a scratch Next.js + Supabase fixture (13-file story diff), given only the new text: N+1 through a per-row component found by following the call up to the page and stated as a count (both runs); unjustified 60s cache asked for invalidation and reason (both); justified catalog cache, nightly 12-query cron and six lines added to a 1,400-line routes file drew no finding (both); correctness findings still ranked first
- [x] Activation proxy over the 14 descriptions: "does this page make too many queries?" and the Polish "czy nie mamy tu n+1" route to `code-review`; a playwright stack trace still routes to `root-cause`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
